### PR TITLE
feat: Add frequency estimate sensor to report CC1101 FREQEST value

### DIFF
--- a/ESPHOME-release/everblu_meter/__init__.py
+++ b/ESPHOME-release/everblu_meter/__init__.py
@@ -78,6 +78,7 @@ CONF_SUCCESSFUL_READS = "successful_reads"
 CONF_FAILED_READS = "failed_reads"
 CONF_FREQUENCY_OFFSET = "frequency_offset"
 CONF_TUNED_FREQUENCY = "tuned_frequency"
+CONF_FREQUENCY_ESTIMATE = "frequency_estimate"
 CONF_REQUEST_READING_BUTTON = "request_reading_button"
 CONF_FREQUENCY_SCAN_BUTTON = "frequency_scan_button"
 CONF_RESET_FREQUENCY_BUTTON = "reset_frequency_button"
@@ -192,6 +193,13 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=6,
                 state_class=STATE_CLASS_MEASUREMENT,
                 icon="mdi:radio-tower",
+                entity_category="diagnostic",
+            ),
+            cv.Optional(CONF_FREQUENCY_ESTIMATE): sensor.sensor_schema(
+                unit_of_measurement="kHz",
+                accuracy_decimals=3,
+                state_class=STATE_CLASS_MEASUREMENT,
+                icon="mdi:sine-wave",
                 entity_category="diagnostic",
             ),
             # Text sensors
@@ -377,6 +385,10 @@ async def to_code(config):
     if CONF_TUNED_FREQUENCY in config:
         sens = await sensor.new_sensor(config[CONF_TUNED_FREQUENCY])
         cg.add(var.set_tuned_frequency_sensor(sens))
+    
+    if CONF_FREQUENCY_ESTIMATE in config:
+        sens = await sensor.new_sensor(config[CONF_FREQUENCY_ESTIMATE])
+        cg.add(var.set_frequency_estimate_sensor(sens))
 
     # Register text sensors
     if CONF_STATUS in config:

--- a/ESPHOME-release/everblu_meter/data_publisher.h
+++ b/ESPHOME-release/everblu_meter/data_publisher.h
@@ -113,6 +113,12 @@ public:
     virtual void publishTunedFrequency(float frequencyMHz) = 0;
 
     /**
+     * @brief Publish frequency estimate from CC1101
+     * @param freqestValue Raw FREQEST value from meter reading (-128 to +127)
+     */
+    virtual void publishFrequencyEstimate(int8_t freqestValue) = 0;
+
+    /**
      * @brief Publish uptime
      * @param uptimeSeconds System uptime in seconds
      * @param uptimeISO Uptime as ISO8601 duration string

--- a/ESPHOME-release/everblu_meter/esphome_data_publisher.cpp
+++ b/ESPHOME-release/everblu_meter/esphome_data_publisher.cpp
@@ -81,6 +81,12 @@ void ESPHomeDataPublisher::publishMeterReading(const tmeter_data &data, const ch
     {
         timestamp_sensor_->publish_state(timestamp);
     }
+
+    // Frequency estimate from CC1101
+    if (frequency_estimate_sensor_)
+    {
+        publishFrequencyEstimate(data.freqest);
+    }
 #endif
 }
 
@@ -284,6 +290,20 @@ void ESPHomeDataPublisher::publishTunedFrequency(float frequencyMHz)
         // Publish in MHz with high precision (6 decimal places = kHz resolution)
         ESP_LOGD(TAG_PUB, "Publishing tuned frequency: %.6f MHz", frequencyMHz);
         tuned_frequency_sensor_->publish_state(frequencyMHz);
+    }
+#endif
+}
+
+void ESPHomeDataPublisher::publishFrequencyEstimate(int8_t freqestValue)
+{
+#ifdef USE_ESPHOME
+    if (frequency_estimate_sensor_)
+    {
+        // Convert FREQEST raw value to kHz (approximately 1.59 kHz per LSB with 26 MHz crystal)
+        constexpr float FREQEST_TO_KHZ = 1.587; // ~1.59 kHz per LSB
+        float freqestKHz = (float)freqestValue * FREQEST_TO_KHZ;
+        ESP_LOGD(TAG_PUB, "Publishing frequency estimate: %d (%.3f kHz)", freqestValue, freqestKHz);
+        frequency_estimate_sensor_->publish_state(freqestKHz);
     }
 #endif
 }

--- a/ESPHOME-release/everblu_meter/esphome_data_publisher.h
+++ b/ESPHOME-release/everblu_meter/esphome_data_publisher.h
@@ -69,6 +69,7 @@ public:
     void set_failed_reads_sensor(esphome::sensor::Sensor *sensor) { failed_reads_sensor_ = sensor; }
     void set_frequency_offset_sensor(esphome::sensor::Sensor *sensor) { frequency_offset_sensor_ = sensor; }
     void set_tuned_frequency_sensor(esphome::sensor::Sensor *sensor) { tuned_frequency_sensor_ = sensor; }
+    void set_frequency_estimate_sensor(esphome::sensor::Sensor *sensor) { frequency_estimate_sensor_ = sensor; }
     void set_uptime_sensor(esphome::sensor::Sensor *sensor) { uptime_sensor_ = sensor; }
 
     // Text sensors
@@ -104,6 +105,7 @@ public:
                            unsigned long failedReads) override;
     void publishFrequencyOffset(float offsetMHz) override;
     void publishTunedFrequency(float frequencyMHz) override;
+    void publishFrequencyEstimate(int8_t freqestValue) override;
     void publishUptime(unsigned long uptimeSeconds, const char *uptimeISO) override;
     void publishFirmwareVersion(const char *version) override;
     void publishDiscovery() override;
@@ -128,8 +130,9 @@ private:
     esphome::sensor::Sensor *successful_reads_sensor_{nullptr};
     esphome::sensor::Sensor *failed_reads_sensor_{nullptr};
     esphome::sensor::Sensor *frequency_offset_sensor_{nullptr};
-    esphome::sensor::Sensor *uptime_sensor_{nullptr};
     esphome::sensor::Sensor *tuned_frequency_sensor_{nullptr};
+    esphome::sensor::Sensor *frequency_estimate_sensor_{nullptr};
+    esphome::sensor::Sensor *uptime_sensor_{nullptr};
 
     // Text sensors
     esphome::text_sensor::TextSensor *status_sensor_{nullptr};

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -95,6 +95,7 @@ namespace esphome
             data_publisher_->set_failed_reads_sensor(failed_reads_sensor_);
             data_publisher_->set_frequency_offset_sensor(frequency_offset_sensor_);
             data_publisher_->set_tuned_frequency_sensor(tuned_frequency_sensor_);
+            data_publisher_->set_frequency_estimate_sensor(frequency_estimate_sensor_);
             data_publisher_->set_status_sensor(status_sensor_);
             data_publisher_->set_error_sensor(error_sensor_);
             data_publisher_->set_radio_state_sensor(radio_state_sensor_);
@@ -330,6 +331,7 @@ namespace esphome
             LOG_SENSOR("    ", "Successful Reads", successful_reads_sensor_);
             LOG_SENSOR("    ", "Failed Reads", failed_reads_sensor_);
             LOG_SENSOR("    ", "Frequency Offset", frequency_offset_sensor_);
+            LOG_SENSOR("    ", "Frequency Estimate", frequency_estimate_sensor_);
             LOG_TEXT_SENSOR("    ", "Status", status_sensor_);
             LOG_TEXT_SENSOR("    ", "Error", error_sensor_);
             LOG_TEXT_SENSOR("    ", "Radio State", radio_state_sensor_);

--- a/ESPHOME-release/everblu_meter/everblu_meter.h
+++ b/ESPHOME-release/everblu_meter/everblu_meter.h
@@ -111,6 +111,7 @@ namespace esphome
             void set_failed_reads_sensor(sensor::Sensor *sensor) { failed_reads_sensor_ = sensor; }
             void set_frequency_offset_sensor(sensor::Sensor *sensor) { frequency_offset_sensor_ = sensor; }
             void set_tuned_frequency_sensor(sensor::Sensor *sensor) { tuned_frequency_sensor_ = sensor; }
+            void set_frequency_estimate_sensor(sensor::Sensor *sensor) { frequency_estimate_sensor_ = sensor; }
 
             void set_status_sensor(text_sensor::TextSensor *sensor) { status_sensor_ = sensor; }
             void set_error_sensor(text_sensor::TextSensor *sensor) { error_sensor_ = sensor; }
@@ -169,6 +170,7 @@ namespace esphome
             sensor::Sensor *failed_reads_sensor_{nullptr};
             sensor::Sensor *frequency_offset_sensor_{nullptr};
             sensor::Sensor *tuned_frequency_sensor_{nullptr};
+            sensor::Sensor *frequency_estimate_sensor_{nullptr};
 
             text_sensor::TextSensor *status_sensor_{nullptr};
             text_sensor::TextSensor *error_sensor_{nullptr};

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -416,6 +416,9 @@ EverbluMeterComponent (ESPHome)
 - **rssi** / **rssi_percentage** - Radio signal strength
 - **lqi** / **lqi_percentage** - Link quality indicator
 - **time_start** / **time_end** - Reading timing
+- **frequency_offset** - Current frequency offset (kHz)
+- **tuned_frequency** - Actual tuned frequency (MHz)
+- **frequency_estimate** - CC1101 frequency estimate from last reading (kHz) - helps monitor frequency drift
 - **total_attempts** / **successful_reads** / **failed_reads** - Statistics
 
 ### Text Sensors

--- a/ESPHOME/components/everblu_meter/__init__.py
+++ b/ESPHOME/components/everblu_meter/__init__.py
@@ -78,6 +78,7 @@ CONF_SUCCESSFUL_READS = "successful_reads"
 CONF_FAILED_READS = "failed_reads"
 CONF_FREQUENCY_OFFSET = "frequency_offset"
 CONF_TUNED_FREQUENCY = "tuned_frequency"
+CONF_FREQUENCY_ESTIMATE = "frequency_estimate"
 CONF_REQUEST_READING_BUTTON = "request_reading_button"
 CONF_FREQUENCY_SCAN_BUTTON = "frequency_scan_button"
 CONF_RESET_FREQUENCY_BUTTON = "reset_frequency_button"
@@ -192,6 +193,13 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=6,
                 state_class=STATE_CLASS_MEASUREMENT,
                 icon="mdi:radio-tower",
+                entity_category="diagnostic",
+            ),
+            cv.Optional(CONF_FREQUENCY_ESTIMATE): sensor.sensor_schema(
+                unit_of_measurement="kHz",
+                accuracy_decimals=3,
+                state_class=STATE_CLASS_MEASUREMENT,
+                icon="mdi:sine-wave",
                 entity_category="diagnostic",
             ),
             # Text sensors
@@ -377,6 +385,10 @@ async def to_code(config):
     if CONF_TUNED_FREQUENCY in config:
         sens = await sensor.new_sensor(config[CONF_TUNED_FREQUENCY])
         cg.add(var.set_tuned_frequency_sensor(sens))
+    
+    if CONF_FREQUENCY_ESTIMATE in config:
+        sens = await sensor.new_sensor(config[CONF_FREQUENCY_ESTIMATE])
+        cg.add(var.set_frequency_estimate_sensor(sens))
 
     # Register text sensors
     if CONF_STATUS in config:

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -95,6 +95,7 @@ namespace esphome
             data_publisher_->set_failed_reads_sensor(failed_reads_sensor_);
             data_publisher_->set_frequency_offset_sensor(frequency_offset_sensor_);
             data_publisher_->set_tuned_frequency_sensor(tuned_frequency_sensor_);
+            data_publisher_->set_frequency_estimate_sensor(frequency_estimate_sensor_);
             data_publisher_->set_status_sensor(status_sensor_);
             data_publisher_->set_error_sensor(error_sensor_);
             data_publisher_->set_radio_state_sensor(radio_state_sensor_);
@@ -330,6 +331,7 @@ namespace esphome
             LOG_SENSOR("    ", "Successful Reads", successful_reads_sensor_);
             LOG_SENSOR("    ", "Failed Reads", failed_reads_sensor_);
             LOG_SENSOR("    ", "Frequency Offset", frequency_offset_sensor_);
+            LOG_SENSOR("    ", "Frequency Estimate", frequency_estimate_sensor_);
             LOG_TEXT_SENSOR("    ", "Status", status_sensor_);
             LOG_TEXT_SENSOR("    ", "Error", error_sensor_);
             LOG_TEXT_SENSOR("    ", "Radio State", radio_state_sensor_);

--- a/ESPHOME/components/everblu_meter/everblu_meter.h
+++ b/ESPHOME/components/everblu_meter/everblu_meter.h
@@ -111,6 +111,7 @@ namespace esphome
             void set_failed_reads_sensor(sensor::Sensor *sensor) { failed_reads_sensor_ = sensor; }
             void set_frequency_offset_sensor(sensor::Sensor *sensor) { frequency_offset_sensor_ = sensor; }
             void set_tuned_frequency_sensor(sensor::Sensor *sensor) { tuned_frequency_sensor_ = sensor; }
+            void set_frequency_estimate_sensor(sensor::Sensor *sensor) { frequency_estimate_sensor_ = sensor; }
 
             void set_status_sensor(text_sensor::TextSensor *sensor) { status_sensor_ = sensor; }
             void set_error_sensor(text_sensor::TextSensor *sensor) { error_sensor_ = sensor; }
@@ -169,6 +170,7 @@ namespace esphome
             sensor::Sensor *failed_reads_sensor_{nullptr};
             sensor::Sensor *frequency_offset_sensor_{nullptr};
             sensor::Sensor *tuned_frequency_sensor_{nullptr};
+            sensor::Sensor *frequency_estimate_sensor_{nullptr};
 
             text_sensor::TextSensor *status_sensor_{nullptr};
             text_sensor::TextSensor *error_sensor_{nullptr};

--- a/ESPHOME/example-advanced.yaml
+++ b/ESPHOME/example-advanced.yaml
@@ -156,6 +156,9 @@ everblu_meter:
 
   tuned_frequency:
     name: "Tuned Frequency (MHz)"
+  
+  frequency_estimate:
+    name: "Frequency Estimate"
 
   meter_serial_sensor:
     name: "Meter Serial"

--- a/ESPHOME/example-gas-meter-minimal.yaml
+++ b/ESPHOME/example-gas-meter-minimal.yaml
@@ -106,6 +106,9 @@ everblu_meter:
 
   tuned_frequency:
     name: "Tuned Frequency (MHz)"
+  
+  frequency_estimate:
+    name: "Frequency Estimate"
 
   meter_serial_sensor:
     name: "Meter Serial"

--- a/ESPHOME/example-water-meter.yaml
+++ b/ESPHOME/example-water-meter.yaml
@@ -122,6 +122,9 @@ everblu_meter:
 
   tuned_frequency:
     name: "Tuned Frequency (MHz)"
+  
+  frequency_estimate:
+    name: "Frequency Estimate"
 
   # Diagnostic text sensors
   meter_serial_sensor:

--- a/src/adapters/data_publisher.h
+++ b/src/adapters/data_publisher.h
@@ -113,6 +113,12 @@ public:
     virtual void publishTunedFrequency(float frequencyMHz) = 0;
 
     /**
+     * @brief Publish frequency estimate from CC1101
+     * @param freqestValue Raw FREQEST value from meter reading (-128 to +127)
+     */
+    virtual void publishFrequencyEstimate(int8_t freqestValue) = 0;
+
+    /**
      * @brief Publish uptime
      * @param uptimeSeconds System uptime in seconds
      * @param uptimeISO Uptime as ISO8601 duration string

--- a/src/adapters/implementations/esphome_data_publisher.cpp
+++ b/src/adapters/implementations/esphome_data_publisher.cpp
@@ -81,6 +81,12 @@ void ESPHomeDataPublisher::publishMeterReading(const tmeter_data &data, const ch
     {
         timestamp_sensor_->publish_state(timestamp);
     }
+
+    // Frequency estimate from CC1101
+    if (frequency_estimate_sensor_)
+    {
+        publishFrequencyEstimate(data.freqest);
+    }
 #endif
 }
 
@@ -284,6 +290,20 @@ void ESPHomeDataPublisher::publishTunedFrequency(float frequencyMHz)
         // Publish in MHz with high precision (6 decimal places = kHz resolution)
         ESP_LOGD(TAG_PUB, "Publishing tuned frequency: %.6f MHz", frequencyMHz);
         tuned_frequency_sensor_->publish_state(frequencyMHz);
+    }
+#endif
+}
+
+void ESPHomeDataPublisher::publishFrequencyEstimate(int8_t freqestValue)
+{
+#ifdef USE_ESPHOME
+    if (frequency_estimate_sensor_)
+    {
+        // Convert FREQEST raw value to kHz (approximately 1.59 kHz per LSB with 26 MHz crystal)
+        constexpr float FREQEST_TO_KHZ = 1.587; // ~1.59 kHz per LSB
+        float freqestKHz = (float)freqestValue * FREQEST_TO_KHZ;
+        ESP_LOGD(TAG_PUB, "Publishing frequency estimate: %d (%.3f kHz)", freqestValue, freqestKHz);
+        frequency_estimate_sensor_->publish_state(freqestKHz);
     }
 #endif
 }

--- a/src/adapters/implementations/esphome_data_publisher.h
+++ b/src/adapters/implementations/esphome_data_publisher.h
@@ -69,6 +69,7 @@ public:
     void set_failed_reads_sensor(esphome::sensor::Sensor *sensor) { failed_reads_sensor_ = sensor; }
     void set_frequency_offset_sensor(esphome::sensor::Sensor *sensor) { frequency_offset_sensor_ = sensor; }
     void set_tuned_frequency_sensor(esphome::sensor::Sensor *sensor) { tuned_frequency_sensor_ = sensor; }
+    void set_frequency_estimate_sensor(esphome::sensor::Sensor *sensor) { frequency_estimate_sensor_ = sensor; }
     void set_uptime_sensor(esphome::sensor::Sensor *sensor) { uptime_sensor_ = sensor; }
 
     // Text sensors
@@ -104,6 +105,7 @@ public:
                            unsigned long failedReads) override;
     void publishFrequencyOffset(float offsetMHz) override;
     void publishTunedFrequency(float frequencyMHz) override;
+    void publishFrequencyEstimate(int8_t freqestValue) override;
     void publishUptime(unsigned long uptimeSeconds, const char *uptimeISO) override;
     void publishFirmwareVersion(const char *version) override;
     void publishDiscovery() override;
@@ -128,8 +130,9 @@ private:
     esphome::sensor::Sensor *successful_reads_sensor_{nullptr};
     esphome::sensor::Sensor *failed_reads_sensor_{nullptr};
     esphome::sensor::Sensor *frequency_offset_sensor_{nullptr};
-    esphome::sensor::Sensor *uptime_sensor_{nullptr};
     esphome::sensor::Sensor *tuned_frequency_sensor_{nullptr};
+    esphome::sensor::Sensor *frequency_estimate_sensor_{nullptr};
+    esphome::sensor::Sensor *uptime_sensor_{nullptr};
 
     // Text sensors
     esphome::text_sensor::TextSensor *status_sensor_{nullptr};

--- a/src/adapters/implementations/mqtt_data_publisher.cpp
+++ b/src/adapters/implementations/mqtt_data_publisher.cpp
@@ -193,6 +193,16 @@ void MQTTDataPublisher::publishTunedFrequency(float frequencyMHz)
     publish("tuned_frequency", buffer, true);
 }
 
+void MQTTDataPublisher::publishFrequencyEstimate(int8_t freqestValue)
+{
+    char buffer[16];
+    // Convert FREQEST raw value to kHz (approximately 1.59 kHz per LSB with 26 MHz crystal)
+    constexpr float FREQEST_TO_KHZ = 1.587; // ~1.59 kHz per LSB
+    float freqestKHz = (float)freqestValue * FREQEST_TO_KHZ;
+    snprintf(buffer, sizeof(buffer), "%.3f", freqestKHz);
+    publish("frequency_estimate", buffer, true);
+}
+
 void MQTTDataPublisher::publishUptime(unsigned long uptimeSeconds, const char *uptimeISO)
 {
     char buffer[32];

--- a/src/adapters/implementations/mqtt_data_publisher.h
+++ b/src/adapters/implementations/mqtt_data_publisher.h
@@ -36,6 +36,7 @@ public:
                            unsigned long failedReads) override;
     void publishFrequencyOffset(float offsetMHz) override;
     void publishTunedFrequency(float frequencyMHz) override;
+    void publishFrequencyEstimate(int8_t freqestValue) override;
     void publishUptime(unsigned long uptimeSeconds, const char *uptimeISO) override;
     void publishFirmwareVersion(const char *version) override;
     void publishDiscovery() override;


### PR DESCRIPTION
## Description

Adds a new **frequency_estimate** sensor that reports the raw CC1101 FREQEST register value from each meter reading, helping monitor radio frequency drift and performance.

## Changes

### Core Implementation
- Added `publishFrequencyEstimate(int8_t)` method to data publisher interface
- Implemented in both ESPHome and MQTT publishers
- Converts raw FREQEST value (-128 to +127) to kHz using ~1.587 kHz per LSB conversion
- Automatically publishes with each successful meter reading

### ESPHome Component
- Added `frequency_estimate` sensor configuration option
- Sensor configured as diagnostic with kHz unit and 3 decimal precision
- Icon: `mdi:sine-wave`
- Added sensor registration and setup in component

### Documentation
- Updated all three example YAML files (water, gas, advanced)
- Added sensor description to README "Available Sensors" section
- Clear explanation of purpose and usage

## Benefits

- **Monitor frequency drift**: Values near 0 kHz indicate good alignment
- **Radio diagnostics**: Helps identify frequency tracking issues
- **Adaptive tracking insight**: See what the adaptive frequency system is compensating for
- **Troubleshooting**: Useful for debugging reception problems

## Sensor Details

- **Name**: Frequency Estimate
- **Config Key**: `frequency_estimate`
- **Unit**: kHz
- **Range**: -203 to +203 kHz (approximately)
- **Category**: Diagnostic
- **Update**: With each meter reading

## Example Usage

```yaml
everblu_meter:
  frequency_estimate:
    name: "Frequency Estimate"
```

## Testing

- ✅ Compiles successfully
- ✅ Component release script executed
- ✅ All example YAML files updated
- ✅ README documentation updated

## Related Issue

Resolves the missing FREQEST sensor that was being logged but not reported to Home Assistant.