### PR TITLE
feat: add compile-time option to disable Home Assistant discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Releases are created manually by tagging commits with version tags matching `v*.*.*` (e.g., `v2.1.0`). Users should build from source and configure `private.h` with their own meter settings.
 
+## [v2.2.1] - 2026-05-07
+
+### Added
+
+- Added compile-time MQTT option `ENABLE_HA_DISCOVERY` (default `1`) to allow disabling Home Assistant discovery topic publishing (`homeassistant/...`) while keeping raw MQTT telemetry and command topics active (Issue #77).
+
+### Changed
+
+- Updated `include/private.example.h` and README configuration guidance with the new Home Assistant discovery toggle.
+- Bumped firmware/component version to `2.2.1`.
+
 ## [v2.2.0] - 2026-04-21
 
 > **⚠️ BREAKING CHANGE** — This release contains a breaking ESPHome configuration schema change due to the explicit SPI integration. Existing `everblu_meter` YAML configurations **will not validate** without migration. See [Migration Required](#migration-required) below.

--- a/ESPHOME-release/everblu_meter/version.h
+++ b/ESPHOME-release/everblu_meter/version.h
@@ -2,5 +2,5 @@
 // Keep this in sync with the latest entry in CHANGELOG.md and Git tags.
 
 #ifndef EVERBLU_FW_VERSION
-#define EVERBLU_FW_VERSION "2.2.0"
+#define EVERBLU_FW_VERSION "2.2.1"
 #endif

--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ Default behavior (if not defined) is enabled:
 ```
 
 With discovery disabled, telemetry and command topics under `everblu/cyble/...` continue to work normally.
+If discovery was enabled previously, retained `homeassistant/...` config topics may remain on the broker until you clear them (or switch to a different discovery prefix), so existing Home Assistant entities may not disappear immediately.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Integrated with Home Assistant via MQTT AutoDiscovery and ESPHome external compo
 
 ---
 
-### **ESPHome** - Release V2.1.3
+### **ESPHome** - Release V2.2.1
 ESPHome integration is now production-ready. For setup and usage, see the ESPHome docs at [ESPHOME/README.md](ESPHOME/README.md)
- - Versioned external component in `ESPHOME-release` with the same 2.1.3 code as the main firmware
+ - Versioned external component in `ESPHOME-release` with the same 2.2.1 code as the main firmware
  - Tested on ESP8266 and ESP32 with water and gas meters; supports the same sensors and calibration logic
  - YAML stays simple: drop in the component, set `meter_year`, `meter_serial`, `meter_type`, and go
  - Build with the Arduino framework (set `esp32.framework.type: arduino`; ESP-IDF is not supported for this component)
@@ -177,6 +177,7 @@ See the Hardware section below for full wiring tables and pictures.
 - `include/private.h` (copy from `include/private.example.h`):
   - Wi‑Fi SSID/password
   - MQTT broker/port (+ credentials, if used)
+  - `ENABLE_HA_DISCOVERY` - set to `0` to disable Home Assistant discovery topic publishing (`homeassistant/...`) and keep raw MQTT topics only
   - `METER_YEAR` and `METER_SERIAL` (from the meter label)
   - `METER_TYPE` - set to `"water"` (default) or `"gas"` depending on your meter type
   - `MAX_RETRIES` - maximum reading retry attempts before cooldown (optional, default is 10)
@@ -670,6 +671,26 @@ In serial logs at startup you’ll see:
 - The UTC time pulled from the time server
 - The configured offset (minutes)
 - The local (UTC+offset) time
+
+---
+
+### Home Assistant Discovery Toggle (MQTT mode)
+
+By default, the standalone MQTT firmware publishes Home Assistant discovery topics under `homeassistant/...` so entities are created automatically.
+
+If you only want raw MQTT topics and do not use Home Assistant discovery, set this in `include/private.h`:
+
+```cpp
+#define ENABLE_HA_DISCOVERY 0
+```
+
+Default behavior (if not defined) is enabled:
+
+```cpp
+#define ENABLE_HA_DISCOVERY 1
+```
+
+With discovery disabled, telemetry and command topics under `everblu/cyble/...` continue to work normally.
 
 ---
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -247,6 +247,8 @@ Discovery publishing is enabled by default. To disable `homeassistant/...` topic
 #define ENABLE_HA_DISCOVERY 0
 ```
 
+If discovery was enabled before, retained `homeassistant/...` config topics may still exist on the broker until they are cleared, so Home Assistant entities may remain visible after switching this to `0`.
+
 The stored offset is automatically applied:
 ```
 Effective Frequency = FREQUENCY + stored_offset

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -240,6 +240,13 @@ The base frequency is defined in `private.h`:
 #define FREQUENCY 433.82  // Base frequency in MHz
 ```
 
+### Home Assistant Discovery (MQTT)
+Discovery publishing is enabled by default. To disable `homeassistant/...` topic publishing and keep only raw MQTT topics:
+
+```cpp
+#define ENABLE_HA_DISCOVERY 0
+```
+
 The stored offset is automatically applied:
 ```
 Effective Frequency = FREQUENCY + stored_offset

--- a/include/private.example.h
+++ b/include/private.example.h
@@ -35,6 +35,15 @@
 // 0 = disable (default)
 #define ENABLE_MQTT_DEBUGGING 0
 
+// Home Assistant MQTT discovery publishing
+// Controls whether the firmware publishes Home Assistant discovery topics
+// under homeassistant/... at startup.
+//
+// 1 (default): Publish discovery topics for automatic Home Assistant entity creation
+// 0:           Disable discovery publishing (raw MQTT topics only)
+//
+#define ENABLE_HA_DISCOVERY 1
+
 // Meter number prefix in entity IDs
 // Controls whether the meter serial number is included as a prefix in MQTT entity IDs
 // and Home Assistant entity names. This is useful for distinguishing entities when

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -2,5 +2,5 @@
 // Keep this in sync with the latest entry in CHANGELOG.md and Git tags.
 
 #ifndef EVERBLU_FW_VERSION
-#define EVERBLU_FW_VERSION "2.2.0"
+#define EVERBLU_FW_VERSION "2.2.1"
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -320,6 +320,11 @@ const char *readingSchedule = DEFAULT_READING_SCHEDULE;
 #define ENABLE_METER_PREFIX_IN_ENTITY_IDS 1
 #endif
 
+// Define Home Assistant MQTT discovery option if not defined in private.h (default to enabled)
+#ifndef ENABLE_HA_DISCOVERY
+#define ENABLE_HA_DISCOVERY 1
+#endif
+
 // Buffer size calculations for MQTT topics:
 // - meterSerialStr: METER_SERIAL as string (max 10 digits for ULONG_MAX) + null = 16 bytes (safe)
 // - mqttBaseTopic: "everblu/cyble/" (15) + optional METER_SERIAL (10) + null (1) = 26 bytes minimum
@@ -1451,8 +1456,12 @@ void onConnectionEstablished()
 
   Serial.println("[MQTT] Send MQTT config for HA.");
 
-  // Publish all Home Assistant discovery messages with serial-specific entity IDs
+  // Publish Home Assistant discovery only when enabled in compile-time config.
+#if ENABLE_HA_DISCOVERY
   publishHADiscovery();
+#else
+  Serial.println("[MQTT] Home Assistant discovery disabled by ENABLE_HA_DISCOVERY=0");
+#endif
 
   // Set initial state for active reading
   char topicBuffer[MQTT_TOPIC_BUFFER_SIZE];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1454,10 +1454,9 @@ void onConnectionEstablished()
     Serial.println("Frequency scan command received via MQTT");
     performFrequencyScan(); });
 
-  Serial.println("[MQTT] Send MQTT config for HA.");
-
   // Publish Home Assistant discovery only when enabled in compile-time config.
 #if ENABLE_HA_DISCOVERY
+  Serial.println("[MQTT] Send Home Assistant discovery config.");
   publishHADiscovery();
 #else
   Serial.println("[MQTT] Home Assistant discovery disabled by ENABLE_HA_DISCOVERY=0");


### PR DESCRIPTION
This pull request introduces a new compile-time option to control Home Assistant discovery publishing over MQTT, along with associated documentation updates and a version bump to `2.2.1`. By default, Home Assistant discovery remains enabled, but users can now disable it to only publish raw MQTT topics. The change is reflected in the codebase, example configuration, and documentation.

**MQTT Home Assistant Discovery Toggle:**

- Added a new compile-time option `ENABLE_HA_DISCOVERY` (default `1`) to allow users to disable Home Assistant discovery topic publishing (`homeassistant/...`) while keeping raw MQTT telemetry and command topics active. This is controlled via `private.h` and can be set to `0` to disable discovery. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R323-R327) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L1454-R1464) [[3]](diffhunk://#diff-437535ee1e72d1f3088b08e1b6b4e58231e6332e51e1001bf49ef797657c0840R38-R46)

**Documentation and Example Updates:**

- Updated `README.md`, `docs/QUICK_REFERENCE.md`, and `include/private.example.h` to document the new `ENABLE_HA_DISCOVERY` option, including configuration guidance and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R180) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R677-R696) [[3]](diffhunk://#diff-a414f8a0572fba48be1498f106e3dd2f463b75705c694a78ee83c9df3b2597c4R243-R249) [[4]](diffhunk://#diff-437535ee1e72d1f3088b08e1b6b4e58231e6332e51e1001bf49ef797657c0840R38-R46)
- Updated the ESPHome release section and configuration instructions to reference version `2.2.1` and the new option.

**Versioning:**

- Bumped firmware/component version to `2.2.1` in `CHANGELOG.md`, `src/core/version.h`, and `ESPHOME-release/everblu_meter/version.h`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R17) [[2]](diffhunk://#diff-653c8776653021398759c7556e1e3952e8a26c69331c1d626e72c57722a59721L5-R5)

**Changelog:**

- Added a new entry for version `2.2.1` in `CHANGELOG.md`, summarizing the new feature and documentation updates.