### PR TITLE
Feature/esphome external component ci

### DIFF
--- a/.ci/esphome/.gitignore
+++ b/.ci/esphome/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/.ci/esphome/everblu_meter/common.yaml
+++ b/.ci/esphome/everblu_meter/common.yaml
@@ -1,0 +1,33 @@
+# Shared configuration included by each platform-specific test file via:
+#   <<: !include common.yaml
+#
+# Paths in external_components are resolved relative to the config file
+# that includes this file (test.*.yaml), not relative to this file itself.
+
+spi:
+  clk_pin: ${spi_clk_pin}
+  miso_pin: ${spi_miso_pin}
+  mosi_pin: ${spi_mosi_pin}
+
+time:
+  - platform: sntp
+    id: ci_time
+
+external_components:
+  - source:
+      type: local
+      path: ../../../ESPHOME-release
+    components: [ everblu_meter ]
+
+everblu_meter:
+  meter_year: 22
+  meter_serial: 87654321
+  meter_type: ${meter_type}
+  gdo0_pin: ${gdo0_pin}
+  time_id: ci_time
+
+  volume:
+    name: "CI Volume"
+
+  status:
+    name: "CI Status"

--- a/.ci/esphome/everblu_meter/test.esp32-ard.yaml
+++ b/.ci/esphome/everblu_meter/test.esp32-ard.yaml
@@ -1,0 +1,28 @@
+substitutions:
+  spi_clk_pin: GPIO18
+  spi_miso_pin: GPIO19
+  spi_mosi_pin: GPIO23
+  gdo0_pin: "4"
+  meter_type: gas
+
+esphome:
+  name: ci-esp32-ard
+  min_version: 2024.6.0
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: CI-WIFI
+  password: CI-PASSWORD
+
+<<: !include common.yaml

--- a/.ci/esphome/everblu_meter/test.esp32-c3-ard.yaml
+++ b/.ci/esphome/everblu_meter/test.esp32-c3-ard.yaml
@@ -1,0 +1,28 @@
+substitutions:
+  spi_clk_pin: GPIO6
+  spi_miso_pin: GPIO5
+  spi_mosi_pin: GPIO7
+  gdo0_pin: "4"
+  meter_type: water
+
+esphome:
+  name: ci-esp32-c3-ard
+  min_version: 2024.6.0
+
+esp32:
+  board: esp32-c3-devkitm-1
+  framework:
+    type: arduino
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: CI-WIFI
+  password: CI-PASSWORD
+
+<<: !include common.yaml

--- a/.ci/esphome/everblu_meter/test.esp8266-ard.yaml
+++ b/.ci/esphome/everblu_meter/test.esp8266-ard.yaml
@@ -1,0 +1,28 @@
+substitutions:
+  spi_clk_pin: GPIO14
+  spi_miso_pin: GPIO12
+  spi_mosi_pin: GPIO13
+  gdo0_pin: "4"
+  meter_type: water
+
+esphome:
+  name: ci-esp8266-ard
+  min_version: 2024.6.0
+
+esp8266:
+  board: d1_mini
+  framework:
+    version: recommended
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: CI-WIFI
+  password: CI-PASSWORD
+
+<<: !include common.yaml

--- a/.ci/esphome/everblu_meter/test.esp8266-git.yaml
+++ b/.ci/esphome/everblu_meter/test.esp8266-git.yaml
@@ -1,0 +1,54 @@
+# Git external_components smoke test.
+# Validates the component is consumable via the public GitHub URL (end-user path).
+# Always targets 'main' branch - tests real-world install, not current branch changes.
+
+esphome:
+  name: ci-esp8266-git
+  min_version: 2024.6.0
+
+esp8266:
+  board: d1_mini
+  framework:
+    version: recommended
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+wifi:
+  ssid: CI-WIFI
+  password: CI-PASSWORD
+
+time:
+  - platform: sntp
+    id: ci_time
+
+spi:
+  clk_pin: GPIO14
+  miso_pin: GPIO12
+  mosi_pin: GPIO13
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/genestealer/everblu-meters-esp8266-improved
+      ref: main
+      path: ESPHOME-release
+    components: [ everblu_meter ]
+    refresh: 0s
+
+everblu_meter:
+  meter_year: 22
+  meter_serial: 87654321
+  meter_type: water
+  gdo0_pin: 4
+  time_id: ci_time
+
+  volume:
+    name: "CI Volume"
+
+  status:
+    name: "CI Status"

--- a/.ci/esphome/everblu_meter/test.esp8266-git.yaml
+++ b/.ci/esphome/everblu_meter/test.esp8266-git.yaml
@@ -1,6 +1,8 @@
 # Git external_components smoke test.
 # Validates the component is consumable via the public GitHub URL (end-user path).
-# Always targets 'main' branch - tests real-world install, not current branch changes.
+# Targets 'main' branch intentionally - this test is skipped on pull requests
+# (see workflow: if condition) and only runs on push to main/master/develop.
+# Running it on PRs would compile whatever is on main, not the proposed changes.
 
 esphome:
   name: ci-esp8266-git

--- a/.github/workflows/build-esp32.yml
+++ b/.github/workflows/build-esp32.yml
@@ -2,7 +2,7 @@ name: ESP32 Build
 
 on:
   push:
-    branches: [main, master, develop, automatic-calibration]
+    branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
   workflow_dispatch:

--- a/.github/workflows/build-esp32.yml
+++ b/.github/workflows/build-esp32.yml
@@ -18,6 +18,8 @@ jobs:
         environment:
           - name: esp32dev
             board: ESP32 DevKit
+          - name: esp32-c3-ard
+            board: ESP32-C3 DevKitM-1 (Arduino)
 
     name: Build ${{ matrix.environment.board }}
 

--- a/.github/workflows/build-esp8266.yml
+++ b/.github/workflows/build-esp8266.yml
@@ -2,7 +2,7 @@ name: ESP8266 Build
 
 on:
   push:
-    branches: [main, master, develop, automatic-calibration]
+    branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
   workflow_dispatch:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -2,12 +2,12 @@ name: Dependency Check
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [main, master, develop]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [main, master, develop]
   schedule:
     # Run weekly on Mondays at 00:00 UTC
-    - cron: '0 0 * * 1'
+    - cron: "0 0 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -18,51 +18,50 @@ jobs:
   dependency-scan:
     runs-on: ubuntu-latest
     name: Scan Dependencies for Vulnerabilities
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    
-    - name: Install PlatformIO
-      run: |
-        python -m pip install --upgrade pip
-        pip install --upgrade platformio
-    
-    - name: Install safety (Python security scanner)
-      run: pip install safety
-    
-    - name: Check Python dependencies
-      run: |
-        pip list --format=json > pip-packages.json
-        safety check --json || true
-      continue-on-error: true
-    
-    - name: Check PlatformIO libraries
-      run: |
-        pio pkg list --only-libraries --json-output > pio-libraries.json || true
-        echo "=== PlatformIO Libraries ==="
-        pio pkg list --only-libraries || true
-      continue-on-error: true
-    
-    - name: Upload dependency lists
-      uses: actions/upload-artifact@v4
-      with:
-        name: dependency-lists
-        path: |
-          pip-packages.json
-          pio-libraries.json
-        retention-days: 30
-    
-    - name: Summary
-      run: |
-        echo "### Dependency Scan Complete" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "#### PlatformIO Libraries" >> $GITHUB_STEP_SUMMARY
-        pio pkg list --only-libraries >> $GITHUB_STEP_SUMMARY || true
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "See artifacts for full dependency lists" >> $GITHUB_STEP_SUMMARY
 
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+
+      - name: Install safety (Python security scanner)
+        run: pip install safety
+
+      - name: Check Python dependencies
+        run: |
+          pip list --format=json > pip-packages.json
+          safety check --json || true
+        continue-on-error: true
+
+      - name: Check PlatformIO libraries
+        run: |
+          pio pkg list --only-libraries --json-output > pio-libraries.json || true
+          echo "=== PlatformIO Libraries ==="
+          pio pkg list --only-libraries || true
+        continue-on-error: true
+
+      - name: Upload dependency lists
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-lists
+          path: |
+            pip-packages.json
+            pio-libraries.json
+          retention-days: 30
+
+      - name: Summary
+        run: |
+          echo "### Dependency Scan Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### PlatformIO Libraries" >> $GITHUB_STEP_SUMMARY
+          pio pkg list --only-libraries >> $GITHUB_STEP_SUMMARY || true
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "See artifacts for full dependency lists" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/esphome-external-component.yml
+++ b/.github/workflows/esphome-external-component.yml
@@ -17,6 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # CI scope rationale:
+          # - Cover architecture families with water on Xtensa (ESP8266) and RISC-V (ESP32-C3)
+          # - Cover the gas-specific code path once (ESP32)
+          # - Keep one git-source smoke test for real external_components install flow
+          # This keeps runtime reasonable while still exercising the main compatibility paths.
           # Xtensa / Arduino - water meter
           - id: esp8266-ard
             config: .ci/esphome/everblu_meter/test.esp8266-ard.yaml

--- a/.github/workflows/esphome-external-component.yml
+++ b/.github/workflows/esphome-external-component.yml
@@ -17,26 +17,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - id: esp8266-local-gas
-            platform: esp8266
-            source_mode: local
-            meter_type: gas
-          - id: esp8266-local-water
-            platform: esp8266
-            source_mode: local
-            meter_type: water
-          - id: esp32-local-gas
-            platform: esp32
-            source_mode: local
-            meter_type: gas
-          - id: esp32-local-water
-            platform: esp32
-            source_mode: local
-            meter_type: water
-          - id: esp8266-git-smoke
-            platform: esp8266
-            source_mode: git
-            meter_type: water
+          # Xtensa / Arduino - water meter
+          - id: esp8266-ard
+            config: .ci/esphome/everblu_meter/test.esp8266-ard.yaml
+          # Xtensa / Arduino - gas meter (verifies gas meter codegen path)
+          - id: esp32-ard
+            config: .ci/esphome/everblu_meter/test.esp32-ard.yaml
+          # RISC-V / Arduino - different architecture family
+          - id: esp32-c3-ard
+            config: .ci/esphome/everblu_meter/test.esp32-c3-ard.yaml
+          # Git external_components smoke test - validates real-world install path
+          - id: esp8266-git
+            config: .ci/esphome/everblu_meter/test.esp8266-git.yaml
 
     name: ${{ matrix.id }}
 
@@ -60,9 +52,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.platformio
-          key: ${{ runner.os }}-pio-esphome-${{ matrix.platform }}-${{ hashFiles('.github/workflows/esphome-external-component.yml') }}
+          key: ${{ runner.os }}-pio-esphome-${{ matrix.id }}-${{ hashFiles('.github/workflows/esphome-external-component.yml') }}
           restore-keys: |
-            ${{ runner.os }}-pio-esphome-${{ matrix.platform }}-
+            ${{ runner.os }}-pio-esphome-${{ matrix.id }}-
             ${{ runner.os }}-pio-esphome-
 
       - name: Install ESPHome
@@ -70,87 +62,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install "esphome>=2025.0"
 
-      - name: Generate test configuration
-        run: |
-          mkdir -p .ci/esphome
-
-          if [ "${{ matrix.source_mode }}" = "local" ]; then
-            EXTERNAL_COMPONENT_BLOCK='external_components:\n  - source:\n      type: local\n      path: ../../ESPHOME-release\n    components: [ everblu_meter ]'
-          else
-            EXTERNAL_COMPONENT_BLOCK='external_components:\n  - source:\n      type: git\n      url: https://github.com/${{ github.repository }}\n      ref: main\n      path: ESPHOME-release\n    components: [ everblu_meter ]\n    refresh: 0s'
-          fi
-
-          if [ "${{ matrix.platform }}" = "esp8266" ]; then
-            PLATFORM_BLOCK='esp8266:\n  board: d1_mini\n  framework:\n    version: recommended'
-            SPI_BLOCK='spi:\n  clk_pin: GPIO14\n  miso_pin: GPIO12\n  mosi_pin: GPIO13'
-            GDO0_PIN='4'
-          else
-            PLATFORM_BLOCK='esp32:\n  board: esp32dev\n  framework:\n    type: arduino'
-            SPI_BLOCK='spi:\n  clk_pin: GPIO18\n  miso_pin: GPIO19\n  mosi_pin: GPIO23'
-            GDO0_PIN='4'
-          fi
-
-          {
-            echo "esphome:"
-            echo "  name: ci-${{ matrix.id }}"
-            echo "  min_version: 2024.6.0"
-            echo ""
-            printf "%b\n" "$PLATFORM_BLOCK"
-            echo ""
-            echo "logger:"
-            echo ""
-            echo "api:"
-            echo ""
-            echo "ota:"
-            echo "  - platform: esphome"
-            echo ""
-            echo "wifi:"
-            echo "  ssid: CI-WIFI"
-            echo "  password: CI-PASSWORD"
-            echo ""
-            echo "time:"
-            echo "  - platform: sntp"
-            echo "    id: ci_time"
-            echo ""
-            printf "%b\n" "$SPI_BLOCK"
-            echo ""
-            printf "%b\n" "$EXTERNAL_COMPONENT_BLOCK"
-            echo ""
-            echo "everblu_meter:"
-            echo "  meter_year: 22"
-            echo "  meter_serial: 87654321"
-            echo "  meter_type: ${{ matrix.meter_type }}"
-            echo "  gdo0_pin: ${GDO0_PIN}"
-            echo "  time_id: ci_time"
-            echo ""
-            echo "  volume:"
-            echo "    name: CI Volume"
-            echo ""
-            echo "  status:"
-            echo "    name: CI Status"
-          } > .ci/esphome/${{ matrix.id }}.yaml
-
-          echo "Generated .ci/esphome/${{ matrix.id }}.yaml"
-          cat .ci/esphome/${{ matrix.id }}.yaml
-
       - name: Validate configuration
-        run: |
-          esphome config .ci/esphome/${{ matrix.id }}.yaml
+        run: esphome config ${{ matrix.config }}
 
-      - name: Compile configuration
-        run: |
-          esphome compile .ci/esphome/${{ matrix.id }}.yaml
+      - name: Compile
+        run: esphome compile ${{ matrix.config }}
 
-      - name: Integration summary
+      - name: Summary
         if: always()
         run: |
           {
-            echo "## ESPHome Integration Test"
+            echo "## ESPHome Integration Test: ${{ matrix.id }}"
             echo ""
-            echo "- Case: ${{ matrix.id }}"
-            echo "- Platform: ${{ matrix.platform }}"
-            echo "- Source mode: ${{ matrix.source_mode }}"
-            echo "- Meter type: ${{ matrix.meter_type }}"
+            echo "Config: \`${{ matrix.config }}\`"
             echo ""
-            echo "Validated with: esphome config + esphome compile"
+            echo "Validated with: \`esphome config\` + \`esphome compile\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/esphome-external-component.yml
+++ b/.github/workflows/esphome-external-component.yml
@@ -2,7 +2,7 @@ name: ESPHome External Component Integration
 
 on:
   push:
-    branches: [main, master, develop, feature/**]
+    branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
   workflow_dispatch:

--- a/.github/workflows/esphome-external-component.yml
+++ b/.github/workflows/esphome-external-component.yml
@@ -36,6 +36,9 @@ jobs:
             config: .ci/esphome/everblu_meter/test.esp8266-git.yaml
 
     name: ${{ matrix.id }}
+    # Skip the git smoke test on pull requests: it compiles ref: main, not the
+    # proposed branch, so it cannot catch regressions introduced by the PR.
+    if: matrix.id != 'esp8266-git' || github.event_name != 'pull_request'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/esphome-external-component.yml
+++ b/.github/workflows/esphome-external-component.yml
@@ -2,7 +2,7 @@ name: ESPHome External Component Integration
 
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, master, develop, feature/**]
   pull_request:
     branches: [main, master, develop]
   workflow_dispatch:

--- a/.github/workflows/esphome-external-component.yml
+++ b/.github/workflows/esphome-external-component.yml
@@ -1,0 +1,156 @@
+name: ESPHome External Component Integration
+
+on:
+  push:
+    branches: [main, master, develop]
+  pull_request:
+    branches: [main, master, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: esp8266-local-gas
+            platform: esp8266
+            source_mode: local
+            meter_type: gas
+          - id: esp8266-local-water
+            platform: esp8266
+            source_mode: local
+            meter_type: water
+          - id: esp32-local-gas
+            platform: esp32
+            source_mode: local
+            meter_type: gas
+          - id: esp32-local-water
+            platform: esp32
+            source_mode: local
+            meter_type: water
+          - id: esp8266-git-smoke
+            platform: esp8266
+            source_mode: git
+            meter_type: water
+
+    name: ${{ matrix.id }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-esphome-${{ hashFiles('.github/workflows/esphome-external-component.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-esphome-
+
+      - name: Cache PlatformIO packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-pio-esphome-${{ matrix.platform }}-${{ hashFiles('.github/workflows/esphome-external-component.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-esphome-${{ matrix.platform }}-
+            ${{ runner.os }}-pio-esphome-
+
+      - name: Install ESPHome
+        run: |
+          python -m pip install --upgrade pip
+          pip install "esphome>=2025.0"
+
+      - name: Generate test configuration
+        run: |
+          mkdir -p .ci/esphome
+
+          if [ "${{ matrix.source_mode }}" = "local" ]; then
+            EXTERNAL_COMPONENT_BLOCK='external_components:\n  - source:\n      type: local\n      path: ../../ESPHOME-release\n    components: [ everblu_meter ]'
+          else
+            EXTERNAL_COMPONENT_BLOCK='external_components:\n  - source:\n      type: git\n      url: https://github.com/${{ github.repository }}\n      ref: main\n      path: ESPHOME-release\n    components: [ everblu_meter ]\n    refresh: 0s'
+          fi
+
+          if [ "${{ matrix.platform }}" = "esp8266" ]; then
+            PLATFORM_BLOCK='esp8266:\n  board: d1_mini\n  framework:\n    version: recommended'
+            SPI_BLOCK='spi:\n  clk_pin: GPIO14\n  miso_pin: GPIO12\n  mosi_pin: GPIO13'
+            GDO0_PIN='4'
+          else
+            PLATFORM_BLOCK='esp32:\n  board: esp32dev\n  framework:\n    type: arduino'
+            SPI_BLOCK='spi:\n  clk_pin: GPIO18\n  miso_pin: GPIO19\n  mosi_pin: GPIO23'
+            GDO0_PIN='4'
+          fi
+
+          {
+            echo "esphome:"
+            echo "  name: ci-${{ matrix.id }}"
+            echo "  min_version: 2024.6.0"
+            echo ""
+            printf "%b\n" "$PLATFORM_BLOCK"
+            echo ""
+            echo "logger:"
+            echo ""
+            echo "api:"
+            echo ""
+            echo "ota:"
+            echo "  - platform: esphome"
+            echo ""
+            echo "wifi:"
+            echo "  ssid: CI-WIFI"
+            echo "  password: CI-PASSWORD"
+            echo ""
+            echo "time:"
+            echo "  - platform: sntp"
+            echo "    id: ci_time"
+            echo ""
+            printf "%b\n" "$SPI_BLOCK"
+            echo ""
+            printf "%b\n" "$EXTERNAL_COMPONENT_BLOCK"
+            echo ""
+            echo "everblu_meter:"
+            echo "  meter_year: 22"
+            echo "  meter_serial: 87654321"
+            echo "  meter_type: ${{ matrix.meter_type }}"
+            echo "  gdo0_pin: ${GDO0_PIN}"
+            echo "  time_id: ci_time"
+            echo ""
+            echo "  volume:"
+            echo "    name: CI Volume"
+            echo ""
+            echo "  status:"
+            echo "    name: CI Status"
+          } > .ci/esphome/${{ matrix.id }}.yaml
+
+          echo "Generated .ci/esphome/${{ matrix.id }}.yaml"
+          cat .ci/esphome/${{ matrix.id }}.yaml
+
+      - name: Validate configuration
+        run: |
+          esphome config .ci/esphome/${{ matrix.id }}.yaml
+
+      - name: Compile configuration
+        run: |
+          esphome compile .ci/esphome/${{ matrix.id }}.yaml
+
+      - name: Integration summary
+        if: always()
+        run: |
+          {
+            echo "## ESPHome Integration Test"
+            echo ""
+            echo "- Case: ${{ matrix.id }}"
+            echo "- Platform: ${{ matrix.platform }}"
+            echo "- Source mode: ${{ matrix.source_mode }}"
+            echo "- Meter type: ${{ matrix.meter_type }}"
+            echo ""
+            echo "Validated with: esphome config + esphome compile"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,7 @@ config.h
 include/config.h
 include/private.h
 include/secrets.h
+__pycache__/
+*.pyc
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,6 @@ include/private.h
 include/secrets.h
 __pycache__/
 *.pyc
+**/.esphome/
 
 

--- a/docs/ESPHOME_TESTING_CHECKLIST.md
+++ b/docs/ESPHOME_TESTING_CHECKLIST.md
@@ -71,6 +71,18 @@ This checklist helps verify that the ESPHome integration works correctly across 
 - [ ] Config with all sensors - compiles
 - [ ] Config with no sensors - compiles (should warn?)
 
+### CI Matrix Strategy (GitHub Actions)
+- [x] Water meter tested on Xtensa (ESP8266) and RISC-V (ESP32-C3)
+- [x] Gas meter tested at least once to validate gas-specific code path
+- [x] Git source external_components smoke test included
+- [x] Matrix balances coverage and CI runtime
+
+Notes:
+- Water-on-two-architectures validates cross-architecture compatibility.
+- Gas-on-one-board validates meter_type-specific generation and compile path.
+- Git smoke test validates the real user install flow (external_components from git).
+- Expand to full water+gas on every board if stricter coverage is preferred over CI time.
+
 ## Upload and Boot Tests
 
 ### First Boot

--- a/platformio.ini
+++ b/platformio.ini
@@ -119,6 +119,15 @@ extends = env:base
 platform = espressif32
 board = esp32dev
 
+; ----------------------------------------------------------------------------
+; ESP32-C3 DevKitM-1
+; https://docs.platformio.org/en/stable/boards/espressif32/esp32-c3-devkitm-1.html
+; ----------------------------------------------------------------------------
+[env:esp32-c3-ard]
+extends = env:base
+platform = espressif32
+board = esp32-c3-devkitm-1
+
 [env:esp32dev-ota]
 extends = env:esp32dev
 upload_protocol = espota

--- a/script/test_build_components
+++ b/script/test_build_components
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run ESPHome compile tests for a component, mirroring official ESPHome CI.
+#
+# Usage:
+#   script/test_build_components                    # tests everblu_meter
+#   script/test_build_components everblu_meter      # explicit component name
+#
+# Prerequisites:
+#   pip install esphome
+#
+# The ESPHOME environment variable overrides the esphome binary location:
+#   ESPHOME=/path/to/esphome script/test_build_components
+
+set -e
+
+COMPONENT="${1:-everblu_meter}"
+ESPHOME_CMD="${ESPHOME:-esphome}"
+TEST_DIR=".ci/esphome/${COMPONENT}"
+
+if [ ! -d "$TEST_DIR" ]; then
+  echo "Error: test directory '$TEST_DIR' not found"
+  exit 1
+fi
+
+echo "Testing component: ${COMPONENT}"
+echo "Using: $(${ESPHOME_CMD} version)"
+echo ""
+
+PASS=0
+FAIL=0
+
+for f in "${TEST_DIR}/test."*.yaml; do
+  [ -f "$f" ] || continue
+  echo "==> ${f}"
+  if "${ESPHOME_CMD}" compile "${f}"; then
+    echo "PASS: ${f}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: ${f}"
+    FAIL=$((FAIL + 1))
+  fi
+  echo ""
+done
+
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ $FAIL -eq 0 ]

--- a/script/test_build_components
+++ b/script/test_build_components
@@ -28,9 +28,11 @@ echo ""
 
 PASS=0
 FAIL=0
+FOUND=0
 
 for f in "${TEST_DIR}/test."*.yaml; do
   [ -f "$f" ] || continue
+  FOUND=$((FOUND + 1))
   echo "==> ${f}"
   if "${ESPHOME_CMD}" compile "${f}"; then
     echo "PASS: ${f}"
@@ -41,6 +43,11 @@ for f in "${TEST_DIR}/test."*.yaml; do
   fi
   echo ""
 done
+
+if [ $FOUND -eq 0 ]; then
+  echo "Error: no test files found in '${TEST_DIR}'"
+  exit 1
+fi
 
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [ $FAIL -eq 0 ]

--- a/script/test_build_components
+++ b/script/test_build_components
@@ -23,7 +23,8 @@ if [ ! -d "$TEST_DIR" ]; then
 fi
 
 echo "Testing component: ${COMPONENT}"
-echo "Using: $(${ESPHOME_CMD} version)"
+ESPHOME_VERSION="$("${ESPHOME_CMD}" version)"
+echo "Using: ${ESPHOME_VERSION}"
 echo ""
 
 PASS=0


### PR DESCRIPTION
This pull request introduces a comprehensive ESPHome CI integration for the `everblu_meter` component. It adds a new GitHub Actions workflow that validates the component across multiple platforms and installation methods, provides reusable test configurations, and includes supporting documentation and scripts. Minor workflow and formatting improvements are also included.

**ESPHome CI Integration and Test Coverage:**

* Added `.github/workflows/esphome-external-component.yml` workflow to validate the `everblu_meter` ESPHome component on ESP8266, ESP32, and ESP32-C3 boards, including both local and git-based external component installation paths.
* Introduced test configuration files in `.ci/esphome/everblu_meter/` for each supported platform and install method, with a shared `common.yaml` for reusability. [[1]](diffhunk://#diff-59ddaacd2077662670972e91508ad53493f53cccbe028b40f8a8145cb302e7beR1-R33) [[2]](diffhunk://#diff-54f28936c7e07cc674ae484ff3b8d7db0ff06f8324a4875efd2b68e999b98ce2R1-R28) [[3]](diffhunk://#diff-9ddee11d8048255ff7997ab00433d804dd5d2b375b101e5a7bca7900e622287cR1-R28) [[4]](diffhunk://#diff-7c573493f5f918d60e95e031e7e33b752661cec54419bf281214297c1b3ee906R1-R28) [[5]](diffhunk://#diff-0ad6790428049f38d264a615c7d1adc79313e4beefc45a7d17134c6227d1401bR1-R54)
* Added a bash script `script/test_build_components` to locally run compile tests for ESPHome components, mirroring CI behavior.

**Documentation Updates:**

* Updated `docs/ESPHOME_TESTING_CHECKLIST.md` to describe the new CI matrix strategy and its coverage rationale.

**Workflow and Formatting Improvements:**

* Added `.ci/esphome/.gitignore` to exclude secrets and build artifacts from version control.
* Cleaned up and standardized formatting in existing workflow files and limited build triggers to main branches only. [[1]](diffhunk://#diff-98e5e7b0797ae005b75cf22bdf7398dbfe40bd413a1f7a5feeca73916957a14bL5-R5) [[2]](diffhunk://#diff-bd19f16f7eed49570bb95e718f570a13cc8c478c4818c6fe76f58da7b8c09faeL5-R5) [[3]](diffhunk://#diff-f3a97e253c69a85e234407553f13590896f600192ea5cf88e77dcec39a8d4c56L10-R10) [[4]](diffhunk://#diff-f3a97e253c69a85e234407553f13590896f600192ea5cf88e77dcec39a8d4c56L28-R28) [[5]](diffhunk://#diff-f3a97e253c69a85e234407553f13590896f600192ea5cf88e77dcec39a8d4c56L68)