### PR TITLE
Remove device_class for battery months remaining

### DIFF
--- a/src/everblu-meters-esp8266.cpp
+++ b/src/everblu-meters-esp8266.cpp
@@ -637,7 +637,6 @@ String jsonDiscoveryBatteryMonths = R"rawliteral(
   "name": "Months Remaining",
   "uniq_id": "water_meter_battery_months",
   "obj_id": "water_meter_battery_months",
-  "device_class": "duration",
   "ic": "mdi:battery-clock",
   "unit_of_meas": "months",
   "qos": 0,


### PR DESCRIPTION
The Battery months remaining sensor uses the device class “duration” with the unit “months.”
Since version 2025.7 of Home Assistant, it is no longer possible to use units that are not validated in the device class (source: https://github.com/home-assistant/core/pull/146722).
Therefore, creating the sensor now generates the following error:
```
Logger: homeassistant.components.mqtt.entity
Source: components/mqtt/entity.py:156
integration: MQTT (documentation, issues)
First occurred: 10:55:47 (1 occurrence)
Last logged: 10:55:47

Error 'The unit of measurement `months` is not valid together with device class `duration`' when processing MQTT discovery message topic: 'homeassistant/sensor/water_meter_battery_months/config', message: '{'device_class': 'duration', 'qos': 0, 'force_update': 'true', 'unique_id': 'water_meter_battery_months', 'unit_of_measurement': 'months', 'object_id': 'water_meter_battery_months', 'icon': 'mdi:battery-clock', 'name': 'Months Remaining', 'state_topic': 'everblu/cyble/battery', 'device': {'identifiers': ['14071984'], 'model': 'Itron EverBlu Cyble Enhanced Water Meter ESP8266/ESP32', 'manufacturer': 'Psykokwak [Forked by Genestealer]', 'name': 'Water Meter'}, 'availability_topic': 'everblu/cyble/status'}'
```

The list of valid units for duration are: d, h, min, s, ms, µs
Source: https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes

Three possible corrections:
- Remove the sensor because it duplicates the battery status in % (same value)
- Convert the value to days (by multiplying by 30), but this remains approximate and it is strange because the value will change from 30 to 30.
- Change the sensor so that it no longer uses the device class duration
