### PR TITLE
feat(esphome): support multiple everblu_meter instances

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,34 @@
 # Copilot instructions
 
-- Do not edit or propose edits to any files under ESPHOME-release/. Treat this directory as generated output that will be overwritten.
+## Project overview
+
+This project reads Itron/Actaris EverBlu Cyble water/gas meters via a CC1101 433 MHz radio transceiver on an ESP8266 or ESP32, and publishes readings to Home Assistant (via MQTT or ESPHome). It supports two independent deployment targets that share the same core radio/protocol logic.
+
+## Repository layout
+
+| Path                                | Purpose                                                                                                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/`                              | PlatformIO/Arduino firmware (standalone deployment via MQTT)                                                                                |
+| `src/core/`                         | CC1101 driver, utils, logging, version — shared low-level code                                                                              |
+| `src/services/`                     | Business logic: meter reading, scheduling, history, frequency calibration                                                                   |
+| `src/adapters/`                     | Interfaces (`config_provider.h`, `data_publisher.h`, `time_provider.h`) and their concrete implementations (MQTT, ESPHome, NTP)             |
+| `ESPHOME/components/everblu_meter/` | **Source** for the ESPHome external component (C++ + Python)                                                                                |
+| `ESPHOME/`                          | ESPHome YAML examples and the release-preparation scripts                                                                                   |
+| `ESPHOME-release/`                  | **Generated output — do not edit.** Produced by `ESPHOME/prepare-component-release.ps1` / `.sh`. Contents are overwritten on every release. |
+| `include/private.h`                 | Device-specific credentials (Wi-Fi, MQTT, meter serial). Not committed; `private.example.h` is the template.                                |
+| `test/`                             | PlatformIO unit tests (native environment)                                                                                                  |
+| `docs/`                             | Design notes, datasheets, and historical analysis. Not shipped.                                                                             |
+
+## Key architectural decisions
+
+- **Adapter pattern**: `src/adapters/` abstracts platform differences so the same service layer compiles for both MQTT-standalone and ESPHome builds.
+- **ESPHome component** (`ESPHOME/components/everblu_meter/`) wraps the same CC1101 + protocol logic in an ESPHome `Component`/`Sensor` hierarchy; it does **not** duplicate `src/`.
+- **Frequency calibration**: The `FrequencyManager` service tunes the CC1101 carrier frequency at runtime to compensate for crystal drift.
+- **Schedule manager**: Meters broadcast on a fixed daily schedule; `ScheduleManager` aligns wakeups to that window.
+
+## Review guidance
+
+- `ESPHOME-release/` is generated — never suggest changes there; raise them against the source in `ESPHOME/components/everblu_meter/` instead.
+- `include/private.h` is gitignored and contains real credentials; do not flag its absence as an error.
+- The project targets both ESP8266 (Arduino framework, no `std::` threading) and ESP32 + ESPHome; avoid suggestions that break 8266 compatibility unless the change is explicitly scoped to ESP32.
+- PlatformIO environments are defined in `platformio.ini`; the default build target is `huzzah` (Adafruit HUZZAH ESP8266).

--- a/ESPHOME-release/everblu_meter/__init__.py
+++ b/ESPHOME-release/everblu_meter/__init__.py
@@ -29,7 +29,7 @@ CODEOWNERS = ["@genestealer"]
 AUTO_LOAD = ["sensor", "text_sensor", "binary_sensor", "button"]
 
 # Tell ESPHome to include all source files in src/ subdirectories
-MULTI_CONF = False
+MULTI_CONF = True
 
 everblu_meter_ns = cg.esphome_ns.namespace("everblu_meter")
 EverbluMeterComponent = everblu_meter_ns.class_("EverbluMeterComponent", cg.PollingComponent)
@@ -289,11 +289,6 @@ async def to_code(config):
     # Use build flags instead of defines to ensure propagation to ALL .cpp files
     cg.add_build_flag("-DUSE_ESPHOME")
     cg.add_build_flag("-DWIFI_SERIAL_NO_REMAP")  # Don't remap Serial in ESPHome builds
-    # Provide compile-time values expected by core code as numeric preprocessor defines
-    # Use explicit -D flags to ensure visibility in all translation units
-    cg.add_build_flag(f"-DMETER_YEAR={config[CONF_METER_YEAR]}")
-    cg.add_build_flag(f"-DMETER_SERIAL={config[CONF_METER_SERIAL]}")
-    
     # Note: ESPHome automatically compiles all .cpp files in component directory
     # No need to explicitly list source files - just ensure main.cpp is excluded from release
     

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1584,7 +1584,7 @@ int receive_radian_frame(int size_byte, int rx_tmo_ms, uint8_t *rxBuffer, int rx
    but for read-only operation, this is not required.
 */
 
-struct tmeter_data get_meter_data(void)
+struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_serial)
 {
   // Avoid leading newline so ESPHome log doesn't emit an empty line first
   echo_debug(1, "[METER] Starting meter read sequence...\n");
@@ -1603,10 +1603,10 @@ struct tmeter_data get_meter_data(void)
   memset(meter_data, 0, sizeof(meter_data)); // Clear static buffer
 
   uint8_t txbuffer[100];
-  Make_Radian_Master_req(txbuffer, METER_YEAR, METER_SERIAL);
+  Make_Radian_Master_req(txbuffer, meter_year, meter_serial);
 
   echo_debug(1, "[METER] Transmitting wake-up + interrogation (Year=%d, Serial=%lu)...\n",
-             METER_YEAR, (unsigned long)METER_SERIAL);
+             meter_year, (unsigned long)meter_serial);
 
   // === Critical: Reset radio state before TX ===
   // If the radio is stuck in RXFIFO_OVERFLOW (0x11) or any non-IDLE state from
@@ -1815,4 +1815,15 @@ struct tmeter_data get_meter_data(void)
   sdata.lqi = halRfReadReg(LQI_ADDR);                                // Read LQI value from CC1101
   sdata.freqest = (int8_t)halRfReadReg(FREQEST_ADDR);                // Read frequency offset estimate for adaptive tracking
   return sdata;
+}
+
+struct tmeter_data get_meter_data(void)
+{
+#if defined(USE_ESPHOME)
+  // ESPHome multi-instance flows should use get_meter_data_for_meter().
+  // Keep this wrapper for backward compatibility and direct tests.
+  return get_meter_data_for_meter(0, 0);
+#else
+  return get_meter_data_for_meter(METER_YEAR, METER_SERIAL);
+#endif
 }

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1821,8 +1821,10 @@ struct tmeter_data get_meter_data(void)
 {
 #if defined(USE_ESPHOME)
   // ESPHome multi-instance flows should use get_meter_data_for_meter().
-  // Keep this wrapper for backward compatibility and direct tests.
-  return get_meter_data_for_meter(0, 0);
+  // Fail fast to avoid a blocking radio transaction with an invalid identity.
+  echo_debug(1, "[METER] get_meter_data() is unsupported in USE_ESPHOME; use get_meter_data_for_meter()\n");
+  struct tmeter_data sdata = {};
+  return sdata;
 #else
   return get_meter_data_for_meter(METER_YEAR, METER_SERIAL);
 #endif

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -105,4 +105,16 @@ void cc1101_rec_mode(void);
  */
 struct tmeter_data get_meter_data(void);
 
+/**
+ * @brief Read data from a specific meter identity
+ *
+ * Same as get_meter_data(), but uses explicit meter identification instead of
+ * compile-time defines. This is required for ESPHome multi-instance support.
+ *
+ * @param meter_year Last two digits of meter production year
+ * @param meter_serial Meter serial number
+ * @return tmeter_data structure containing all extracted meter data
+ */
+struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_serial);
+
 #endif // __CC1101_H__

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -144,24 +144,8 @@ namespace esphome
 
             ESP_LOGD(TAG, "Linked sensors -> numeric: %d, text: %d, binary: %d", numeric, texts, binaries);
 
-            // Initialize CC1101 SPI device before creating meter reader
-            auto *spi_device = static_cast<spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST,
-                                                          spi::CLOCK_POLARITY_LOW,
-                                                          spi::CLOCK_PHASE_LEADING,
-                                                          spi::DATA_RATE_1MHZ> *>(this);
-            cc1101_set_spi_device(static_cast<void *>(spi_device));
-            ESP_LOGD(TAG, "CC1101 SPI device configured");
-
-            // Configure GDO0 pin for CC1101
-            if (gdo0_pin_ != nullptr)
-            {
-                cc1101_set_gdo0_pin(gdo0_pin_->get_pin());
-                ESP_LOGD(TAG, "CC1101 GDO0 pin configured: %d", gdo0_pin_->get_pin());
-            }
-            else
-            {
-                ESP_LOGE(TAG, "GDO0 pin not configured for CC1101!");
-            }
+            // Initialize CC1101 context before creating meter reader
+            apply_radio_context();
 
             // Create meter reader with all adapters (but don't initialize yet)
             meter_reader_ = new MeterReader(config_provider_, time_provider_, data_publisher_);
@@ -237,6 +221,9 @@ namespace esphome
             // Let the meter reader handle its periodic tasks
             if (meter_reader_ != nullptr)
             {
+                // Ensure this instance's SPI and GDO0 settings are active before any radio operations.
+                apply_radio_context();
+
 #ifdef USE_API
                 // Initialize meter reader when Home Assistant connects (ensures safe boot sequence)
                 // This is better than WiFi-only check because API connection is more stable
@@ -249,6 +236,7 @@ namespace esphome
                     if (!meter_initialized_ && is_ha_connected)
                     {
                         ESP_LOGI(TAG, "Home Assistant connected, initializing meter reader...");
+                        apply_radio_context();
                         meter_reader_->begin();
 
                         // Set adaptive frequency tracking threshold
@@ -302,6 +290,7 @@ namespace esphome
             }
 
             ESP_LOGI(TAG, "Manual read requested via button");
+            apply_radio_context();
             meter_reader_->triggerReading(false);
         }
 
@@ -314,6 +303,7 @@ namespace esphome
             }
 
             ESP_LOGI(TAG, "Frequency scan requested via button");
+            apply_radio_context();
             meter_reader_->performFrequencyScan(false);
         }
 
@@ -326,8 +316,27 @@ namespace esphome
             }
 
             ESP_LOGI(TAG, "Reset frequency offset requested via button");
+            apply_radio_context();
             meter_reader_->resetFrequencyOffset();
             ESP_LOGI(TAG, "Frequency offset reset to 0.000 kHz");
+        }
+
+        void EverbluMeterComponent::apply_radio_context()
+        {
+            auto *spi_device = static_cast<spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST,
+                                                          spi::CLOCK_POLARITY_LOW,
+                                                          spi::CLOCK_PHASE_LEADING,
+                                                          spi::DATA_RATE_1MHZ> *>(this);
+            cc1101_set_spi_device(static_cast<void *>(spi_device));
+
+            if (gdo0_pin_ != nullptr)
+            {
+                cc1101_set_gdo0_pin(gdo0_pin_->get_pin());
+            }
+            else
+            {
+                ESP_LOGE(TAG, "GDO0 pin not configured for CC1101!");
+            }
         }
 
         void EverbluMeterComponent::update()

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -335,7 +335,12 @@ namespace esphome
             }
             else
             {
-                ESP_LOGE(TAG, "GDO0 pin not configured for CC1101!");
+                // Log error only once to avoid flooding the log
+                if (!gdo0_error_logged_)
+                {
+                    ESP_LOGE(TAG, "GDO0 pin not configured for CC1101!");
+                    gdo0_error_logged_ = true;
+                }
             }
         }
 

--- a/ESPHOME-release/everblu_meter/everblu_meter.h
+++ b/ESPHOME-release/everblu_meter/everblu_meter.h
@@ -156,6 +156,7 @@ namespace esphome
             // Internal state tracking
             void republish_initial_states();
             void apply_radio_context();
+            bool gdo0_error_logged_{false};  // One-shot flag to prevent log flooding
 
             // GDO0 pin (raw GPIO number for CC1101 Arduino driver)
             InternalGPIOPin *gdo0_pin_{nullptr};

--- a/ESPHOME-release/everblu_meter/everblu_meter.h
+++ b/ESPHOME-release/everblu_meter/everblu_meter.h
@@ -155,6 +155,7 @@ namespace esphome
 
             // Internal state tracking
             void republish_initial_states();
+            void apply_radio_context();
 
             // GDO0 pin (raw GPIO number for CC1101 Arduino driver)
             InternalGPIOPin *gdo0_pin_{nullptr};

--- a/ESPHOME-release/everblu_meter/meter_reader.cpp
+++ b/ESPHOME-release/everblu_meter/meter_reader.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "meter_reader.h"
-#include "schedule_manager.h"
 #include "meter_history.h"
 
 // Conditional includes based on build environment
@@ -54,13 +53,44 @@ MeterReader::MeterReader(IConfigProvider *config, ITimeProvider *timeProvider, I
 {
 }
 
+MeterReader *MeterReader::s_active_reader = nullptr;
+
+bool MeterReader::radioInitCallback(float freq)
+{
+    if (!s_active_reader)
+    {
+        return false;
+    }
+    return cc1101_init(freq);
+}
+
+tmeter_data MeterReader::meterReadCallback()
+{
+    tmeter_data data{};
+    if (!s_active_reader)
+    {
+        return data;
+    }
+
+    return get_meter_data_for_meter(
+        s_active_reader->m_config->getMeterYear(),
+        s_active_reader->m_config->getMeterSerial());
+}
+
+void MeterReader::activateCallbackContext()
+{
+    s_active_reader = this;
+}
+
 void MeterReader::begin()
 {
     LOG_I("everblu_meter", "Initializing...");
 
+    activateCallbackContext();
+
     // Register FrequencyManager callbacks
-    FrequencyManager::setRadioInitCallback(cc1101_init);
-    FrequencyManager::setMeterReadCallback(get_meter_data);
+    FrequencyManager::setRadioInitCallback(MeterReader::radioInitCallback);
+    FrequencyManager::setMeterReadCallback(MeterReader::meterReadCallback);
 
     // Initialize FrequencyManager with configured frequency
     float frequency = m_config->getFrequency();
@@ -227,7 +257,7 @@ bool MeterReader::shouldPerformScheduledRead()
     struct tm *ptm = gmtime(&localTime);
 
     // Check if today is a valid reading day
-    bool isDayMatch = ScheduleManager::isReadingDay(ptm);
+    bool isDayMatch = isReadingDayForConfiguredSchedule(ptm);
     bool isTimeMatch = (ptm->tm_hour == m_readHourLocal && ptm->tm_min == m_readMinuteLocal);
     bool isSecondMatch = (ptm->tm_sec == 0);
 
@@ -259,6 +289,8 @@ void MeterReader::triggerReading(bool isScheduled)
 
 void MeterReader::performReading()
 {
+    activateCallbackContext();
+
     if (!m_publisher->isReady())
     {
         LOG_W("everblu_meter", "Publisher not ready, aborting read");
@@ -282,7 +314,7 @@ void MeterReader::performReading()
           currentFreq, currentOffset * 1000.0);
 
     // Perform actual meter read
-    struct tmeter_data meter_data = get_meter_data();
+    struct tmeter_data meter_data = meterReadCallback();
 
     // Validate data
     if (meter_data.reads_counter == 0 || meter_data.volume == 0)
@@ -393,6 +425,8 @@ void MeterReader::resetRetryState()
 
 void MeterReader::performFrequencyScan(bool wideRange)
 {
+    activateCallbackContext();
+
     LOG_I("everblu_meter", "Starting %s frequency scan...", wideRange ? "wide" : "narrow");
 
     if (wideRange)
@@ -417,6 +451,8 @@ void MeterReader::performFrequencyScan(bool wideRange)
 
 void MeterReader::resetFrequencyOffset()
 {
+    activateCallbackContext();
+
     LOG_I("everblu_meter", "Resetting frequency offset to 0");
 
     // Reset offset to 0 and save
@@ -424,7 +460,7 @@ void MeterReader::resetFrequencyOffset()
 
     // Reinitialize radio with base frequency
     float baseFrequency = FrequencyManager::getBaseFrequency();
-    bool radio_ok = cc1101_init(baseFrequency);
+    bool radio_ok = radioInitCallback(baseFrequency);
     m_radioConnected = radio_ok;
 
     if (radio_ok)
@@ -455,4 +491,35 @@ void MeterReader::getStatistics(unsigned long &totalAttempts, unsigned long &suc
 void MeterReader::setHAConnected(bool connected)
 {
     m_haConnected = connected;
+}
+
+bool MeterReader::isReadingDayForConfiguredSchedule(const struct tm *ptm) const
+{
+    if (ptm == nullptr)
+    {
+        return false;
+    }
+
+    const char *schedule = m_config->getReadingSchedule();
+    if (schedule == nullptr)
+    {
+        schedule = "Monday-Friday";
+    }
+
+    const int dayOfWeek = ptm->tm_wday; // 0=Sunday, 1=Monday, ... 6=Saturday
+    if (strcmp(schedule, "Monday-Friday") == 0)
+    {
+        return dayOfWeek >= 1 && dayOfWeek <= 5;
+    }
+    if (strcmp(schedule, "Monday-Saturday") == 0)
+    {
+        return dayOfWeek >= 1 && dayOfWeek <= 6;
+    }
+    if (strcmp(schedule, "Monday-Sunday") == 0)
+    {
+        return true;
+    }
+
+    // Default to safe weekdays behaviour for unknown schedule strings.
+    return dayOfWeek >= 1 && dayOfWeek <= 5;
 }

--- a/ESPHOME-release/everblu_meter/meter_reader.cpp
+++ b/ESPHOME-release/everblu_meter/meter_reader.cpp
@@ -520,6 +520,7 @@ bool MeterReader::isReadingDayForConfiguredSchedule(const struct tm *ptm) const
         return true;
     }
 
-    // Default to safe weekdays behaviour for unknown schedule strings.
-    return dayOfWeek >= 1 && dayOfWeek <= 5;
+    // Unknown schedule: log warning and skip read to avoid misconfiguration
+    LOG_W("everblu_meter", "Unknown reading_schedule '%s'; skipping scheduled read.", schedule);
+    return false;
 }

--- a/ESPHOME-release/everblu_meter/meter_reader.h
+++ b/ESPHOME-release/everblu_meter/meter_reader.h
@@ -117,6 +117,14 @@ public:
     void setHAConnected(bool connected);
 
 private:
+    static MeterReader *s_active_reader;
+
+    static bool radioInitCallback(float freq);
+    static tmeter_data meterReadCallback();
+
+    void activateCallbackContext();
+    bool isReadingDayForConfiguredSchedule(const struct tm *ptm) const;
+
     /**
      * @brief Perform actual meter reading operation
      *

--- a/ESPHOME/components/everblu_meter/__init__.py
+++ b/ESPHOME/components/everblu_meter/__init__.py
@@ -29,7 +29,7 @@ CODEOWNERS = ["@genestealer"]
 AUTO_LOAD = ["sensor", "text_sensor", "binary_sensor", "button"]
 
 # Tell ESPHome to include all source files in src/ subdirectories
-MULTI_CONF = False
+MULTI_CONF = True
 
 everblu_meter_ns = cg.esphome_ns.namespace("everblu_meter")
 EverbluMeterComponent = everblu_meter_ns.class_("EverbluMeterComponent", cg.PollingComponent)
@@ -289,11 +289,6 @@ async def to_code(config):
     # Use build flags instead of defines to ensure propagation to ALL .cpp files
     cg.add_build_flag("-DUSE_ESPHOME")
     cg.add_build_flag("-DWIFI_SERIAL_NO_REMAP")  # Don't remap Serial in ESPHome builds
-    # Provide compile-time values expected by core code as numeric preprocessor defines
-    # Use explicit -D flags to ensure visibility in all translation units
-    cg.add_build_flag(f"-DMETER_YEAR={config[CONF_METER_YEAR]}")
-    cg.add_build_flag(f"-DMETER_SERIAL={config[CONF_METER_SERIAL]}")
-    
     # Note: ESPHome automatically compiles all .cpp files in component directory
     # No need to explicitly list source files - just ensure main.cpp is excluded from release
     

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -144,24 +144,8 @@ namespace esphome
 
             ESP_LOGD(TAG, "Linked sensors -> numeric: %d, text: %d, binary: %d", numeric, texts, binaries);
 
-            // Initialize CC1101 SPI device before creating meter reader
-            auto *spi_device = static_cast<spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST,
-                                                          spi::CLOCK_POLARITY_LOW,
-                                                          spi::CLOCK_PHASE_LEADING,
-                                                          spi::DATA_RATE_1MHZ> *>(this);
-            cc1101_set_spi_device(static_cast<void *>(spi_device));
-            ESP_LOGD(TAG, "CC1101 SPI device configured");
-
-            // Configure GDO0 pin for CC1101
-            if (gdo0_pin_ != nullptr)
-            {
-                cc1101_set_gdo0_pin(gdo0_pin_->get_pin());
-                ESP_LOGD(TAG, "CC1101 GDO0 pin configured: %d", gdo0_pin_->get_pin());
-            }
-            else
-            {
-                ESP_LOGE(TAG, "GDO0 pin not configured for CC1101!");
-            }
+            // Initialize CC1101 context before creating meter reader
+            apply_radio_context();
 
             // Create meter reader with all adapters (but don't initialize yet)
             meter_reader_ = new MeterReader(config_provider_, time_provider_, data_publisher_);
@@ -237,6 +221,9 @@ namespace esphome
             // Let the meter reader handle its periodic tasks
             if (meter_reader_ != nullptr)
             {
+                // Ensure this instance's SPI and GDO0 settings are active before any radio operations.
+                apply_radio_context();
+
 #ifdef USE_API
                 // Initialize meter reader when Home Assistant connects (ensures safe boot sequence)
                 // This is better than WiFi-only check because API connection is more stable
@@ -249,6 +236,7 @@ namespace esphome
                     if (!meter_initialized_ && is_ha_connected)
                     {
                         ESP_LOGI(TAG, "Home Assistant connected, initializing meter reader...");
+                        apply_radio_context();
                         meter_reader_->begin();
 
                         // Set adaptive frequency tracking threshold
@@ -302,6 +290,7 @@ namespace esphome
             }
 
             ESP_LOGI(TAG, "Manual read requested via button");
+            apply_radio_context();
             meter_reader_->triggerReading(false);
         }
 
@@ -314,6 +303,7 @@ namespace esphome
             }
 
             ESP_LOGI(TAG, "Frequency scan requested via button");
+            apply_radio_context();
             meter_reader_->performFrequencyScan(false);
         }
 
@@ -326,8 +316,27 @@ namespace esphome
             }
 
             ESP_LOGI(TAG, "Reset frequency offset requested via button");
+            apply_radio_context();
             meter_reader_->resetFrequencyOffset();
             ESP_LOGI(TAG, "Frequency offset reset to 0.000 kHz");
+        }
+
+        void EverbluMeterComponent::apply_radio_context()
+        {
+            auto *spi_device = static_cast<spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST,
+                                                          spi::CLOCK_POLARITY_LOW,
+                                                          spi::CLOCK_PHASE_LEADING,
+                                                          spi::DATA_RATE_1MHZ> *>(this);
+            cc1101_set_spi_device(static_cast<void *>(spi_device));
+
+            if (gdo0_pin_ != nullptr)
+            {
+                cc1101_set_gdo0_pin(gdo0_pin_->get_pin());
+            }
+            else
+            {
+                ESP_LOGE(TAG, "GDO0 pin not configured for CC1101!");
+            }
         }
 
         void EverbluMeterComponent::update()

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -335,7 +335,12 @@ namespace esphome
             }
             else
             {
-                ESP_LOGE(TAG, "GDO0 pin not configured for CC1101!");
+                // Log error only once to avoid flooding the log
+                if (!gdo0_error_logged_)
+                {
+                    ESP_LOGE(TAG, "GDO0 pin not configured for CC1101!");
+                    gdo0_error_logged_ = true;
+                }
             }
         }
 

--- a/ESPHOME/components/everblu_meter/everblu_meter.h
+++ b/ESPHOME/components/everblu_meter/everblu_meter.h
@@ -156,6 +156,7 @@ namespace esphome
             // Internal state tracking
             void republish_initial_states();
             void apply_radio_context();
+            bool gdo0_error_logged_{false};  // One-shot flag to prevent log flooding
 
             // GDO0 pin (raw GPIO number for CC1101 Arduino driver)
             InternalGPIOPin *gdo0_pin_{nullptr};

--- a/ESPHOME/components/everblu_meter/everblu_meter.h
+++ b/ESPHOME/components/everblu_meter/everblu_meter.h
@@ -155,6 +155,7 @@ namespace esphome
 
             // Internal state tracking
             void republish_initial_states();
+            void apply_radio_context();
 
             // GDO0 pin (raw GPIO number for CC1101 Arduino driver)
             InternalGPIOPin *gdo0_pin_{nullptr};

--- a/ESPHOME/docs/ESPHOME_INTEGRATION_GUIDE.md
+++ b/ESPHOME/docs/ESPHOME_INTEGRATION_GUIDE.md
@@ -530,14 +530,19 @@ sensor:
 
 ### Multiple Meters
 
-You SHOULD be able to configure multiple meters on one ESP (I have not been able to test this):
+Multiple meters are supported by defining a YAML list under `everblu_meter`:
 
 ```yaml
 everblu_meter:
   - id: water_meter
     meter_year: 21
     meter_serial: 12345678
-    gdo0_pin: 4
+    cs_pin:
+      number: GPIO15
+      allow_other_uses: true
+    gdo0_pin:
+      number: GPIO4
+      allow_other_uses: true
     meter_type: water
     volume:
       name: "Water Volume"
@@ -545,13 +550,25 @@ everblu_meter:
   - id: gas_meter
     meter_year: 22
     meter_serial: 87654321
-    gdo0_pin: 4
+    cs_pin:
+      number: GPIO15
+      allow_other_uses: true
+    gdo0_pin:
+      number: GPIO4
+      allow_other_uses: true
     meter_type: gas
     volume:
       name: "Gas Volume"
 ```
 
 **Note**: Reading multiple meters requires careful scheduling to avoid conflicts.
+
+Use unique `id` and entity `name` values per meter block. If both meters share one CC1101 module,
+they should use the same SPI, CS, and GDO0 wiring settings.
+
+**Shared pin note**: When multiple `everblu_meter` instances share the same CC1101 radio,
+ESPHome requires shared pins to be declared with `allow_other_uses: true`. Apply this to both
+`cs_pin` and `gdo0_pin` in every meter block that uses the shared radio.
 
 ## Developer Notes
 

--- a/ESPHOME/example-multi-meter.yaml
+++ b/ESPHOME/example-multi-meter.yaml
@@ -1,0 +1,224 @@
+substitutions:
+  device_name: everblu-meter
+  friendly_name: EverBlu Meter
+
+  cc1101_cs: "GPIO15"
+  cc1101_gdo0: "GPIO5"
+  tz_offset_min: "0"
+  meter_1_prefix: "Meter 1"
+  meter_2_prefix: "Meter 2"
+
+esphome:
+  name: ${device_name}
+  friendly_name: ${friendly_name}
+
+esp8266:
+  board: huzzah
+  framework:
+    version: recommended
+
+logger:
+  level: DEBUG
+  logs:
+    everblu_meter: DEBUG
+    sensor: WARN
+
+api:
+  encryption:
+    key: "CHANGE_ME"
+
+ota:
+  - platform: esphome
+    password: "CHANGE_ME"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/genestealer/everblu-meters-esp8266-improved
+      ref: main
+      path: ESPHOME-release
+    components: [everblu_meter]
+    refresh: 1d
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+
+spi:
+  - id: main_bus
+    clk_pin: GPIO14
+    mosi_pin: GPIO13
+    miso_pin: GPIO12
+
+everblu_meter:
+  - id: cold_water_meter
+    meter_year: 20
+    meter_serial: 257750
+    meter_type: water
+    debug_cc1101: true
+    spi_id: main_bus
+    cs_pin:
+      number: ${cc1101_cs}
+      allow_other_uses: true
+    gdo0_pin:
+      number: ${cc1101_gdo0}
+      allow_other_uses: true
+    time_id: homeassistant_time
+    timezone_offset: ${tz_offset_min}
+    read_hour: 11
+    read_minute: 30
+
+    request_reading_button:
+      name: "${meter_1_prefix} Read Meter Now"
+    frequency_scan_button:
+      name: "${meter_1_prefix} Scan Frequency"
+    reset_frequency_button:
+      name: "${meter_1_prefix} Reset Frequency Offset"
+
+    volume:
+      name: "${meter_1_prefix} Water Volume"
+    counter:
+      name: "${meter_1_prefix} Read Counter"
+    battery:
+      name: "${meter_1_prefix} Meter Battery"
+    rssi:
+      name: "${meter_1_prefix} Meter RSSI"
+    rssi_percentage:
+      name: "${meter_1_prefix} RSSI Percentage"
+    lqi:
+      name: "${meter_1_prefix} LQI"
+    lqi_percentage:
+      name: "${meter_1_prefix} LQI Percentage"
+
+    total_attempts:
+      name: "${meter_1_prefix} Total Read Attempts"
+    successful_reads:
+      name: "${meter_1_prefix} Successful Reads"
+    failed_reads:
+      name: "${meter_1_prefix} Failed Reads"
+    frequency_offset:
+      name: "${meter_1_prefix} Frequency Offset"
+    tuned_frequency:
+      name: "${meter_1_prefix} Tuned Frequency (MHz)"
+    frequency_estimate:
+      name: "${meter_1_prefix} Frequency Estimate"
+
+    meter_serial_sensor:
+      name: "${meter_1_prefix} Meter Serial"
+    meter_year_sensor:
+      name: "${meter_1_prefix} Meter Year"
+    reading_schedule_sensor:
+      name: "${meter_1_prefix} Reading Schedule"
+    reading_time_utc_sensor:
+      name: "${meter_1_prefix} Reading Time (UTC)"
+
+    time_start:
+      name: "${meter_1_prefix} Reading Start Time"
+    time_end:
+      name: "${meter_1_prefix} Reading End Time"
+
+    status:
+      name: "${meter_1_prefix} Meter Status"
+    error:
+      name: "${meter_1_prefix} Last Error"
+    radio_state:
+      name: "${meter_1_prefix} CC1101 State"
+    timestamp:
+      name: "${meter_1_prefix} Last Reading Time"
+    history_json:
+      name: "${meter_1_prefix} Meter History (JSON)"
+    firmware_version:
+      name: "${meter_1_prefix} Firmware Version"
+
+    active_reading:
+      name: "${meter_1_prefix} Reading Active"
+    radio_connected:
+      name: "${meter_1_prefix} CC1101 Connected"
+
+  - id: hot_water_meter
+    meter_year: 20
+    meter_serial: 259301
+    meter_type: water
+    debug_cc1101: true
+    spi_id: main_bus
+    cs_pin:
+      number: ${cc1101_cs}
+      allow_other_uses: true
+    gdo0_pin:
+      number: ${cc1101_gdo0}
+      allow_other_uses: true
+    time_id: homeassistant_time
+    timezone_offset: ${tz_offset_min}
+    read_hour: 11
+    read_minute: 40
+
+    request_reading_button:
+      name: "${meter_2_prefix} Read Meter Now"
+    frequency_scan_button:
+      name: "${meter_2_prefix} Scan Frequency"
+    reset_frequency_button:
+      name: "${meter_2_prefix} Reset Frequency Offset"
+
+    volume:
+      name: "${meter_2_prefix} Water Volume"
+    counter:
+      name: "${meter_2_prefix} Read Counter"
+    battery:
+      name: "${meter_2_prefix} Meter Battery"
+    rssi:
+      name: "${meter_2_prefix} Meter RSSI"
+    rssi_percentage:
+      name: "${meter_2_prefix} RSSI Percentage"
+    lqi:
+      name: "${meter_2_prefix} LQI"
+    lqi_percentage:
+      name: "${meter_2_prefix} LQI Percentage"
+
+    total_attempts:
+      name: "${meter_2_prefix} Total Read Attempts"
+    successful_reads:
+      name: "${meter_2_prefix} Successful Reads"
+    failed_reads:
+      name: "${meter_2_prefix} Failed Reads"
+    frequency_offset:
+      name: "${meter_2_prefix} Frequency Offset"
+    tuned_frequency:
+      name: "${meter_2_prefix} Tuned Frequency (MHz)"
+    frequency_estimate:
+      name: "${meter_2_prefix} Frequency Estimate"
+
+    meter_serial_sensor:
+      name: "${meter_2_prefix} Meter Serial"
+    meter_year_sensor:
+      name: "${meter_2_prefix} Meter Year"
+    reading_schedule_sensor:
+      name: "${meter_2_prefix} Reading Schedule"
+    reading_time_utc_sensor:
+      name: "${meter_2_prefix} Reading Time (UTC)"
+
+    time_start:
+      name: "${meter_2_prefix} Reading Start Time"
+    time_end:
+      name: "${meter_2_prefix} Reading End Time"
+
+    status:
+      name: "${meter_2_prefix} Meter Status"
+    error:
+      name: "${meter_2_prefix} Last Error"
+    radio_state:
+      name: "${meter_2_prefix} CC1101 State"
+    timestamp:
+      name: "${meter_2_prefix} Last Reading Time"
+    history_json:
+      name: "${meter_2_prefix} Meter History (JSON)"
+    firmware_version:
+      name: "${meter_2_prefix} Firmware Version"
+
+    active_reading:
+      name: "${meter_2_prefix} Reading Active"
+    radio_connected:
+      name: "${meter_2_prefix} CC1101 Connected"

--- a/ESPHOME/example-nano-esp32.yaml
+++ b/ESPHOME/example-nano-esp32.yaml
@@ -28,11 +28,6 @@ esp32:
 wifi:
   ssid: "YourWiFiSSID"
   password: "YourWiFiPassword"
-  
-  # Enable fallback hotspot
-  ap:
-    ssid: "EverBlu Fallback"
-    password: "ConfigMe123"
 
 # Enable logging
 logger:

--- a/ESPHOME/example-water-meter.yaml
+++ b/ESPHOME/example-water-meter.yaml
@@ -13,11 +13,6 @@ esp8266:
 wifi:
   ssid: "YourWiFiSSID"
   password: "YourWiFiPassword"
-  
-  # Enable fallback hotspot
-  ap:
-    ssid: "EverBlu Fallback"
-    password: "ConfigMe123"
 
 # Enable logging
 logger:

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1584,7 +1584,7 @@ int receive_radian_frame(int size_byte, int rx_tmo_ms, uint8_t *rxBuffer, int rx
    but for read-only operation, this is not required.
 */
 
-struct tmeter_data get_meter_data(void)
+struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_serial)
 {
   // Avoid leading newline so ESPHome log doesn't emit an empty line first
   echo_debug(1, "[METER] Starting meter read sequence...\n");
@@ -1603,10 +1603,10 @@ struct tmeter_data get_meter_data(void)
   memset(meter_data, 0, sizeof(meter_data)); // Clear static buffer
 
   uint8_t txbuffer[100];
-  Make_Radian_Master_req(txbuffer, METER_YEAR, METER_SERIAL);
+  Make_Radian_Master_req(txbuffer, meter_year, meter_serial);
 
   echo_debug(1, "[METER] Transmitting wake-up + interrogation (Year=%d, Serial=%lu)...\n",
-             METER_YEAR, (unsigned long)METER_SERIAL);
+             meter_year, (unsigned long)meter_serial);
 
   // === Critical: Reset radio state before TX ===
   // If the radio is stuck in RXFIFO_OVERFLOW (0x11) or any non-IDLE state from
@@ -1815,4 +1815,15 @@ struct tmeter_data get_meter_data(void)
   sdata.lqi = halRfReadReg(LQI_ADDR);                                // Read LQI value from CC1101
   sdata.freqest = (int8_t)halRfReadReg(FREQEST_ADDR);                // Read frequency offset estimate for adaptive tracking
   return sdata;
+}
+
+struct tmeter_data get_meter_data(void)
+{
+#if defined(USE_ESPHOME)
+  // ESPHome multi-instance flows should use get_meter_data_for_meter().
+  // Keep this wrapper for backward compatibility and direct tests.
+  return get_meter_data_for_meter(0, 0);
+#else
+  return get_meter_data_for_meter(METER_YEAR, METER_SERIAL);
+#endif
 }

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1821,8 +1821,10 @@ struct tmeter_data get_meter_data(void)
 {
 #if defined(USE_ESPHOME)
   // ESPHome multi-instance flows should use get_meter_data_for_meter().
-  // Keep this wrapper for backward compatibility and direct tests.
-  return get_meter_data_for_meter(0, 0);
+  // Fail fast to avoid a blocking radio transaction with an invalid identity.
+  echo_debug(1, "[METER] get_meter_data() is unsupported in USE_ESPHOME; use get_meter_data_for_meter()\n");
+  struct tmeter_data sdata = {};
+  return sdata;
 #else
   return get_meter_data_for_meter(METER_YEAR, METER_SERIAL);
 #endif

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -105,4 +105,16 @@ void cc1101_rec_mode(void);
  */
 struct tmeter_data get_meter_data(void);
 
+/**
+ * @brief Read data from a specific meter identity
+ *
+ * Same as get_meter_data(), but uses explicit meter identification instead of
+ * compile-time defines. This is required for ESPHome multi-instance support.
+ *
+ * @param meter_year Last two digits of meter production year
+ * @param meter_serial Meter serial number
+ * @return tmeter_data structure containing all extracted meter data
+ */
+struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_serial);
+
 #endif // __CC1101_H__

--- a/src/services/meter_reader.cpp
+++ b/src/services/meter_reader.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "meter_reader.h"
-#include "schedule_manager.h"
 #include "meter_history.h"
 
 // Conditional includes based on build environment
@@ -54,13 +53,44 @@ MeterReader::MeterReader(IConfigProvider *config, ITimeProvider *timeProvider, I
 {
 }
 
+MeterReader *MeterReader::s_active_reader = nullptr;
+
+bool MeterReader::radioInitCallback(float freq)
+{
+    if (!s_active_reader)
+    {
+        return false;
+    }
+    return cc1101_init(freq);
+}
+
+tmeter_data MeterReader::meterReadCallback()
+{
+    tmeter_data data{};
+    if (!s_active_reader)
+    {
+        return data;
+    }
+
+    return get_meter_data_for_meter(
+        s_active_reader->m_config->getMeterYear(),
+        s_active_reader->m_config->getMeterSerial());
+}
+
+void MeterReader::activateCallbackContext()
+{
+    s_active_reader = this;
+}
+
 void MeterReader::begin()
 {
     LOG_I("everblu_meter", "Initializing...");
 
+    activateCallbackContext();
+
     // Register FrequencyManager callbacks
-    FrequencyManager::setRadioInitCallback(cc1101_init);
-    FrequencyManager::setMeterReadCallback(get_meter_data);
+    FrequencyManager::setRadioInitCallback(MeterReader::radioInitCallback);
+    FrequencyManager::setMeterReadCallback(MeterReader::meterReadCallback);
 
     // Initialize FrequencyManager with configured frequency
     float frequency = m_config->getFrequency();
@@ -227,7 +257,7 @@ bool MeterReader::shouldPerformScheduledRead()
     struct tm *ptm = gmtime(&localTime);
 
     // Check if today is a valid reading day
-    bool isDayMatch = ScheduleManager::isReadingDay(ptm);
+    bool isDayMatch = isReadingDayForConfiguredSchedule(ptm);
     bool isTimeMatch = (ptm->tm_hour == m_readHourLocal && ptm->tm_min == m_readMinuteLocal);
     bool isSecondMatch = (ptm->tm_sec == 0);
 
@@ -259,6 +289,8 @@ void MeterReader::triggerReading(bool isScheduled)
 
 void MeterReader::performReading()
 {
+    activateCallbackContext();
+
     if (!m_publisher->isReady())
     {
         LOG_W("everblu_meter", "Publisher not ready, aborting read");
@@ -282,7 +314,7 @@ void MeterReader::performReading()
           currentFreq, currentOffset * 1000.0);
 
     // Perform actual meter read
-    struct tmeter_data meter_data = get_meter_data();
+    struct tmeter_data meter_data = meterReadCallback();
 
     // Validate data
     if (meter_data.reads_counter == 0 || meter_data.volume == 0)
@@ -393,6 +425,8 @@ void MeterReader::resetRetryState()
 
 void MeterReader::performFrequencyScan(bool wideRange)
 {
+    activateCallbackContext();
+
     LOG_I("everblu_meter", "Starting %s frequency scan...", wideRange ? "wide" : "narrow");
 
     if (wideRange)
@@ -417,6 +451,8 @@ void MeterReader::performFrequencyScan(bool wideRange)
 
 void MeterReader::resetFrequencyOffset()
 {
+    activateCallbackContext();
+
     LOG_I("everblu_meter", "Resetting frequency offset to 0");
 
     // Reset offset to 0 and save
@@ -424,7 +460,7 @@ void MeterReader::resetFrequencyOffset()
 
     // Reinitialize radio with base frequency
     float baseFrequency = FrequencyManager::getBaseFrequency();
-    bool radio_ok = cc1101_init(baseFrequency);
+    bool radio_ok = radioInitCallback(baseFrequency);
     m_radioConnected = radio_ok;
 
     if (radio_ok)
@@ -455,4 +491,35 @@ void MeterReader::getStatistics(unsigned long &totalAttempts, unsigned long &suc
 void MeterReader::setHAConnected(bool connected)
 {
     m_haConnected = connected;
+}
+
+bool MeterReader::isReadingDayForConfiguredSchedule(const struct tm *ptm) const
+{
+    if (ptm == nullptr)
+    {
+        return false;
+    }
+
+    const char *schedule = m_config->getReadingSchedule();
+    if (schedule == nullptr)
+    {
+        schedule = "Monday-Friday";
+    }
+
+    const int dayOfWeek = ptm->tm_wday; // 0=Sunday, 1=Monday, ... 6=Saturday
+    if (strcmp(schedule, "Monday-Friday") == 0)
+    {
+        return dayOfWeek >= 1 && dayOfWeek <= 5;
+    }
+    if (strcmp(schedule, "Monday-Saturday") == 0)
+    {
+        return dayOfWeek >= 1 && dayOfWeek <= 6;
+    }
+    if (strcmp(schedule, "Monday-Sunday") == 0)
+    {
+        return true;
+    }
+
+    // Default to safe weekdays behaviour for unknown schedule strings.
+    return dayOfWeek >= 1 && dayOfWeek <= 5;
 }

--- a/src/services/meter_reader.cpp
+++ b/src/services/meter_reader.cpp
@@ -520,6 +520,7 @@ bool MeterReader::isReadingDayForConfiguredSchedule(const struct tm *ptm) const
         return true;
     }
 
-    // Default to safe weekdays behaviour for unknown schedule strings.
-    return dayOfWeek >= 1 && dayOfWeek <= 5;
+    // Unknown schedule: log warning and skip read to avoid misconfiguration
+    LOG_W("everblu_meter", "Unknown reading_schedule '%s'; skipping scheduled read.", schedule);
+    return false;
 }

--- a/src/services/meter_reader.h
+++ b/src/services/meter_reader.h
@@ -117,6 +117,14 @@ public:
     void setHAConnected(bool connected);
 
 private:
+    static MeterReader *s_active_reader;
+
+    static bool radioInitCallback(float freq);
+    static tmeter_data meterReadCallback();
+
+    void activateCallbackContext();
+    bool isReadingDayForConfiguredSchedule(const struct tm *ptm) const;
+
     /**
      * @brief Perform actual meter reading operation
      *


### PR DESCRIPTION
- enable multi-instance ESPHome configuration
- move meter reads to runtime meter year/serial selection
- reapply per-instance radio context before operations
- add multi-meter example YAML
- document shared cs_pin/gdo0_pin usage with allow_other_uses