### PR TITLE
chore: treat ESPHOME-release as generated read-only output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,9 @@
 # and Linux CI-regenerated content stay byte-for-byte identical.
 ESPHOME-release/**  text eol=lf
 
+# Mark release artifacts as generated in GitHub so PR review focuses on source.
+ESPHOME-release/**  linguist-generated=true
+
 # Shell scripts must always be LF (required for execution on Linux/macOS)
 *.sh  text eol=lf
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,3 +32,9 @@ This project reads Itron/Actaris EverBlu Cyble water/gas meters via a CC1101 433
 - `include/private.h` is gitignored and contains real credentials; do not flag its absence as an error.
 - The project targets both ESP8266 (Arduino framework, no `std::` threading) and ESP32 + ESPHome; avoid suggestions that break 8266 compatibility unless the change is explicitly scoped to ESP32.
 - PlatformIO environments are defined in `platformio.ini`; the default build target is `huzzah` (Adafruit HUZZAH ESP8266).
+
+## Generated output policy
+
+- Treat `ESPHOME-release/` as read-only generated output.
+- Never edit files in `ESPHOME-release/` directly, even if a user asks for behavior changes.
+- Make changes only in `ESPHOME/components/everblu_meter/` (and related source), then regenerate `ESPHOME-release/` via `ESPHOME/prepare-component-release.ps1` or `.sh`.

--- a/.github/instructions/esphome-release-readonly.instructions.md
+++ b/.github/instructions/esphome-release-readonly.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "ESPHOME-release/**"
+---
+
+# ESPHOME-release is generated output
+
+Do not edit files in this folder directly.
+
+If a change is needed:
+
+1. Edit the source under ESPHOME/components/everblu_meter/.
+2. Regenerate this folder using ESPHOME/prepare-component-release.ps1 or ESPHOME/prepare-component-release.sh.
+3. Commit both source and regenerated output only when intentionally preparing a release.

--- a/.github/workflows/build-esp32.yml
+++ b/.github/workflows/build-esp32.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+    paths:
+      - src/**
+      - include/**
+      - platformio.ini
+      - .github/workflows/build-esp32.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-esp8266.yml
+++ b/.github/workflows/build-esp8266.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+    paths:
+      - src/**
+      - include/**
+      - platformio.ini
+      - .github/workflows/build-esp8266.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+    paths:
+      - src/**
+      - include/**
+      - .clang-format
+      - .github/workflows/code-quality.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+    paths:
+      - platformio.ini
+      - include/private.example.h
+      - src/**
+      - .github/workflows/config-validation.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+    paths:
+      - platformio.ini
+      - .github/workflows/dependency-check.yml
   schedule:
     # Run weekly on Mondays at 00:00 UTC
     - cron: "0 0 * * 1"

--- a/.github/workflows/esphome-external-component.yml
+++ b/.github/workflows/esphome-external-component.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+    paths:
+      - ESPHOME/components/everblu_meter/**
+      - .ci/esphome/everblu_meter/**
+      - ESPHOME/example-*.yaml
+      - ESPHOME/README.md
+      - .github/workflows/esphome-external-component.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/memory-and-size.yml
+++ b/.github/workflows/memory-and-size.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+    paths:
+      - src/**
+      - include/**
+      - platformio.ini
+      - .github/workflows/memory-and-size.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/meter-fixture-tests.yml
+++ b/.github/workflows/meter-fixture-tests.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
+    paths:
+      - src/**
+      - include/**
+      - platformio.ini
+      - test/fixtures/**
+      - test/test_native_meter_fixtures/**
+      - .github/workflows/meter-fixture-tests.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request introduces a policy and supporting configuration to treat the `ESPHOME-release/` directory as read-only, generated output. The changes ensure that contributors and automated tools do not edit release artifacts directly, but instead make changes in the source and regenerate the output as needed.

**Generated Output Policy and Enforcement:**

* Documentation update in `.github/copilot-instructions.md` to clarify that `ESPHOME-release/` is read-only generated output, and to specify the correct workflow for making changes (edit source, then regenerate release artifacts).
* Addition of `.github/instructions/esphome-release-readonly.instructions.md` to provide explicit instructions not to edit files in `ESPHOME-release/` directly, and to outline the correct regeneration process.

**Repository and GitHub Configuration:**

* Update to `.gitattributes` to mark all files in `ESPHOME-release/` as `linguist-generated`, ensuring GitHub focuses PR review on source files and not generated artifacts.