### PR TITLE
feat(cc1101): hardware TX FIFO threshold via GDO2 to prevent TXFIFO_UNDERFLOW - PART A (#83)

### DIFF
--- a/ESPHOME-release/everblu_meter/__init__.py
+++ b/ESPHOME-release/everblu_meter/__init__.py
@@ -94,6 +94,7 @@ SCHEDULE_MONDAY_SATURDAY = "Monday-Saturday"
 SCHEDULE_MONDAY_SUNDAY = "Monday-Sunday"
 
 CONF_GDO0_PIN = "gdo0_pin"
+CONF_GDO2_PIN = "gdo2_pin"
 
 
 def validate_meter_code(value):
@@ -161,6 +162,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(EverbluMeterComponent),
             cv.Required(CONF_METER_CODE): validate_meter_code,
             cv.Required(CONF_GDO0_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Optional(CONF_GDO2_PIN): pins.internal_gpio_input_pin_schema,
             cv.Required(CONF_TIME_ID): cv.use_id(time_.RealTimeClock),
             cv.Optional(CONF_METER_TYPE, default=METER_TYPE_WATER): cv.enum(
                 {METER_TYPE_WATER: False, METER_TYPE_GAS: True}
@@ -339,6 +341,10 @@ async def to_code(config):
     # CS pin is managed by SPIDevice; pass the InternalGPIOPin for CC1101 interrupts.
     gdo0 = await cg.gpio_pin_expression(config[CONF_GDO0_PIN])
     cg.add(var.set_gdo0_pin(gdo0))
+
+    if CONF_GDO2_PIN in config:
+        gdo2 = await cg.gpio_pin_expression(config[CONF_GDO2_PIN])
+        cg.add(var.set_gdo2_pin(gdo2))
 
     # No custom include paths needed when using flat release layout
 

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1642,7 +1642,10 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
         // Final underflow check: if FIFO underflowed during the wait, abort TX loop.
         uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
         if (txbytes_reg & 0x80)
+        {
+          marcstate = halRfReadReg(MARCSTATE_ADDR); // refresh so tx_aborted check below is accurate
           break; // TXFIFO_UNDERFLOW already occurred
+        }
       }
       else
       {

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -88,7 +88,7 @@ static const uint8_t debug_out = (uint8_t)(DEBUG_CC1101);
 /*-------------------------[CC1100 - Register Values]----------------------------*/
 // IOCFG2 - GDO2 Output Pin Configuration
 #define IOCFG2_SERIAL_DATA_OUTPUT 0x0D // GDO2: Serial Data Output (kept for reference, not used)
-#define IOCFG2_TX_FIFO_THR        0x02 // GDO2: asserts HIGH when TX FIFO >= threshold; de-asserts LOW when below threshold
+#define IOCFG2_TX_FIFO_THR 0x02        // GDO2: asserts HIGH when TX FIFO >= threshold; de-asserts LOW when below threshold
 
 // IOCFG0 - GDO0 Output Pin Configuration
 #define IOCFG0_SYNC_WORD_DETECT 0x06 // Asserts when sync word detected, deasserts at end of packet
@@ -547,11 +547,11 @@ void cc1101_configureRF_0(float freq)
   // GDO2: TX FIFO threshold signal when pin is wired; falls back to IOCFG2_SERIAL_DATA_OUTPUT
   // if not connected (output floats harmlessly). Using IOCFG2_TX_FIFO_THR lets the TX feeding
   // loop replace SPI TXBYTES polling with a fast digitalRead() for proactive underflow prevention.
-  halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);        // GDO2: TX FIFO at/above threshold
-  halRfWriteReg(IOCFG0, IOCFG0_SYNC_WORD_DETECT);   // GDO0: Sync word detection
-  halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_25_40);   // FIFO thresholds: TX=25 bytes, RX=40 bytes
-  halRfWriteReg(SYNC1, SYNC1_PATTERN_55);           // Sync word MSB: 0x55
-  halRfWriteReg(SYNC0, SYNC0_PATTERN_00);           // Sync word LSB: 0x00
+  halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);      // GDO2: TX FIFO at/above threshold
+  halRfWriteReg(IOCFG0, IOCFG0_SYNC_WORD_DETECT); // GDO0: Sync word detection
+  halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_25_40); // FIFO thresholds: TX=25 bytes, RX=40 bytes
+  halRfWriteReg(SYNC1, SYNC1_PATTERN_55);         // Sync word MSB: 0x55
+  halRfWriteReg(SYNC0, SYNC0_PATTERN_00);         // Sync word LSB: 0x00
 
   halRfWriteReg(PKTCTRL1, PKTCTRL1_NO_ADDR_CHECK); // No address check
   halRfWriteReg(PKTCTRL0, PKTCTRL0_FIXED_LENGTH);  // Fixed packet length

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1644,7 +1644,7 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
         if (txbytes_reg & 0x80)
         {
           marcstate = halRfReadReg(MARCSTATE_ADDR); // refresh so tx_aborted check below is accurate
-          break; // TXFIFO_UNDERFLOW already occurred
+          break;                                    // TXFIFO_UNDERFLOW already occurred
         }
       }
       else

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -544,9 +544,9 @@ void cc1101_configureRF_0(float freq)
   //
   // RF settings for CC1101 - RADIAN protocol (Itron EverBlu)
   //
-  // GDO2: TX FIFO threshold signal when pin is wired; falls back to IOCFG2_SERIAL_DATA_OUTPUT
-  // if not connected (output floats harmlessly). Using IOCFG2_TX_FIFO_THR lets the TX feeding
-  // loop replace SPI TXBYTES polling with a fast digitalRead() for proactive underflow prevention.
+  // GDO2: always configured as TX FIFO threshold signal (IOCFG2_TX_FIFO_THR = 0x02).
+  // When GDO2 is not physically wired, the output is unused; the TX feeding loop falls back
+  // to SPI TXBYTES polling instead of digitalRead(). IOCFG2_SERIAL_DATA_OUTPUT is not restored.
   halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);      // GDO2: TX FIFO at/above threshold
   halRfWriteReg(IOCFG0, IOCFG0_SYNC_WORD_DETECT); // GDO0: Sync word detection
   halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_25_40); // FIFO thresholds: TX=25 bytes, RX=40 bytes

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1626,6 +1626,9 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
     else
     {
       // Wait for TX FIFO to drain enough to fit the 39-byte interrogation frame.
+      // Only write when FIFO space is confirmed; skip and retry the outer TX loop if
+      // the safety limit fires before the FIFO drains (avoids write with no headroom).
+      bool fifo_ready = false;
       if (GET_GDO2_PIN() >= 0)
       {
         // With FIFOTHR_FIFO_THR_25_40: GDO2 de-asserts (LOW) when FIFO < 25 bytes,
@@ -1646,6 +1649,8 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
           marcstate = halRfReadReg(MARCSTATE_ADDR); // refresh so tx_aborted check below is accurate
           break;                                    // TXFIFO_UNDERFLOW already occurred
         }
+        // Confirm GDO2 is actually LOW (FIFO drained), not merely timed out with FIFO still full.
+        fifo_ready = (digitalRead(GET_GDO2_PIN()) == LOW);
       }
       else
       {
@@ -1656,23 +1661,29 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
         {
           uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
           if (txbytes_reg & 0x80)
-            break; // TXFIFO_UNDERFLOW already occurred
+            break; // TXFIFO_UNDERFLOW — marcstate check at loop bottom will abort
           uint8_t num_txbytes = txbytes_reg & 0x7F;
           if (num_txbytes <= 25)
-            break; // 64 - 25 = 39 free bytes available
+          {
+            fifo_ready = true; // 64 - 25 = 39 free bytes confirmed
+            break;
+          }
           delay(5);
           wait_count++;
           if (wait_count % 10 == 0)
             FEED_WDT();
         }
       }
-      SPIWriteBurstReg(TX_FIFO_ADDR, txbuffer, 39);
-      if (debug_out && 0)
+      if (fifo_ready)
       {
-        echo_debug(debug_out, "txbuffer:\n");
-        show_in_hex_array(&txbuffer[0], 39);
+        SPIWriteBurstReg(TX_FIFO_ADDR, txbuffer, 39);
+        if (debug_out && 0)
+        {
+          echo_debug(debug_out, "txbuffer:\n");
+          show_in_hex_array(&txbuffer[0], 39);
+        }
+        wup2send = 0xFF;
       }
-      wup2send = 0xFF;
     }
     delay(10);
     tmo++;

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -87,13 +87,18 @@ static const uint8_t debug_out = (uint8_t)(DEBUG_CC1101);
 
 /*-------------------------[CC1100 - Register Values]----------------------------*/
 // IOCFG2 - GDO2 Output Pin Configuration
-#define IOCFG2_SERIAL_DATA_OUTPUT 0x0D // GDO2: Serial Data Output
+#define IOCFG2_SERIAL_DATA_OUTPUT 0x0D // GDO2: Serial Data Output (kept for reference, not used)
+#define IOCFG2_TX_FIFO_THR        0x02 // GDO2: asserts HIGH when TX FIFO >= threshold; de-asserts LOW when below threshold
 
 // IOCFG0 - GDO0 Output Pin Configuration
 #define IOCFG0_SYNC_WORD_DETECT 0x06 // Asserts when sync word detected, deasserts at end of packet
 
 // FIFOTHR - RX FIFO and TX FIFO Thresholds
-#define FIFOTHR_FIFO_THR_33_32 0x47 // RX FIFO threshold: 33 bytes, TX FIFO threshold: 32 bytes
+// FIFO_THR=9 (0x49): TX threshold=25 bytes — de-assertion guarantees >=40 free bytes, safely fits both
+//                    the 8-byte WUP buffer and the 39-byte interrogation frame with a single GDO2 check.
+//                    RX threshold shifts to 40 bytes (no impact: RX loop uses GDO0 + RXBYTES, not FIFO signal).
+#define FIFOTHR_FIFO_THR_33_32 0x47 // FIFO_THR=7: TX threshold 33 bytes, RX threshold 33 bytes (legacy)
+#define FIFOTHR_FIFO_THR_25_40 0x49 // FIFO_THR=9: TX threshold 25 bytes, RX threshold 40 bytes
 
 // SYNC1/SYNC0 - Sync Word Configuration
 #define SYNC1_PATTERN_55 0x55 // Sync word pattern: 0x55 (01010101)
@@ -219,6 +224,7 @@ using CC1101SpiDevice = esphome::spi::SPIDevice<esphome::spi::BIT_ORDER_MSB_FIRS
                                                 esphome::spi::DATA_RATE_1MHZ>;
 static CC1101SpiDevice *_spi_device = nullptr;
 static int _gdo0_pin = -1;
+static int _gdo2_pin = -1;
 
 void cc1101_set_spi_device(void *device)
 {
@@ -231,11 +237,22 @@ void cc1101_set_gdo0_pin(int gdo0_pin)
   _gdo0_pin = gdo0_pin;
 }
 
-// Macro to get GDO0 pin - use variable in ESPHome mode, build flag otherwise
+void cc1101_set_gdo2_pin(int gdo2_pin)
+{
+  _gdo2_pin = gdo2_pin;
+}
+
+// Macros to get GDO pin numbers - use variables in ESPHome mode, build flags otherwise
 #define GET_GDO0_PIN() (_gdo0_pin)
+#define GET_GDO2_PIN() (_gdo2_pin)
 #else
-// Non-ESPHome mode: GDO0 comes from build flag
+// Non-ESPHome mode: GDO0 comes from build flag; GDO2 is optional
 #define GET_GDO0_PIN() (GDO0)
+#ifdef GDO2
+#define GET_GDO2_PIN() (GDO2)
+#else
+#define GET_GDO2_PIN() (-1)
+#endif
 #endif
 
 // Change these define according to your ESP8266 board
@@ -527,9 +544,12 @@ void cc1101_configureRF_0(float freq)
   //
   // RF settings for CC1101 - RADIAN protocol (Itron EverBlu)
   //
-  halRfWriteReg(IOCFG2, IOCFG2_SERIAL_DATA_OUTPUT); // GDO2: Serial data output
+  // GDO2: TX FIFO threshold signal when pin is wired; falls back to IOCFG2_SERIAL_DATA_OUTPUT
+  // if not connected (output floats harmlessly). Using IOCFG2_TX_FIFO_THR lets the TX feeding
+  // loop replace SPI TXBYTES polling with a fast digitalRead() for proactive underflow prevention.
+  halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);        // GDO2: TX FIFO at/above threshold
   halRfWriteReg(IOCFG0, IOCFG0_SYNC_WORD_DETECT);   // GDO0: Sync word detection
-  halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_33_32);   // FIFO thresholds
+  halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_25_40);   // FIFO thresholds: TX=25 bytes, RX=40 bytes
   halRfWriteReg(SYNC1, SYNC1_PATTERN_55);           // Sync word MSB: 0x55
   halRfWriteReg(SYNC0, SYNC0_PATTERN_00);           // Sync word LSB: 0x00
 
@@ -573,6 +593,13 @@ bool cc1101_init(float freq)
 #endif
 
   pinMode(GET_GDO0_PIN(), INPUT_PULLUP);
+
+  // GDO2 is optional; configure as input only when a pin is assigned.
+  if (GET_GDO2_PIN() >= 0)
+  {
+    pinMode(GET_GDO2_PIN(), INPUT);
+    echo_debug(debug_out, "[CC1101] GDO2 pin %d configured as TX FIFO threshold input\n", GET_GDO2_PIN());
+  }
 
   // Initialize SPI transport for CC1101 communication.
   // Standalone builds configure Arduino SPI here at 500 kHz.
@@ -1569,26 +1596,58 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
     {
       if (wup2send < 0xFF)
       {
-        if (CC1101_status_FIFO_FreeByte <= 10)
-        { // this gives 10+20ms from previous frame : 8*8/2.4k=26.6ms  time to send a wupbuffer
-          delay(20);
-          tmo++;
-          tmo++;
+        if (GET_GDO2_PIN() >= 0)
+        {
+          // GDO2 configured: asserts HIGH when TX FIFO >= 25 bytes (FIFOTHR_FIFO_THR_25_40).
+          // Only refill when GDO2 de-asserts LOW (FIFO below threshold, >= 40 free bytes).
+          // This replaces the stale CC1101_status_FIFO_FreeByte check + fixed delay(20) with
+          // a real-time hardware signal, preventing underflows under ESPHome scheduler load.
+          if (digitalRead(GET_GDO2_PIN()) == LOW)
+          {
+            SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+            wup2send--;
+          }
+          // else: FIFO still above threshold — skip write this iteration
         }
-        SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
-        wup2send--;
+        else
+        {
+          // Fallback: use SPI status byte FIFO level (may be stale by one transaction).
+          if (CC1101_status_FIFO_FreeByte <= 10)
+          { // this gives 10+20ms from previous frame : 8*8/2.4k=26.6ms  time to send a wupbuffer
+            delay(20);
+            tmo++;
+            tmo++;
+          }
+          SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+          wup2send--;
+        }
       }
     }
     else
     {
-      // Wait for enough FIFO space for the 39-byte interrogation frame.
-      // Poll TXBYTES register instead of fixed delay(130) to prevent
-      // TXFIFO_UNDERFLOW when FIFO level is low. This commonly occurs in
-      // ESPHome builds where yield()/delay() service heavy background tasks
-      // (WiFi, API server, OTA, logger, mDNS, web_server) causing the FIFO
-      // feeding loop to fall behind the 2.4 kbps TX drain rate.
-      // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/58
+      // Wait for TX FIFO to drain enough to fit the 39-byte interrogation frame.
+      if (GET_GDO2_PIN() >= 0)
       {
+        // With FIFOTHR_FIFO_THR_25_40: GDO2 de-asserts (LOW) when FIFO < 25 bytes,
+        // guaranteeing >= 40 free bytes — safely fits the 39-byte frame.
+        // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/83
+        uint8_t wait_count = 0;
+        while (digitalRead(GET_GDO2_PIN()) == HIGH && wait_count < 100) // Safety limit ~500ms
+        {
+          delay(5);
+          wait_count++;
+          if (wait_count % 10 == 0)
+            FEED_WDT();
+        }
+        // Final underflow check: if FIFO underflowed during the wait, abort TX loop.
+        uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
+        if (txbytes_reg & 0x80)
+          break; // TXFIFO_UNDERFLOW already occurred
+      }
+      else
+      {
+        // Fallback: poll TXBYTES register until <= 25 bytes remain (39 free bytes).
+        // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/58
         uint8_t wait_count = 0;
         while (wait_count < 100) // Safety limit ~500ms
         {

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -31,6 +31,18 @@ void cc1101_set_spi_device(void *device);
  * @param gdo0_pin GPIO pin number for GDO0 interrupt signal
  */
 void cc1101_set_gdo0_pin(int gdo0_pin);
+
+/**
+ * @brief Set GDO2 pin for ESPHome mode (optional)
+ *
+ * When configured, GDO2 is read as a hardware TX FIFO threshold signal
+ * (IOCFG2 = 0x02), replacing SPI-based TXBYTES polling in the TX feeding loop.
+ * If not called (or called with -1), the driver falls back to the legacy
+ * CC1101_status_FIFO_FreeByte + delay(20) approach.
+ *
+ * @param gdo2_pin GPIO pin number connected to CC1101 GDO2, or -1 to disable
+ */
+void cc1101_set_gdo2_pin(int gdo2_pin);
 #endif
 
 /**

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -342,6 +342,17 @@ namespace esphome
                     gdo0_error_logged_ = true;
                 }
             }
+
+            // GDO2 is optional: when wired and configured, it drives hardware-assisted
+            // TX FIFO threshold detection instead of SPI TXBYTES polling.
+            if (gdo2_pin_ != nullptr)
+            {
+                cc1101_set_gdo2_pin(gdo2_pin_->get_pin());
+            }
+            else
+            {
+                cc1101_set_gdo2_pin(-1); // Ensure fallback mode on re-entry
+            }
         }
 
         void EverbluMeterComponent::update()
@@ -370,6 +381,8 @@ namespace esphome
             ESP_LOGCONFIG(TAG, "  Max Retries: %d", max_retries_);
             ESP_LOGCONFIG(TAG, "  Retry Cooldown: %lu ms", retry_cooldown_ms_);
             ESP_LOGCONFIG(TAG, "  Initial Read On Boot: %s", initial_read_on_boot_ ? "Enabled" : "Disabled");
+            ESP_LOGCONFIG(TAG, "  GDO0 Pin: %s", gdo0_pin_ != nullptr ? "configured" : "NOT configured (error)");
+            ESP_LOGCONFIG(TAG, "  GDO2 Pin: %s", gdo2_pin_ != nullptr ? "configured (HW TX FIFO threshold)" : "not wired (SPI polling fallback)");
 
             ESP_LOGCONFIG(TAG, "  Sensors:");
             LOG_SENSOR("    ", "Volume", volume_sensor_);

--- a/ESPHOME-release/everblu_meter/everblu_meter.h
+++ b/ESPHOME-release/everblu_meter/everblu_meter.h
@@ -101,6 +101,7 @@ namespace esphome
             void set_initial_read_on_boot(bool v) { initial_read_on_boot_ = v; }
             void set_adaptive_threshold(int threshold) { adaptive_threshold_ = threshold; }
             void set_gdo0_pin(InternalGPIOPin *pin) { gdo0_pin_ = pin; }
+            void set_gdo2_pin(InternalGPIOPin *pin) { gdo2_pin_ = pin; }
 
             // Sensor setters
             void set_volume_sensor(sensor::Sensor *sensor) { volume_sensor_ = sensor; }
@@ -162,8 +163,9 @@ namespace esphome
             void apply_radio_context();
             bool gdo0_error_logged_{false}; // One-shot flag to prevent log flooding
 
-            // GDO0 pin (raw GPIO number for CC1101 Arduino driver)
+            // GDO0 pin (required) and GDO2 pin (optional TX FIFO threshold)
             InternalGPIOPin *gdo0_pin_{nullptr};
+            InternalGPIOPin *gdo2_pin_{nullptr};
 
             // ESPHome components
             time::RealTimeClock *time_component_{nullptr};

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -237,23 +237,24 @@ esp32:
 
 ### Key Parameters
 
-| Parameter            | Type     | Default       | Required | Description                                                           |
-| -------------------- | -------- | ------------- | -------- | --------------------------------------------------------------------- |
-| `meter_code`         | string   | -             | Yes      | Dashed meter code: `YY-SSSSSSS` or `YY-SSSSSSS-NNN` (suffix optional) |
-| `spi_id`             | id       | -             | Yes      | SPI bus ID from the top-level `spi:` block                            |
-| `cs_pin`             | pin      | -             | Yes      | CC1101 chip select pin                                                |
-| `meter_type`         | enum     | water         | No       | `water` or `gas`                                                      |
-| `gdo0_pin`           | pin      | -             | Yes      | CC1101 GDO0 pin (e.g. `GPIO4`, `D2`, `4`)                             |
-| `time_id`            | id       | -             | Yes      | Time component ID                                                     |
-| `frequency`          | float    | 433.82        | No       | RF frequency (MHz)                                                    |
-| `auto_scan`          | bool     | true          | No       | Auto frequency scan                                                   |
-| `schedule`           | enum     | Monday-Friday | No       | Reading schedule                                                      |
-| `read_hour`          | int      | 10            | No       | Read hour (0-23)                                                      |
-| `read_minute`        | int      | 0             | No       | Read minute (0-59)                                                    |
-| `max_retries`        | int      | 10            | No       | Max read attempts                                                     |
-| `retry_cooldown`     | duration | 1h            | No       | Cooldown time                                                         |
-| `gas_volume_divisor` | int      | 100           | No       | Gas divisor (100/1000)                                                |
-| `debug_cc1101`       | bool     | false         | No       | Enable hex dump for debugging                                         |
+| Parameter            | Type     | Default       | Required | Description                                                                                                                                                               |
+| -------------------- | -------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `meter_code`         | string   | -             | Yes      | Dashed meter code: `YY-SSSSSSS` or `YY-SSSSSSS-NNN` (suffix optional)                                                                                                     |
+| `spi_id`             | id       | -             | Yes      | SPI bus ID from the top-level `spi:` block                                                                                                                                |
+| `cs_pin`             | pin      | -             | Yes      | CC1101 chip select pin                                                                                                                                                    |
+| `meter_type`         | enum     | water         | No       | `water` or `gas`                                                                                                                                                          |
+| `gdo0_pin`           | pin      | -             | Yes      | CC1101 GDO0 pin (e.g. `GPIO4`, `D2`, `4`)                                                                                                                                 |
+| `gdo2_pin`           | pin      | (none)        | No       | CC1101 GDO2 pin for hardware TX FIFO threshold. When wired, replaces SPI-polling fallback and eliminates `TXFIFO_UNDERFLOW` under ESPHome load. Leave unset if not wired. |
+| `time_id`            | id       | -             | Yes      | Time component ID                                                                                                                                                         |
+| `frequency`          | float    | 433.82        | No       | RF frequency (MHz)                                                                                                                                                        |
+| `auto_scan`          | bool     | true          | No       | Auto frequency scan                                                                                                                                                       |
+| `schedule`           | enum     | Monday-Friday | No       | Reading schedule                                                                                                                                                          |
+| `read_hour`          | int      | 10            | No       | Read hour (0-23)                                                                                                                                                          |
+| `read_minute`        | int      | 0             | No       | Read minute (0-59)                                                                                                                                                        |
+| `max_retries`        | int      | 10            | No       | Max read attempts                                                                                                                                                         |
+| `retry_cooldown`     | duration | 1h            | No       | Cooldown time                                                                                                                                                             |
+| `gas_volume_divisor` | int      | 100           | No       | Gas divisor (100/1000)                                                                                                                                                    |
+| `debug_cc1101`       | bool     | false         | No       | Enable hex dump for debugging                                                                                                                                             |
 
 ### Schedule Options
 
@@ -339,7 +340,7 @@ Three complete example configurations are provided:
 | MOSI       | D7      | 13   |
 | CSN        | D8      | 15   |
 | GDO0       | D1      | 5    |
-| GDO2       | D2      | 4    |
+| GDO2       | D2      | 4    | ← optional: enables hardware TX FIFO threshold |
 
 ### Wiring (ESP32)
 
@@ -352,9 +353,11 @@ Three complete example configurations are provided:
 | MOSI   | 23    |
 | CSN    | 5     |
 | GDO0   | 4     |
-| GDO2   | 2     |
+| GDO2   | 2     | ← optional: enables hardware TX FIFO threshold |
 
 Important: The CC1101 requires 3.3V power. Do not connect to 5V!
+
+> **GDO2 is optional.** When wired and configured via `gdo2_pin:`, the driver reads GDO2 as a hardware TX FIFO threshold signal, preventing `TXFIFO_UNDERFLOW` errors under ESPHome scheduler load. Without GDO2, the driver falls back to SPI-based TXBYTES polling (original behaviour, still fully functional).
 
 ## Benefits
 

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -331,28 +331,28 @@ Three complete example configurations are provided:
 
 ### Wiring (ESP8266 D1 Mini)
 
-| CC1101 Pin | D1 Mini | GPIO |
-| ---------- | ------- | ---- |
-| VCC        | 3.3V    | -    |
-| GND        | GND     | -    |
-| SCK        | D5      | 14   |
-| MISO       | D6      | 12   |
-| MOSI       | D7      | 13   |
-| CSN        | D8      | 15   |
-| GDO0       | D1      | 5    |
+| CC1101 Pin | D1 Mini | GPIO         |
+| ---------- | ------- | ------------ |
+| VCC        | 3.3V    | -            |
+| GND        | GND     | -            |
+| SCK        | D5      | 14           |
+| MISO       | D6      | 12           |
+| MOSI       | D7      | 13           |
+| CSN        | D8      | 15           |
+| GDO0       | D1      | 5            |
 | GDO2       | D2      | 4 (optional) |
 
 ### Wiring (ESP32)
 
-| CC1101 | ESP32 |
-| ------ | ----- |
-| VCC    | 3.3V  |
-| GND    | GND   |
-| SCK    | 18    |
-| MISO   | 19    |
-| MOSI   | 23    |
-| CSN    | 5     |
-| GDO0   | 4     |
+| CC1101 | ESP32        |
+| ------ | ------------ |
+| VCC    | 3.3V         |
+| GND    | GND          |
+| SCK    | 18           |
+| MISO   | 19           |
+| MOSI   | 23           |
+| CSN    | 5            |
+| GDO0   | 4            |
 | GDO2   | 2 (optional) |
 
 Important: The CC1101 requires 3.3V power. Do not connect to 5V!

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -344,15 +344,15 @@ Three complete example configurations are provided:
 
 ### Wiring (ESP32)
 
-| CC1101 | ESP32        |
-| ------ | ------------ |
-| VCC    | 3.3V         |
-| GND    | GND          |
-| SCK    | 18           |
-| MISO   | 19           |
-| MOSI   | 23           |
-| CSN    | 5            |
-| GDO0   | 4            |
+| CC1101 | ESP32         |
+| ------ | ------------- |
+| VCC    | 3.3V          |
+| GND    | GND           |
+| SCK    | 18            |
+| MISO   | 19            |
+| MOSI   | 23            |
+| CSN    | 5             |
+| GDO0   | 4             |
 | GDO2   | 27 (optional) |
 
 Important: The CC1101 requires 3.3V power. Do not connect to 5V!

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -353,7 +353,7 @@ Three complete example configurations are provided:
 | MOSI   | 23           |
 | CSN    | 5            |
 | GDO0   | 4            |
-| GDO2   | 2 (optional) |
+| GDO2   | 27 (optional) |
 
 Important: The CC1101 requires 3.3V power. Do not connect to 5V!
 

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -340,7 +340,7 @@ Three complete example configurations are provided:
 | MOSI       | D7      | 13   |
 | CSN        | D8      | 15   |
 | GDO0       | D1      | 5    |
-| GDO2       | D2      | 4    | ← optional: enables hardware TX FIFO threshold |
+| GDO2       | D2      | 4 (optional) |
 
 ### Wiring (ESP32)
 
@@ -353,7 +353,7 @@ Three complete example configurations are provided:
 | MOSI   | 23    |
 | CSN    | 5     |
 | GDO0   | 4     |
-| GDO2   | 2     | ← optional: enables hardware TX FIFO threshold |
+| GDO2   | 2 (optional) |
 
 Important: The CC1101 requires 3.3V power. Do not connect to 5V!
 

--- a/ESPHOME/components/everblu_meter/__init__.py
+++ b/ESPHOME/components/everblu_meter/__init__.py
@@ -94,6 +94,7 @@ SCHEDULE_MONDAY_SATURDAY = "Monday-Saturday"
 SCHEDULE_MONDAY_SUNDAY = "Monday-Sunday"
 
 CONF_GDO0_PIN = "gdo0_pin"
+CONF_GDO2_PIN = "gdo2_pin"
 
 
 def validate_meter_code(value):
@@ -161,6 +162,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(EverbluMeterComponent),
             cv.Required(CONF_METER_CODE): validate_meter_code,
             cv.Required(CONF_GDO0_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Optional(CONF_GDO2_PIN): pins.internal_gpio_input_pin_schema,
             cv.Required(CONF_TIME_ID): cv.use_id(time_.RealTimeClock),
             cv.Optional(CONF_METER_TYPE, default=METER_TYPE_WATER): cv.enum(
                 {METER_TYPE_WATER: False, METER_TYPE_GAS: True}
@@ -339,6 +341,10 @@ async def to_code(config):
     # CS pin is managed by SPIDevice; pass the InternalGPIOPin for CC1101 interrupts.
     gdo0 = await cg.gpio_pin_expression(config[CONF_GDO0_PIN])
     cg.add(var.set_gdo0_pin(gdo0))
+
+    if CONF_GDO2_PIN in config:
+        gdo2 = await cg.gpio_pin_expression(config[CONF_GDO2_PIN])
+        cg.add(var.set_gdo2_pin(gdo2))
 
     # No custom include paths needed when using flat release layout
 

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -342,6 +342,17 @@ namespace esphome
                     gdo0_error_logged_ = true;
                 }
             }
+
+            // GDO2 is optional: when wired and configured, it drives hardware-assisted
+            // TX FIFO threshold detection instead of SPI TXBYTES polling.
+            if (gdo2_pin_ != nullptr)
+            {
+                cc1101_set_gdo2_pin(gdo2_pin_->get_pin());
+            }
+            else
+            {
+                cc1101_set_gdo2_pin(-1); // Ensure fallback mode on re-entry
+            }
         }
 
         void EverbluMeterComponent::update()
@@ -370,6 +381,8 @@ namespace esphome
             ESP_LOGCONFIG(TAG, "  Max Retries: %d", max_retries_);
             ESP_LOGCONFIG(TAG, "  Retry Cooldown: %lu ms", retry_cooldown_ms_);
             ESP_LOGCONFIG(TAG, "  Initial Read On Boot: %s", initial_read_on_boot_ ? "Enabled" : "Disabled");
+            ESP_LOGCONFIG(TAG, "  GDO0 Pin: %s", gdo0_pin_ != nullptr ? "configured" : "NOT configured (error)");
+            ESP_LOGCONFIG(TAG, "  GDO2 Pin: %s", gdo2_pin_ != nullptr ? "configured (HW TX FIFO threshold)" : "not wired (SPI polling fallback)");
 
             ESP_LOGCONFIG(TAG, "  Sensors:");
             LOG_SENSOR("    ", "Volume", volume_sensor_);

--- a/ESPHOME/components/everblu_meter/everblu_meter.h
+++ b/ESPHOME/components/everblu_meter/everblu_meter.h
@@ -101,6 +101,7 @@ namespace esphome
             void set_initial_read_on_boot(bool v) { initial_read_on_boot_ = v; }
             void set_adaptive_threshold(int threshold) { adaptive_threshold_ = threshold; }
             void set_gdo0_pin(InternalGPIOPin *pin) { gdo0_pin_ = pin; }
+            void set_gdo2_pin(InternalGPIOPin *pin) { gdo2_pin_ = pin; }
 
             // Sensor setters
             void set_volume_sensor(sensor::Sensor *sensor) { volume_sensor_ = sensor; }
@@ -162,8 +163,9 @@ namespace esphome
             void apply_radio_context();
             bool gdo0_error_logged_{false}; // One-shot flag to prevent log flooding
 
-            // GDO0 pin (raw GPIO number for CC1101 Arduino driver)
+            // GDO0 pin (required) and GDO2 pin (optional TX FIFO threshold)
             InternalGPIOPin *gdo0_pin_{nullptr};
+            InternalGPIOPin *gdo2_pin_{nullptr};
 
             // ESPHome components
             time::RealTimeClock *time_component_{nullptr};

--- a/ESPHOME/example-advanced.yaml
+++ b/ESPHOME/example-advanced.yaml
@@ -81,6 +81,7 @@ everblu_meter:
   cs_pin: GPIO5
   gdo0_pin: 4
   # gdo2_pin: 12          # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+                          # Use any free GPIO (not SPI pins: avoid GPIO18/CLK, GPIO19/MISO, GPIO23/MOSI)
                           # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   meter_type: water
   

--- a/ESPHOME/example-advanced.yaml
+++ b/ESPHOME/example-advanced.yaml
@@ -80,8 +80,9 @@ everblu_meter:
   meter_code: "23-1234567-800"  # Replace with your meter's code
   cs_pin: GPIO5
   gdo0_pin: 4
-  # gdo2_pin: 12          # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+  # gdo2_pin: 27          # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
                           # Use any free GPIO (not SPI pins: avoid GPIO18/CLK, GPIO19/MISO, GPIO23/MOSI)
+                          # (not strapping pins: avoid GPIO0, GPIO2, GPIO12; GPIO27 is safe)
                           # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   meter_type: water
   

--- a/ESPHOME/example-advanced.yaml
+++ b/ESPHOME/example-advanced.yaml
@@ -80,6 +80,8 @@ everblu_meter:
   meter_code: "23-1234567-800"  # Replace with your meter's code
   cs_pin: GPIO5
   gdo0_pin: 4
+  # gdo2_pin: 12          # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+                          # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   meter_type: water
   
   # Radio configuration - custom frequency

--- a/ESPHOME/example-gas-meter-minimal.yaml
+++ b/ESPHOME/example-gas-meter-minimal.yaml
@@ -58,6 +58,8 @@ everblu_meter:
   meter_code: "22-8765432-100"  # Replace with your meter's code
   cs_pin: GPIO15
   gdo0_pin: 4
+  # gdo2_pin: 12          # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+                          # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   
   # REQUIRED: Meter type
   meter_type: gas

--- a/ESPHOME/example-gas-meter-minimal.yaml
+++ b/ESPHOME/example-gas-meter-minimal.yaml
@@ -58,7 +58,8 @@ everblu_meter:
   meter_code: "22-8765432-100"  # Replace with your meter's code
   cs_pin: GPIO15
   gdo0_pin: 4
-  # gdo2_pin: 12          # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+  # gdo2_pin: 5           # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+                          # Use GPIO5 (D1) — free GPIO when GDO0 uses GPIO4 (D2). Do NOT use GPIO12 (MISO)
                           # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   
   # REQUIRED: Meter type

--- a/ESPHOME/example-gas-meter-minimal.yaml
+++ b/ESPHOME/example-gas-meter-minimal.yaml
@@ -59,7 +59,7 @@ everblu_meter:
   cs_pin: GPIO15
   gdo0_pin: 4
   # gdo2_pin: 5           # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
-                          # Use GPIO5 (D1) — free GPIO when GDO0 uses GPIO4 (D2). Do NOT use GPIO12 (MISO)
+                          # Use GPIO5 (D1) — free GPIO when GDO0 uses GPIO4 (D2). Do NOT use GPIO12 (MISO), GPIO13 (MOSI), GPIO14 (SCK)
                           # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   
   # REQUIRED: Meter type

--- a/ESPHOME/example-multi-meter.yaml
+++ b/ESPHOME/example-multi-meter.yaml
@@ -66,7 +66,9 @@ everblu_meter:
     gdo0_pin:
       number: ${cc1101_gdo0}
       allow_other_uses: true
-    # gdo2_pin: GPIO12      # Optional: hardware TX FIFO threshold (prevents TXFIFO_UNDERFLOW)
+    # gdo2_pin:              # Optional: hardware TX FIFO threshold (prevents TXFIFO_UNDERFLOW)
+    #   number: GPIO4        # D2 — free GPIO (not SPI: avoid GPIO12/MISO, GPIO13/MOSI, GPIO14/SCK)
+    #   allow_other_uses: true  # Required — both meter entries share the same CC1101
     time_id: homeassistant_time
     timezone_offset: ${tz_offset_min}
     read_hour: 11
@@ -150,7 +152,9 @@ everblu_meter:
     gdo0_pin:
       number: ${cc1101_gdo0}
       allow_other_uses: true
-    # gdo2_pin: GPIO12      # Optional: hardware TX FIFO threshold (prevents TXFIFO_UNDERFLOW)
+    # gdo2_pin:              # Optional: hardware TX FIFO threshold (prevents TXFIFO_UNDERFLOW)
+    #   number: GPIO4        # D2 — free GPIO (not SPI: avoid GPIO12/MISO, GPIO13/MOSI, GPIO14/SCK)
+    #   allow_other_uses: true  # Required — both meter entries share the same CC1101
     time_id: homeassistant_time
     timezone_offset: ${tz_offset_min}
     read_hour: 11

--- a/ESPHOME/example-multi-meter.yaml
+++ b/ESPHOME/example-multi-meter.yaml
@@ -66,6 +66,7 @@ everblu_meter:
     gdo0_pin:
       number: ${cc1101_gdo0}
       allow_other_uses: true
+    # gdo2_pin: GPIO12      # Optional: hardware TX FIFO threshold (prevents TXFIFO_UNDERFLOW)
     time_id: homeassistant_time
     timezone_offset: ${tz_offset_min}
     read_hour: 11
@@ -149,6 +150,7 @@ everblu_meter:
     gdo0_pin:
       number: ${cc1101_gdo0}
       allow_other_uses: true
+    # gdo2_pin: GPIO12      # Optional: hardware TX FIFO threshold (prevents TXFIFO_UNDERFLOW)
     time_id: homeassistant_time
     timezone_offset: ${tz_offset_min}
     read_hour: 11

--- a/ESPHOME/example-nano-esp32.yaml
+++ b/ESPHOME/example-nano-esp32.yaml
@@ -78,6 +78,8 @@ everblu_meter:
   meter_code: "21-1234567-800"  # Replace with your meter's code
   cs_pin: GPIO21          # Nano ESP32 D10 -> CC1101 CS / NSS
   gdo0_pin: GPIO5         # Nano ESP32 D2 -> CC1101 GDO0
+  # gdo2_pin: GPIO12      # Optional: Nano ESP32 D6 -> CC1101 GDO2 (hardware TX FIFO threshold)
+                          # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   
   # Optional: set meter_type to 'gas' for gas meters (defaults to water)
   

--- a/ESPHOME/example-water-meter.yaml
+++ b/ESPHOME/example-water-meter.yaml
@@ -63,7 +63,8 @@ everblu_meter:
   meter_code: "21-1234567-800"  # Replace with your meter's code
   cs_pin: GPIO15          # CC1101 CS / NSS on ESP8266 Huzzah GPIO15
   gdo0_pin: GPIO5         # GPIO connected to CC1101 GDO0 on ESP8266 Huzzah GPIO5 (D1)
-  # gdo2_pin: GPIO12      # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+  # gdo2_pin: GPIO4       # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+                          # Use GPIO4 (D2) — free GPIO. Do NOT use GPIO12 (D6/MISO), GPIO13 (D7/MOSI), GPIO14 (D5/SCK)
                           # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   
   # Optional: set meter_type to 'gas' for gas meters (defaults to water)

--- a/ESPHOME/example-water-meter.yaml
+++ b/ESPHOME/example-water-meter.yaml
@@ -63,6 +63,8 @@ everblu_meter:
   meter_code: "21-1234567-800"  # Replace with your meter's code
   cs_pin: GPIO15          # CC1101 CS / NSS on ESP8266 Huzzah GPIO15
   gdo0_pin: GPIO5         # GPIO connected to CC1101 GDO0 on ESP8266 Huzzah GPIO5 (D1)
+  # gdo2_pin: GPIO12      # Optional: wire CC1101 GDO2 here for hardware TX FIFO threshold
+                          # (prevents TXFIFO_UNDERFLOW; leave unset to use SPI polling fallback)
   
   # Optional: set meter_type to 'gas' for gas meters (defaults to water)
   

--- a/docs/GDO2_FIFO_MANAGEMENT.md
+++ b/docs/GDO2_FIFO_MANAGEMENT.md
@@ -1,17 +1,25 @@
 # GDO2 as CC1101 FIFO Threshold Signal
 
-**Implements:** GitHub Issues [#83](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/83) / [#84](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/84)  
-**Integration target:** Both (ESPHome + MQTT)  
-**Branch:** `feature/gdo2-fifo-threshold`
+|                        |                                                                                                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Issue**              | [#83](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/83) (TX FIFO — implemented) · [#84](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/84) (RX FIFO + dynamic reconfiguration — future work) |
+| **Integration target** | Both (ESPHome + MQTT)                                                                                                                                                                                                                       |
+| **Implemented in**     | `feature/gdo2-fifo-threshold` (Part 1 only)                                                                                                                                                                                                 |
+| **Future work branch** | New branch off `main` after this merges (Parts 2 & 3)                                                                                                                                                                                       |
 
 GDO2 is currently configured as async serial data output (`IOCFG2 = 0x0D`) and left physically
 unconnected. This document describes how wiring GDO2 to a free MCU GPIO and reconfiguring it as
 a FIFO threshold signal improves both TX FIFO feeding (preventing underflows) and RX FIFO draining
 (reducing unnecessary SPI traffic and improving ESPHome task scheduling).
 
+> **Status summary**
+> - **Part 1 (TX FIFO threshold)** — ✅ implemented in `feature/gdo2-fifo-threshold`
+> - **Part 2 (RX FIFO threshold)** — ⏳ future work, tracked in issue [#84](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/84)
+> - **Part 3 (dynamic IOCFG2 reconfiguration)** — ⏳ future work, tracked in issue [#84](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/84)
+
 ---
 
-## Part 1 — TX FIFO Threshold
+## Part 1 — TX FIFO Threshold ✅ Implemented
 
 ### Problem
 
@@ -54,19 +62,19 @@ if (GET_GDO2_PIN() >= 0) {
 }
 ```
 
-| | Current | With GDO2 TX |
-|---|---|---|
-| Refill trigger | SPI read of `TXBYTES` (stale status byte) | `digitalRead()` — real-time, ~1 µs |
-| Refill timing | Fixed `delay(20)` heuristic | Event-driven: fires the moment threshold crosses |
-| Underflow detection | Reactive: poll `MARCSTATE == 0x16` after the fact | Proactive: refill fires before FIFO empties |
-| Interrogation frame gate | Dedicated SPI poll loop (`TXBYTES ≤ 25`) | Same `digitalRead(GDO2) == LOW` if FIFOTHR adjusted |
+|                          | Current                                           | With GDO2 TX                                        |
+| ------------------------ | ------------------------------------------------- | --------------------------------------------------- |
+| Refill trigger           | SPI read of `TXBYTES` (stale status byte)         | `digitalRead()` — real-time, ~1 µs                  |
+| Refill timing            | Fixed `delay(20)` heuristic                       | Event-driven: fires the moment threshold crosses    |
+| Underflow detection      | Reactive: poll `MARCSTATE == 0x16` after the fact | Proactive: refill fires before FIFO empties         |
+| Interrogation frame gate | Dedicated SPI poll loop (`TXBYTES ≤ 25`)          | Same `digitalRead(GDO2) == LOW` if FIFOTHR adjusted |
 
 ### FIFOTHR adjustment
 
-| `FIFO_THR` | `FIFOTHR` | TX threshold | Free bytes at de-assert | Covers 39-byte frame? |
-|---|---|---|---|---|
-| 7 (previous default) | `0x47` | 33 bytes | ≥ 32 | No |
-| 9 (implemented) | `0x49` | 25 bytes | ≥ 40 | Yes |
+| `FIFO_THR`           | `FIFOTHR` | TX threshold | Free bytes at de-assert | Covers 39-byte frame? |
+| -------------------- | --------- | ------------ | ----------------------- | --------------------- |
+| 7 (previous default) | `0x47`    | 33 bytes     | ≥ 32                    | No                    |
+| 9 (implemented)      | `0x49`    | 25 bytes     | ≥ 40                    | Yes                   |
 
 Changing `FIFO_THR` from 7 to 9 shifts the TX threshold from 33 → 25 bytes. When GDO2
 de-asserts, the FIFO has fewer than 25 bytes remaining, guaranteeing at least 40 free bytes —
@@ -83,7 +91,7 @@ threshold signal.
 
 ---
 
-## Part 2 — RX FIFO Threshold
+## Part 2 — RX FIFO Threshold ⏳ Future work
 
 ### Current RX loop behaviour
 
@@ -118,9 +126,9 @@ enhancement is lower priority.
 
 ### IOCFG2 signal choices for RX
 
-| Value | Behaviour |
-|---|---|
-| `0x00` | HIGH when RX FIFO ≥ threshold; LOW only when FIFO reaches **0** |
+| Value  | Behaviour                                                                         |
+| ------ | --------------------------------------------------------------------------------- |
+| `0x00` | HIGH when RX FIFO ≥ threshold; LOW only when FIFO reaches **0**                   |
 | `0x01` | Same as `0x00`, **plus** asserts at end-of-packet even if FIFO is below threshold |
 
 Signal `0x01` is the correct choice. It handles two cases that threshold-only cannot:
@@ -158,16 +166,16 @@ while (digitalRead(GET_GDO0_PIN()) == TRUE) {
 The shift is from **"poll every 2 ms"** to **"yield until GDO2 says there is work, then drain
 in one burst"**.
 
-| | Current | With GDO2 RX |
-|---|---|---|
-| SPI reads during empty FIFO | Every 2 ms regardless | Zero — `yield()` until GDO2 fires |
-| ESPHome task scheduling | Blocked 2 ms per poll iteration | Proper `yield()` between batches |
-| Final sub-threshold drain | Collected on next 2 ms poll after GDO0 LOW | Guaranteed by EOP assertion of `0x01` |
-| Overflow protection | `RXBYTES` bit-7 check after the fact | Unchanged — still the safety net |
+|                             | Current                                    | With GDO2 RX                          |
+| --------------------------- | ------------------------------------------ | ------------------------------------- |
+| SPI reads during empty FIFO | Every 2 ms regardless                      | Zero — `yield()` until GDO2 fires     |
+| ESPHome task scheduling     | Blocked 2 ms per poll iteration            | Proper `yield()` between batches      |
+| Final sub-threshold drain   | Collected on next 2 ms poll after GDO0 LOW | Guaranteed by EOP assertion of `0x01` |
+| Overflow protection         | `RXBYTES` bit-7 check after the fact       | Unchanged — still the safety net      |
 
 ---
 
-## Part 3 — Dynamic GDO2 Reconfiguration
+## Part 3 — Dynamic GDO2 Reconfiguration ⏳ Future work
 
 The firmware already reconfigures `MDMCFG2` and `PKTCTRL0` between TX and RX phases. GDO2 follows
 the same pattern — one extra register write per phase transition:
@@ -209,17 +217,17 @@ if (GET_GDO2_PIN() >= 0) {
 
 ### Files affected
 
-| File | Change |
-|---|---|
-| `src/core/cc1101.cpp` | New `IOCFG2_TX_FIFO_THR`/`IOCFG2_RX_FIFO_THR_EOP` defines; `_gdo2_pin` var + `cc1101_set_gdo2_pin()`; update `cc1101_configureRF_0()`; update TX and RX loops |
-| `src/core/cc1101.h` | Expose `cc1101_set_gdo2_pin()` |
-| `include/private.example.h` | Add `GDO2` with wiring note |
-| `src/main.cpp` | Report GDO2 pin status in startup validation |
-| `ESPHOME/components/everblu_meter/__init__.py` | Add optional `gdo2_pin` config key |
-| `ESPHOME/components/everblu_meter/everblu_meter.h` | `set_gdo2_pin()` setter + `gdo2_pin_` member |
-| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | Call `cc1101_set_gdo2_pin()` in `apply_radio_context()`; log in `dump_config()` |
-| `ESPHOME/example-*.yaml` | Document optional `gdo2_pin:` parameter |
-| `ESPHOME-release/` | Regenerated via `prepare-component-release.ps1` |
+| File                                                 | Change                                                                                                                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/core/cc1101.cpp`                                | New `IOCFG2_TX_FIFO_THR`/`IOCFG2_RX_FIFO_THR_EOP` defines; `_gdo2_pin` var + `cc1101_set_gdo2_pin()`; update `cc1101_configureRF_0()`; update TX and RX loops |
+| `src/core/cc1101.h`                                  | Expose `cc1101_set_gdo2_pin()`                                                                                                                                |
+| `include/private.example.h`                          | Add `GDO2` with wiring note                                                                                                                                   |
+| `src/main.cpp`                                       | Report GDO2 pin status in startup validation                                                                                                                  |
+| `ESPHOME/components/everblu_meter/__init__.py`       | Add optional `gdo2_pin` config key                                                                                                                            |
+| `ESPHOME/components/everblu_meter/everblu_meter.h`   | `set_gdo2_pin()` setter + `gdo2_pin_` member                                                                                                                  |
+| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | Call `cc1101_set_gdo2_pin()` in `apply_radio_context()`; log in `dump_config()`                                                                               |
+| `ESPHOME/example-*.yaml`                             | Document optional `gdo2_pin:` parameter                                                                                                                       |
+| `ESPHOME-release/`                                   | Regenerated via `prepare-component-release.ps1`                                                                                                               |
 
 ### Not in scope
 
@@ -234,215 +242,3 @@ if (GET_GDO2_PIN() >= 0) {
   existing `TXBYTES` poll loop.
 - Use the existing `TXBYTES` poll loop with a tighter threshold and shorter delay — rejected
   because it still depends on `delay()` which is unreliable under ESPHome scheduler load.
-
-
----
-
-## Background: The TXFIFO_UNDERFLOW Problem
-
-When communicating with an EverBlu Cyble meter, the firmware transmits a sequence of frames into the CC1101's 64-byte TX FIFO:
-
-1. Multiple 8-byte **Wake-Up Packets (WUP)** — repeated ~25 times to wake the meter
-2. One 39-byte **interrogation frame** — requests the meter reading
-
-The CC1101 continuously drains the TX FIFO at the configured data rate (2.4 kbps for the RADIAN protocol). The firmware must refill the FIFO fast enough to avoid emptying it completely, which causes an irreversible **TXFIFO_UNDERFLOW** state (`MARCSTATE = 0x16`) that silently discards all further TX data.
-
-### Why the Original SPI Polling Approach Fails Under ESPHome
-
-The original code polled the TX FIFO level by reading the `TXBYTES` register over SPI:
-
-```cpp
-// Original approach — unreliable under ESPHome scheduler
-if (CC1101_status_FIFO_FreeByte <= 10) {
-    delay(20);  // Wait for FIFO to drain a bit
-}
-```
-
-Two compounding problems:
-
-| Problem                                                                                                          | Effect                                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `CC1101_status_FIFO_FreeByte` is the **status byte from the previous SPI transaction**, not a fresh TXBYTES read | Stale data; does not reflect current FIFO level                                                                                       |
-| `delay(20)` in ESPHome yields to the ESP-IDF/FreeRTOS scheduler                                                  | WiFi, mDNS, OTA, API tasks can stall it for **10–80 ms** — far exceeding the time to drain a 64-byte FIFO at 2.4 kbps (≈213 ms total) |
-
-The result: the FIFO empties mid-transmission, CC1101 enters `TXFIFO_UNDERFLOW`, and the meter never receives a valid wake sequence.
-
----
-
-## Part 1: GDO2 as Hardware TX FIFO Threshold Signal
-
-### How GDO2 Works
-
-The CC1101 `GDO2` output pin is configurable via register `IOCFG2`. Setting `IOCFG2 = 0x02` configures GDO2 as:
-
-> **TX FIFO at or above threshold → GDO2 asserts HIGH**  
-> **TX FIFO below threshold → GDO2 de-asserts LOW**
-
-This is a hardware signal, updated by the CC1101's internal logic on every byte drained — no SPI transaction required to read it.
-
-```
-digitalRead(GDO2)   ~1 µs  (GPIO register read)
-halRfReadReg(TXBYTES)  ~10 µs  (SPI: CS assert + 2 bytes + CS de-assert)
-```
-
-More importantly, `digitalRead()` is immune to ESP scheduler stalls — it reads a hardware register synchronously.
-
-### FIFOTHR Register Selection
-
-The `FIFOTHR` register (address `0x03`) controls both the TX and RX threshold levels. The key insight is that when GDO2 **de-asserts** (FIFO falls below threshold), the number of **free** bytes in the FIFO is:
-
-```
-free_bytes = 64 - TX_threshold
-```
-
-For reliable single-check operation:
-- **8-byte WUP buffer**: needs 8 free bytes
-- **39-byte interrogation frame**: needs 39 free bytes
-
-We need `64 - TX_threshold ≥ 39`, so `TX_threshold ≤ 25`.
-
-| `FIFOTHR` value     | TX threshold | Free bytes on de-assert | Notes                          |
-| ------------------- | ------------ | ----------------------- | ------------------------------ |
-| `0x47` (FIFO_THR=7) | 33 bytes     | 32 bytes                | ❌ Not enough for 39-byte frame |
-| `0x49` (FIFO_THR=9) | 25 bytes     | **40 bytes**            | ✅ Fits WUP (8) and frame (39)  |
-
-**Setting used:** `FIFOTHR = 0x49`
-
-> **Note:** This shifts the RX FIFO threshold from 33 bytes to 40 bytes, but this has no functional impact since the RX loop uses `GDO0` (sync-word detect) plus `RXBYTES` polling, not the FIFO threshold signal.
-
-### WUP Feeding Loop (TX Phase)
-
-```cpp
-// GDO2 path: hardware signal — immune to scheduler stalls
-if (GET_GDO2_PIN() >= 0) {
-    if (digitalRead(GET_GDO2_PIN()) == LOW) {
-        // FIFO < 25 bytes → ≥40 free bytes guaranteed → safe to write 8-byte WUP
-        SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
-        wup2send--;
-    }
-    // else: FIFO still above threshold — skip write this iteration
-} else {
-    // Fallback: stale FreeByte check + delay(20) (original behaviour)
-    if (CC1101_status_FIFO_FreeByte <= 10) {
-        delay(20);
-    }
-    SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
-    wup2send--;
-}
-```
-
-### Interrogation Frame Wait (TX Phase)
-
-```cpp
-if (GET_GDO2_PIN() >= 0) {
-    // Wait until GDO2 goes LOW (FIFO < 25 bytes → ≥40 free bytes → fits 39-byte frame)
-    int wait_count = 0;
-    while (digitalRead(GET_GDO2_PIN()) == HIGH && wait_count < 100) { // safety ~500ms
-        delay(5);
-        wait_count++;
-    }
-    // Final underflow guard before writing
-    uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
-    if (txbytes_reg & 0x80) break; // Overflow flag set — abort
-    SPIWriteBurstReg(TX_FIFO_ADDR, buffer, length);
-} else {
-    // Fallback: TXBYTES SPI poll (original behaviour)
-    while (halRfReadReg(TXBYTES_ADDR) > 25) { delay(5); }
-    SPIWriteBurstReg(TX_FIFO_ADDR, buffer, length);
-}
-```
-
----
-
-## Part 2: RX FIFO Threshold (Future Work)
-
-The RX FIFO overflow risk is lower in priority:
-
-- The EverBlu meter response is ≈200 bytes at 2.4 kbps → takes ≈667 ms to arrive
-- The 64-byte RX FIFO takes ≈213 ms to fill
-- The RX loop calls `delay(2)` between reads, yielding to the scheduler
-
-A future enhancement (separate issue) could reconfigure `IOCFG2 = 0x01` (RX FIFO at/above threshold **or** end-of-packet) during the RX phase to trigger `yield()` more precisely. This would require dynamic IOCFG2 reconfiguration between TX and RX phases.
-
----
-
-## Part 3: Dynamic IOCFG2 Reconfiguration (Future Work)
-
-The current implementation configures `IOCFG2 = 0x02` (TX FIFO threshold) permanently at init time. A more sophisticated approach would be:
-
-1. **TX phase**: `IOCFG2 = 0x02` (TX FIFO threshold, current implementation)
-2. **RX phase**: `IOCFG2 = 0x01` (RX FIFO at/above threshold OR end-of-packet)
-
-This would allow GDO2 to serve double duty — but requires a single SPI write at the TX→RX transition and careful handling of the GDO2 signal polarity change.
-
----
-
-## Part 4: Implementation Scope
-
-| File                                                 | Change                                                                                                         | Scope                 |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `src/core/cc1101.cpp`                                | IOCFG2 = TX_FIFO_THR; FIFOTHR = 0x49; GDO2 pin variable/setter/macro; init pinMode; TX WUP loop; TX frame wait | Both (MQTT + ESPHome) |
-| `src/core/cc1101.h`                                  | `cc1101_set_gdo2_pin()` declaration                                                                            | ESPHome only          |
-| `include/private.example.h`                          | Optional `#define GDO2 <pin>`                                                                                  | MQTT/PlatformIO only  |
-| `src/main.cpp`                                       | GDO2 pin reporting in startup validation                                                                       | MQTT/PlatformIO only  |
-| `ESPHOME/components/everblu_meter/everblu_meter.h`   | `set_gdo2_pin()` setter + `gdo2_pin_` member                                                                   | ESPHome only          |
-| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | `apply_radio_context()` + `dump_config()`                                                                      | ESPHome only          |
-| `ESPHOME/components/everblu_meter/__init__.py`       | `CONF_GDO2_PIN`, optional schema entry, `to_code()`                                                            | ESPHome only          |
-| `ESPHOME/example-*.yaml`                             | Commented `gdo2_pin:` entries                                                                                  | ESPHome examples      |
-| `ESPHOME-release/`                                   | Regenerated via `prepare-component-release.ps1`                                                                | Generated output      |
-
-### Backward Compatibility
-
-GDO2 is **entirely optional**:
-
-- `GET_GDO2_PIN()` returns `-1` when not wired/defined
-- Every GDO2 code path is guarded by `if (GET_GDO2_PIN() >= 0)`
-- All existing users with no GDO2 wiring get exactly the previous behaviour
-
-### Non-ESPHome (MQTT/PlatformIO) Usage
-
-Add to `include/private.h` (see `private.example.h` for template):
-
-```cpp
-// Optional: wire CC1101 GDO2 to a free GPIO
-#define GDO2 12  // D6 on D1 Mini
-```
-
-### ESPHome Usage
-
-Add to your YAML configuration:
-
-```yaml
-everblu_meter:
-  spi_id: main_bus
-  cs_pin: GPIO15
-  gdo0_pin: GPIO5
-  gdo2_pin: GPIO4    # optional — wire CC1101 GDO2 here
-  meter_code: "21-1234567-000"
-  time_id: ha_time
-```
-
----
-
-## Verification
-
-Build with PlatformIO (`huzzah` environment):
-
-```bash
-pio run --environment huzzah
-```
-
-At boot (MQTT mode), with `#define GDO2 12`:
-```
-✓ GDO2 Pin: GPIO 12 (TX FIFO threshold - hardware-assisted underflow prevention)
-```
-
-At boot (ESPHome mode, `dump_config`):
-```
-[everblu_meter]   GDO2 Pin: configured (HW TX FIFO threshold)
-```
-
-Without GDO2 wired:
-```
-[everblu_meter]   GDO2 Pin: not wired (SPI polling fallback)
-```

--- a/docs/GDO2_FIFO_MANAGEMENT.md
+++ b/docs/GDO2_FIFO_MANAGEMENT.md
@@ -1,7 +1,240 @@
-# GDO2 Hardware TX FIFO Threshold Management
+# GDO2 as CC1101 FIFO Threshold Signal
 
-**Implements:** GitHub Issue #83 — Hardware-accelerated FIFO management to eliminate `TXFIFO_UNDERFLOW` errors  
+**Implements:** GitHub Issues [#83](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/83) / [#84](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/84)  
+**Integration target:** Both (ESPHome + MQTT)  
 **Branch:** `feature/gdo2-fifo-threshold`
+
+GDO2 is currently configured as async serial data output (`IOCFG2 = 0x0D`) and left physically
+unconnected. This document describes how wiring GDO2 to a free MCU GPIO and reconfiguring it as
+a FIFO threshold signal improves both TX FIFO feeding (preventing underflows) and RX FIFO draining
+(reducing unnecessary SPI traffic and improving ESPHome task scheduling).
+
+---
+
+## Part 1 — TX FIFO Threshold
+
+### Problem
+
+The TX FIFO refill loop in `cc1101_send_and_listen()` is driven by polling the `TXBYTES` status
+register over SPI and a fixed `delay(20)` heuristic:
+
+```cpp
+// src/core/cc1101.cpp ~L1567
+if (CC1101_status_FIFO_FreeByte <= 10) {
+    delay(20);
+}
+SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+```
+
+Two weaknesses:
+
+1. **Stale FIFO level.** `CC1101_status_FIFO_FreeByte` is extracted from the SPI status byte of
+   the *previous* register write — not a real-time read. The actual FIFO level at the moment of
+   the write can be significantly different.
+
+2. **Fixed delay is unreliable in ESPHome.** `delay()` and `yield()` in ESPHome service background
+   tasks (WiFi stack, API server, OTA, mDNS, web server). These can consume tens to hundreds of
+   milliseconds unpredictably, causing the TX FIFO to drain at 2.4 kbps while the MCU is occupied.
+   This results in `TXFIFO_UNDERFLOW` (MARCSTATE `0x16`). The interrogation frame write has a
+   dedicated TXBYTES poll loop as a partial mitigation, but the WUP feeding loop remains vulnerable.
+
+### Proposed solution
+
+Configure GDO2 as **TX FIFO threshold** (`IOCFG2 = 0x02`): asserts HIGH when TX FIFO ≥ threshold,
+de-asserts LOW when TX FIFO drops below threshold. A `digitalRead(gdo2_pin)` replaces the SPI
+polling in the TX feeding loop:
+
+```cpp
+if (GET_GDO2_PIN() >= 0) {
+    if (digitalRead(GET_GDO2_PIN()) == LOW) {
+        SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8); // threshold crossed → refill immediately
+    }
+} else {
+    // fallback: existing CC1101_status_FIFO_FreeByte + delay(20) path
+}
+```
+
+| | Current | With GDO2 TX |
+|---|---|---|
+| Refill trigger | SPI read of `TXBYTES` (stale status byte) | `digitalRead()` — real-time, ~1 µs |
+| Refill timing | Fixed `delay(20)` heuristic | Event-driven: fires the moment threshold crosses |
+| Underflow detection | Reactive: poll `MARCSTATE == 0x16` after the fact | Proactive: refill fires before FIFO empties |
+| Interrogation frame gate | Dedicated SPI poll loop (`TXBYTES ≤ 25`) | Same `digitalRead(GDO2) == LOW` if FIFOTHR adjusted |
+
+### FIFOTHR adjustment
+
+| `FIFO_THR` | `FIFOTHR` | TX threshold | Free bytes at de-assert | Covers 39-byte frame? |
+|---|---|---|---|---|
+| 7 (previous default) | `0x47` | 33 bytes | ≥ 32 | No |
+| 9 (implemented) | `0x49` | 25 bytes | ≥ 40 | Yes |
+
+Changing `FIFO_THR` from 7 to 9 shifts the TX threshold from 33 → 25 bytes. When GDO2
+de-asserts, the FIFO has fewer than 25 bytes remaining, guaranteeing at least 40 free bytes —
+enough to safely write both the 8-byte WUP buffer *and* the 39-byte interrogation frame using
+the same GDO2 check, eliminating the separate TXBYTES poll loop entirely.
+
+The RX threshold shifts from 33 → 40 bytes as a side effect. This has no functional impact:
+the RX loop is gated by GDO0 (sync word detect) and direct `RXBYTES` polling, not by the FIFO
+threshold signal.
+
+> **Conservative option**: keep `FIFO_THR=7` and use GDO2 only for the WUP loop. Keep the
+> existing `TXBYTES` poll for the interrogation frame gate. This covers ~95% of the underflow
+> risk with no FIFOTHR change.
+
+---
+
+## Part 2 — RX FIFO Threshold
+
+### Current RX loop behaviour
+
+```
+cc1101_wait_for_packet(ms)            // outer: delay(1) per iteration, polls GDO0
+  └─ cc1101_check_packet_received()
+       ├─ if (GDO0 == HIGH)            // sync word detected — packet started
+       └─ while (GDO0 == HIGH)
+              delay(2)                 // blind wait — may be 20ms+ under ESPHome load
+              halRfReadReg(RXBYTES)    // SPI read every iteration regardless of fill level
+              SPIReadBurstReg(...)     // drain whatever is there
+```
+
+Two inefficiencies:
+
+1. **Every `delay(2)` produces an unconditional SPI read.** When the FIFO has 0–1 bytes,
+   `RXBYTES` is still read. At 2.4 kbps that is roughly one SPI transaction per ~0.6 bytes
+   received — most reads bring back `0x00` and do nothing.
+
+2. **`delay(2)` in ESPHome is not 2 ms.** It yields to the scheduler, which can service WiFi,
+   mDNS, the API server, OTA, web_server — any of which may take 10–80 ms. The inner loop fires
+   much less often than intended, and during the *wait* phase the firmware is interrupted every
+   2 ms by an unnecessary SPI poll rather than being able to yield cleanly.
+
+### Why RX overflow is less likely than TX underflow
+
+At 2.4 kbps the meter injects exactly 1 byte every 3.33 ms. The 64-byte RX FIFO takes ~213 ms
+to fill from empty. Even if `delay(2)` balloons to 20 ms, only ~6 bytes arrive per missed drain.
+A typical meter response packet is ≤ 40 bytes — overflow requires missing ~10 consecutive reads in
+a row. Overflow happens, but it is a softer constraint than TX underflow, which is why this
+enhancement is lower priority.
+
+### IOCFG2 signal choices for RX
+
+| Value | Behaviour |
+|---|---|
+| `0x00` | HIGH when RX FIFO ≥ threshold; LOW only when FIFO reaches **0** |
+| `0x01` | Same as `0x00`, **plus** asserts at end-of-packet even if FIFO is below threshold |
+
+Signal `0x01` is the correct choice. It handles two cases that threshold-only cannot:
+
+- **Packet shorter than threshold** (e.g. a 20-byte response with threshold = 33 bytes): GDO2
+  never fires on a threshold crossing, but fires at EOP so the final bytes are still drained.
+- **Sub-threshold remainder at EOP**: after the last threshold crossing, a few bytes below
+  threshold remain when GDO0 goes LOW. GDO2 fires at EOP to collect them regardless.
+
+Signal `0x00` de-asserts only at FIFO-empty, so once HIGH after threshold it stays HIGH during
+draining — useful, but the missing EOP assertion means a short packet could never trigger GDO2
+at all. Signal `0x01` guarantees GDO2 fires at least once per received packet.
+
+### Proposed RX loop with GDO2
+
+```cpp
+while (digitalRead(GET_GDO0_PIN()) == TRUE) {
+    if (GET_GDO2_PIN() >= 0) {
+        if (digitalRead(GET_GDO2_PIN()) == LOW) {
+            yield();   // below threshold — let ESPHome tasks run, no SPI read needed
+            continue;
+        }
+        // GDO2 HIGH: threshold reached or EOP → drain now
+    } else {
+        delay(2);      // fallback: existing blind poll
+    }
+    uint8_t rxbytes_reg = halRfReadReg(RXBYTES_ADDR);
+    if (rxbytes_reg & 0x80) { /* overflow */ break; }
+    l_nb_byte = rxbytes_reg & RXBYTES_MASK;
+    if (l_nb_byte && ...) SPIReadBurstReg(RX_FIFO_ADDR, ...);
+}
+// Post-loop: GDO0 went LOW; EOP already triggered GDO2 for final drain above
+```
+
+The shift is from **"poll every 2 ms"** to **"yield until GDO2 says there is work, then drain
+in one burst"**.
+
+| | Current | With GDO2 RX |
+|---|---|---|
+| SPI reads during empty FIFO | Every 2 ms regardless | Zero — `yield()` until GDO2 fires |
+| ESPHome task scheduling | Blocked 2 ms per poll iteration | Proper `yield()` between batches |
+| Final sub-threshold drain | Collected on next 2 ms poll after GDO0 LOW | Guaranteed by EOP assertion of `0x01` |
+| Overflow protection | `RXBYTES` bit-7 check after the fact | Unchanged — still the safety net |
+
+---
+
+## Part 3 — Dynamic GDO2 Reconfiguration
+
+The firmware already reconfigures `MDMCFG2` and `PKTCTRL0` between TX and RX phases. GDO2 follows
+the same pattern — one extra register write per phase transition:
+
+```cpp
+// New register defines
+#define IOCFG2_TX_FIFO_THR       0x02  // TX FIFO at/above threshold
+#define IOCFG2_RX_FIFO_THR_EOP  0x01  // RX FIFO at/above threshold OR end-of-packet
+
+// Before entering TX
+if (GET_GDO2_PIN() >= 0)
+    halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);
+
+// Before entering RX (cc1101_rec_mode call sites: ~L1262, ~L1346)
+if (GET_GDO2_PIN() >= 0)
+    halRfWriteReg(IOCFG2, IOCFG2_RX_FIFO_THR_EOP);
+```
+
+---
+
+## Part 4 — Implementation Scope
+
+### Hardware prerequisite (user action)
+
+Wire the CC1101 module's **GDO2** pin to any free MCU GPIO. Avoid SPI bus pins, GDO0, and
+UART TX/RX. Declare it as `GDO2` in `private.h` (MQTT build) or `gdo2_pin:` in ESPHome YAML.
+
+### Backward compatibility
+
+`gdo2_pin` defaults to `-1` (not configured). All new code paths are guarded:
+
+```cpp
+if (GET_GDO2_PIN() >= 0) {
+    // GDO2 fast path
+} else {
+    // existing SPI polling fallback — no behaviour change
+}
+```
+
+### Files affected
+
+| File | Change |
+|---|---|
+| `src/core/cc1101.cpp` | New `IOCFG2_TX_FIFO_THR`/`IOCFG2_RX_FIFO_THR_EOP` defines; `_gdo2_pin` var + `cc1101_set_gdo2_pin()`; update `cc1101_configureRF_0()`; update TX and RX loops |
+| `src/core/cc1101.h` | Expose `cc1101_set_gdo2_pin()` |
+| `include/private.example.h` | Add `GDO2` with wiring note |
+| `src/main.cpp` | Report GDO2 pin status in startup validation |
+| `ESPHOME/components/everblu_meter/__init__.py` | Add optional `gdo2_pin` config key |
+| `ESPHOME/components/everblu_meter/everblu_meter.h` | `set_gdo2_pin()` setter + `gdo2_pin_` member |
+| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | Call `cc1101_set_gdo2_pin()` in `apply_radio_context()`; log in `dump_config()` |
+| `ESPHOME/example-*.yaml` | Document optional `gdo2_pin:` parameter |
+| `ESPHOME-release/` | Regenerated via `prepare-component-release.ps1` |
+
+### Not in scope
+
+- Interrupt-driven refill via `attachInterrupt` on GDO2. SPI writes from ISR context are not safe
+  on ESP8266. Polling within the existing TX/RX loops is the correct approach.
+- Temperature sensor mode (GDO0/GDO2 shared with ADC) — irrelevant for this use case.
+
+### Alternatives considered
+
+- Keep `FIFO_THR=7` and gate only the WUP refill on GDO2 (conservative option). Eliminates
+  ~95% of underflow risk without touching FIFOTHR. The interrogation frame gate keeps its
+  existing `TXBYTES` poll loop.
+- Use the existing `TXBYTES` poll loop with a tighter threshold and shorter delay — rejected
+  because it still depends on `delay()` which is unreliable under ESPHome scheduler load.
+
 
 ---
 
@@ -27,10 +260,10 @@ if (CC1101_status_FIFO_FreeByte <= 10) {
 
 Two compounding problems:
 
-| Problem | Effect |
-|---------|--------|
-| `CC1101_status_FIFO_FreeByte` is the **status byte from the previous SPI transaction**, not a fresh TXBYTES read | Stale data; does not reflect current FIFO level |
-| `delay(20)` in ESPHome yields to the ESP-IDF/FreeRTOS scheduler | WiFi, mDNS, OTA, API tasks can stall it for **10–80 ms** — far exceeding the time to drain a 64-byte FIFO at 2.4 kbps (≈213 ms total) |
+| Problem                                                                                                          | Effect                                                                                                                                |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `CC1101_status_FIFO_FreeByte` is the **status byte from the previous SPI transaction**, not a fresh TXBYTES read | Stale data; does not reflect current FIFO level                                                                                       |
+| `delay(20)` in ESPHome yields to the ESP-IDF/FreeRTOS scheduler                                                  | WiFi, mDNS, OTA, API tasks can stall it for **10–80 ms** — far exceeding the time to drain a 64-byte FIFO at 2.4 kbps (≈213 ms total) |
 
 The result: the FIFO empties mid-transmission, CC1101 enters `TXFIFO_UNDERFLOW`, and the meter never receives a valid wake sequence.
 
@@ -68,10 +301,10 @@ For reliable single-check operation:
 
 We need `64 - TX_threshold ≥ 39`, so `TX_threshold ≤ 25`.
 
-| `FIFOTHR` value | TX threshold | Free bytes on de-assert | Notes |
-|-----------------|--------------|-------------------------|-------|
-| `0x47` (FIFO_THR=7) | 33 bytes | 32 bytes | ❌ Not enough for 39-byte frame |
-| `0x49` (FIFO_THR=9) | 25 bytes | **40 bytes** | ✅ Fits WUP (8) and frame (39) |
+| `FIFOTHR` value     | TX threshold | Free bytes on de-assert | Notes                          |
+| ------------------- | ------------ | ----------------------- | ------------------------------ |
+| `0x47` (FIFO_THR=7) | 33 bytes     | 32 bytes                | ❌ Not enough for 39-byte frame |
+| `0x49` (FIFO_THR=9) | 25 bytes     | **40 bytes**            | ✅ Fits WUP (8) and frame (39)  |
 
 **Setting used:** `FIFOTHR = 0x49`
 
@@ -146,17 +379,17 @@ This would allow GDO2 to serve double duty — but requires a single SPI write a
 
 ## Part 4: Implementation Scope
 
-| File | Change | Scope |
-|------|--------|-------|
-| `src/core/cc1101.cpp` | IOCFG2 = TX_FIFO_THR; FIFOTHR = 0x49; GDO2 pin variable/setter/macro; init pinMode; TX WUP loop; TX frame wait | Both (MQTT + ESPHome) |
-| `src/core/cc1101.h` | `cc1101_set_gdo2_pin()` declaration | ESPHome only |
-| `include/private.example.h` | Optional `#define GDO2 <pin>` | MQTT/PlatformIO only |
-| `src/main.cpp` | GDO2 pin reporting in startup validation | MQTT/PlatformIO only |
-| `ESPHOME/components/everblu_meter/everblu_meter.h` | `set_gdo2_pin()` setter + `gdo2_pin_` member | ESPHome only |
-| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | `apply_radio_context()` + `dump_config()` | ESPHome only |
-| `ESPHOME/components/everblu_meter/__init__.py` | `CONF_GDO2_PIN`, optional schema entry, `to_code()` | ESPHome only |
-| `ESPHOME/example-*.yaml` | Commented `gdo2_pin:` entries | ESPHome examples |
-| `ESPHOME-release/` | Regenerated via `prepare-component-release.ps1` | Generated output |
+| File                                                 | Change                                                                                                         | Scope                 |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `src/core/cc1101.cpp`                                | IOCFG2 = TX_FIFO_THR; FIFOTHR = 0x49; GDO2 pin variable/setter/macro; init pinMode; TX WUP loop; TX frame wait | Both (MQTT + ESPHome) |
+| `src/core/cc1101.h`                                  | `cc1101_set_gdo2_pin()` declaration                                                                            | ESPHome only          |
+| `include/private.example.h`                          | Optional `#define GDO2 <pin>`                                                                                  | MQTT/PlatformIO only  |
+| `src/main.cpp`                                       | GDO2 pin reporting in startup validation                                                                       | MQTT/PlatformIO only  |
+| `ESPHOME/components/everblu_meter/everblu_meter.h`   | `set_gdo2_pin()` setter + `gdo2_pin_` member                                                                   | ESPHome only          |
+| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | `apply_radio_context()` + `dump_config()`                                                                      | ESPHome only          |
+| `ESPHOME/components/everblu_meter/__init__.py`       | `CONF_GDO2_PIN`, optional schema entry, `to_code()`                                                            | ESPHome only          |
+| `ESPHOME/example-*.yaml`                             | Commented `gdo2_pin:` entries                                                                                  | ESPHome examples      |
+| `ESPHOME-release/`                                   | Regenerated via `prepare-component-release.ps1`                                                                | Generated output      |
 
 ### Backward Compatibility
 

--- a/docs/GDO2_FIFO_MANAGEMENT.md
+++ b/docs/GDO2_FIFO_MANAGEMENT.md
@@ -7,7 +7,7 @@
 | **Implemented in**     | `feature/gdo2-fifo-threshold` (Part 1 only)                                                                                                                                                                                                 |
 | **Future work branch** | New branch off `main` after this merges (Parts 2 & 3)                                                                                                                                                                                       |
 
-GDO2 is currently configured as async serial data output (`IOCFG2 = 0x0D`) and left physically
+GDO2 was previously configured as async serial data output (`IOCFG2 = 0x0D`) and left physically
 unconnected. This document describes how wiring GDO2 to a free MCU GPIO and reconfiguring it as
 a FIFO threshold signal improves both TX FIFO feeding (preventing underflows) and RX FIFO draining
 (reducing unnecessary SPI traffic and improving ESPHome task scheduling).
@@ -23,7 +23,7 @@ a FIFO threshold signal improves both TX FIFO feeding (preventing underflows) an
 
 ### Problem
 
-The TX FIFO refill loop in `cc1101_send_and_listen()` is driven by polling the `TXBYTES` status
+The TX FIFO refill loop in `get_meter_data_for_meter()` is driven by polling the `TXBYTES` status
 register over SPI and a fixed `delay(20)` heuristic:
 
 ```cpp
@@ -219,7 +219,7 @@ if (GET_GDO2_PIN() >= 0) {
 
 | File                                                 | Change                                                                                                                                                        |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/core/cc1101.cpp`                                | New `IOCFG2_TX_FIFO_THR`/`IOCFG2_RX_FIFO_THR_EOP` defines; `_gdo2_pin` var + `cc1101_set_gdo2_pin()`; update `cc1101_configureRF_0()`; update TX and RX loops |
+| `src/core/cc1101.cpp`                                | New `IOCFG2_TX_FIFO_THR` define; `_gdo2_pin` var + `cc1101_set_gdo2_pin()`; update `cc1101_configureRF_0()`; update TX FIFO feeding loop in `get_meter_data_for_meter()` |
 | `src/core/cc1101.h`                                  | Expose `cc1101_set_gdo2_pin()`                                                                                                                                |
 | `include/private.example.h`                          | Add `GDO2` with wiring note                                                                                                                                   |
 | `src/main.cpp`                                       | Report GDO2 pin status in startup validation                                                                                                                  |

--- a/docs/GDO2_FIFO_MANAGEMENT.md
+++ b/docs/GDO2_FIFO_MANAGEMENT.md
@@ -205,15 +205,21 @@ UART TX/RX. Declare it as `GDO2` in `private.h` (MQTT build) or `gdo2_pin:` in E
 
 ### Backward compatibility
 
-`gdo2_pin` defaults to `-1` (not configured). All new code paths are guarded:
+`gdo2_pin` defaults to `-1` (not configured). The TX/RX loop code paths are guarded:
 
 ```cpp
 if (GET_GDO2_PIN() >= 0) {
     // GDO2 fast path
 } else {
-    // existing SPI polling fallback — no behaviour change
+    // SPI polling fallback (runs with updated IOCFG2/FIFOTHR register values — see note below)
 }
 ```
+
+> **Note:** `IOCFG2` (→ `IOCFG2_TX_FIFO_THR`, `0x02`) and `FIFOTHR` (→ `FIFOTHR_FIFO_THR_25_40`,
+> `0x49`) are written unconditionally in `cc1101_configureRF_0()` regardless of whether GDO2 is
+> wired. The SPI polling fallback path therefore runs with the updated register values. The TX
+> threshold shifts from 33 → 25 bytes and the RX threshold from 33 → 40 bytes. The RX change
+> has no functional impact since the RX loop is gated by GDO0 and `RXBYTES`, not the FIFO signal.
 
 ### Files affected
 

--- a/docs/GDO2_FIFO_MANAGEMENT.md
+++ b/docs/GDO2_FIFO_MANAGEMENT.md
@@ -1,0 +1,215 @@
+# GDO2 Hardware TX FIFO Threshold Management
+
+**Implements:** GitHub Issue #83 — Hardware-accelerated FIFO management to eliminate `TXFIFO_UNDERFLOW` errors  
+**Branch:** `feature/gdo2-fifo-threshold`
+
+---
+
+## Background: The TXFIFO_UNDERFLOW Problem
+
+When communicating with an EverBlu Cyble meter, the firmware transmits a sequence of frames into the CC1101's 64-byte TX FIFO:
+
+1. Multiple 8-byte **Wake-Up Packets (WUP)** — repeated ~25 times to wake the meter
+2. One 39-byte **interrogation frame** — requests the meter reading
+
+The CC1101 continuously drains the TX FIFO at the configured data rate (2.4 kbps for the RADIAN protocol). The firmware must refill the FIFO fast enough to avoid emptying it completely, which causes an irreversible **TXFIFO_UNDERFLOW** state (`MARCSTATE = 0x16`) that silently discards all further TX data.
+
+### Why the Original SPI Polling Approach Fails Under ESPHome
+
+The original code polled the TX FIFO level by reading the `TXBYTES` register over SPI:
+
+```cpp
+// Original approach — unreliable under ESPHome scheduler
+if (CC1101_status_FIFO_FreeByte <= 10) {
+    delay(20);  // Wait for FIFO to drain a bit
+}
+```
+
+Two compounding problems:
+
+| Problem | Effect |
+|---------|--------|
+| `CC1101_status_FIFO_FreeByte` is the **status byte from the previous SPI transaction**, not a fresh TXBYTES read | Stale data; does not reflect current FIFO level |
+| `delay(20)` in ESPHome yields to the ESP-IDF/FreeRTOS scheduler | WiFi, mDNS, OTA, API tasks can stall it for **10–80 ms** — far exceeding the time to drain a 64-byte FIFO at 2.4 kbps (≈213 ms total) |
+
+The result: the FIFO empties mid-transmission, CC1101 enters `TXFIFO_UNDERFLOW`, and the meter never receives a valid wake sequence.
+
+---
+
+## Part 1: GDO2 as Hardware TX FIFO Threshold Signal
+
+### How GDO2 Works
+
+The CC1101 `GDO2` output pin is configurable via register `IOCFG2`. Setting `IOCFG2 = 0x02` configures GDO2 as:
+
+> **TX FIFO at or above threshold → GDO2 asserts HIGH**  
+> **TX FIFO below threshold → GDO2 de-asserts LOW**
+
+This is a hardware signal, updated by the CC1101's internal logic on every byte drained — no SPI transaction required to read it.
+
+```
+digitalRead(GDO2)   ~1 µs  (GPIO register read)
+halRfReadReg(TXBYTES)  ~10 µs  (SPI: CS assert + 2 bytes + CS de-assert)
+```
+
+More importantly, `digitalRead()` is immune to ESP scheduler stalls — it reads a hardware register synchronously.
+
+### FIFOTHR Register Selection
+
+The `FIFOTHR` register (address `0x03`) controls both the TX and RX threshold levels. The key insight is that when GDO2 **de-asserts** (FIFO falls below threshold), the number of **free** bytes in the FIFO is:
+
+```
+free_bytes = 64 - TX_threshold
+```
+
+For reliable single-check operation:
+- **8-byte WUP buffer**: needs 8 free bytes
+- **39-byte interrogation frame**: needs 39 free bytes
+
+We need `64 - TX_threshold ≥ 39`, so `TX_threshold ≤ 25`.
+
+| `FIFOTHR` value | TX threshold | Free bytes on de-assert | Notes |
+|-----------------|--------------|-------------------------|-------|
+| `0x47` (FIFO_THR=7) | 33 bytes | 32 bytes | ❌ Not enough for 39-byte frame |
+| `0x49` (FIFO_THR=9) | 25 bytes | **40 bytes** | ✅ Fits WUP (8) and frame (39) |
+
+**Setting used:** `FIFOTHR = 0x49`
+
+> **Note:** This shifts the RX FIFO threshold from 33 bytes to 40 bytes, but this has no functional impact since the RX loop uses `GDO0` (sync-word detect) plus `RXBYTES` polling, not the FIFO threshold signal.
+
+### WUP Feeding Loop (TX Phase)
+
+```cpp
+// GDO2 path: hardware signal — immune to scheduler stalls
+if (GET_GDO2_PIN() >= 0) {
+    if (digitalRead(GET_GDO2_PIN()) == LOW) {
+        // FIFO < 25 bytes → ≥40 free bytes guaranteed → safe to write 8-byte WUP
+        SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+        wup2send--;
+    }
+    // else: FIFO still above threshold — skip write this iteration
+} else {
+    // Fallback: stale FreeByte check + delay(20) (original behaviour)
+    if (CC1101_status_FIFO_FreeByte <= 10) {
+        delay(20);
+    }
+    SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+    wup2send--;
+}
+```
+
+### Interrogation Frame Wait (TX Phase)
+
+```cpp
+if (GET_GDO2_PIN() >= 0) {
+    // Wait until GDO2 goes LOW (FIFO < 25 bytes → ≥40 free bytes → fits 39-byte frame)
+    int wait_count = 0;
+    while (digitalRead(GET_GDO2_PIN()) == HIGH && wait_count < 100) { // safety ~500ms
+        delay(5);
+        wait_count++;
+    }
+    // Final underflow guard before writing
+    uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
+    if (txbytes_reg & 0x80) break; // Overflow flag set — abort
+    SPIWriteBurstReg(TX_FIFO_ADDR, buffer, length);
+} else {
+    // Fallback: TXBYTES SPI poll (original behaviour)
+    while (halRfReadReg(TXBYTES_ADDR) > 25) { delay(5); }
+    SPIWriteBurstReg(TX_FIFO_ADDR, buffer, length);
+}
+```
+
+---
+
+## Part 2: RX FIFO Threshold (Future Work)
+
+The RX FIFO overflow risk is lower in priority:
+
+- The EverBlu meter response is ≈200 bytes at 2.4 kbps → takes ≈667 ms to arrive
+- The 64-byte RX FIFO takes ≈213 ms to fill
+- The RX loop calls `delay(2)` between reads, yielding to the scheduler
+
+A future enhancement (separate issue) could reconfigure `IOCFG2 = 0x01` (RX FIFO at/above threshold **or** end-of-packet) during the RX phase to trigger `yield()` more precisely. This would require dynamic IOCFG2 reconfiguration between TX and RX phases.
+
+---
+
+## Part 3: Dynamic IOCFG2 Reconfiguration (Future Work)
+
+The current implementation configures `IOCFG2 = 0x02` (TX FIFO threshold) permanently at init time. A more sophisticated approach would be:
+
+1. **TX phase**: `IOCFG2 = 0x02` (TX FIFO threshold, current implementation)
+2. **RX phase**: `IOCFG2 = 0x01` (RX FIFO at/above threshold OR end-of-packet)
+
+This would allow GDO2 to serve double duty — but requires a single SPI write at the TX→RX transition and careful handling of the GDO2 signal polarity change.
+
+---
+
+## Part 4: Implementation Scope
+
+| File | Change | Scope |
+|------|--------|-------|
+| `src/core/cc1101.cpp` | IOCFG2 = TX_FIFO_THR; FIFOTHR = 0x49; GDO2 pin variable/setter/macro; init pinMode; TX WUP loop; TX frame wait | Both (MQTT + ESPHome) |
+| `src/core/cc1101.h` | `cc1101_set_gdo2_pin()` declaration | ESPHome only |
+| `include/private.example.h` | Optional `#define GDO2 <pin>` | MQTT/PlatformIO only |
+| `src/main.cpp` | GDO2 pin reporting in startup validation | MQTT/PlatformIO only |
+| `ESPHOME/components/everblu_meter/everblu_meter.h` | `set_gdo2_pin()` setter + `gdo2_pin_` member | ESPHome only |
+| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | `apply_radio_context()` + `dump_config()` | ESPHome only |
+| `ESPHOME/components/everblu_meter/__init__.py` | `CONF_GDO2_PIN`, optional schema entry, `to_code()` | ESPHome only |
+| `ESPHOME/example-*.yaml` | Commented `gdo2_pin:` entries | ESPHome examples |
+| `ESPHOME-release/` | Regenerated via `prepare-component-release.ps1` | Generated output |
+
+### Backward Compatibility
+
+GDO2 is **entirely optional**:
+
+- `GET_GDO2_PIN()` returns `-1` when not wired/defined
+- Every GDO2 code path is guarded by `if (GET_GDO2_PIN() >= 0)`
+- All existing users with no GDO2 wiring get exactly the previous behaviour
+
+### Non-ESPHome (MQTT/PlatformIO) Usage
+
+Add to `include/private.h` (see `private.example.h` for template):
+
+```cpp
+// Optional: wire CC1101 GDO2 to a free GPIO
+#define GDO2 12  // D6 on D1 Mini
+```
+
+### ESPHome Usage
+
+Add to your YAML configuration:
+
+```yaml
+everblu_meter:
+  spi_id: main_bus
+  cs_pin: GPIO15
+  gdo0_pin: GPIO5
+  gdo2_pin: GPIO4    # optional — wire CC1101 GDO2 here
+  meter_code: "21-1234567-000"
+  time_id: ha_time
+```
+
+---
+
+## Verification
+
+Build with PlatformIO (`huzzah` environment):
+
+```bash
+pio run --environment huzzah
+```
+
+At boot (MQTT mode), with `#define GDO2 12`:
+```
+✓ GDO2 Pin: GPIO 12 (TX FIFO threshold - hardware-assisted underflow prevention)
+```
+
+At boot (ESPHome mode, `dump_config`):
+```
+[everblu_meter]   GDO2 Pin: configured (HW TX FIFO threshold)
+```
+
+Without GDO2 wired:
+```
+[everblu_meter]   GDO2 Pin: not wired (SPI polling fallback)
+```

--- a/docs/GDO2_FIFO_MANAGEMENT.md
+++ b/docs/GDO2_FIFO_MANAGEMENT.md
@@ -217,17 +217,17 @@ if (GET_GDO2_PIN() >= 0) {
 
 ### Files affected
 
-| File                                                 | Change                                                                                                                                                        |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| File                                                 | Change                                                                                                                                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `src/core/cc1101.cpp`                                | New `IOCFG2_TX_FIFO_THR` define; `_gdo2_pin` var + `cc1101_set_gdo2_pin()`; update `cc1101_configureRF_0()`; update TX FIFO feeding loop in `get_meter_data_for_meter()` |
-| `src/core/cc1101.h`                                  | Expose `cc1101_set_gdo2_pin()`                                                                                                                                |
-| `include/private.example.h`                          | Add `GDO2` with wiring note                                                                                                                                   |
-| `src/main.cpp`                                       | Report GDO2 pin status in startup validation                                                                                                                  |
-| `ESPHOME/components/everblu_meter/__init__.py`       | Add optional `gdo2_pin` config key                                                                                                                            |
-| `ESPHOME/components/everblu_meter/everblu_meter.h`   | `set_gdo2_pin()` setter + `gdo2_pin_` member                                                                                                                  |
-| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | Call `cc1101_set_gdo2_pin()` in `apply_radio_context()`; log in `dump_config()`                                                                               |
-| `ESPHOME/example-*.yaml`                             | Document optional `gdo2_pin:` parameter                                                                                                                       |
-| `ESPHOME-release/`                                   | Regenerated via `prepare-component-release.ps1`                                                                                                               |
+| `src/core/cc1101.h`                                  | Expose `cc1101_set_gdo2_pin()`                                                                                                                                           |
+| `include/private.example.h`                          | Add `GDO2` with wiring note                                                                                                                                              |
+| `src/main.cpp`                                       | Report GDO2 pin status in startup validation                                                                                                                             |
+| `ESPHOME/components/everblu_meter/__init__.py`       | Add optional `gdo2_pin` config key                                                                                                                                       |
+| `ESPHOME/components/everblu_meter/everblu_meter.h`   | `set_gdo2_pin()` setter + `gdo2_pin_` member                                                                                                                             |
+| `ESPHOME/components/everblu_meter/everblu_meter.cpp` | Call `cc1101_set_gdo2_pin()` in `apply_radio_context()`; log in `dump_config()`                                                                                          |
+| `ESPHOME/example-*.yaml`                             | Document optional `gdo2_pin:` parameter                                                                                                                                  |
+| `ESPHOME-release/`                                   | Regenerated via `prepare-component-release.ps1`                                                                                                                          |
 
 ### Not in scope
 

--- a/include/private.example.h
+++ b/include/private.example.h
@@ -166,6 +166,15 @@
 // ESP32 DevKit: GPIO4 or GPIO27
 #define GDO0 5
 
+// CC1101 GDO2 (TX FIFO threshold) pin assignment — OPTIONAL
+// When defined, the TX FIFO feeding loop uses a fast digitalRead() on this pin
+// instead of polling the TXBYTES register over SPI, preventing TXFIFO_UNDERFLOW
+// under ESPHome scheduler load. Leave commented out if GDO2 is not wired.
+// Connect CC1101 GDO2 to any free GPIO (avoid SPI bus pins and GDO0).
+// ESP8266 example: GPIO12 (D6), GPIO14 (D5 conflicts with CLK — use D6 or D7)
+// ESP32 example:   GPIO27, GPIO26
+// #define GDO2 12
+
 // Radio protocol debug output
 // 1 = enable verbose CC1101 / RADIAN logging
 // 0 = disable (default)

--- a/include/private.example.h
+++ b/include/private.example.h
@@ -170,10 +170,11 @@
 // When defined, the TX FIFO feeding loop uses a fast digitalRead() on this pin
 // instead of polling the TXBYTES register over SPI, preventing TXFIFO_UNDERFLOW
 // under ESPHome scheduler load. Leave commented out if GDO2 is not wired.
-// Connect CC1101 GDO2 to any free GPIO (avoid SPI bus pins and GDO0).
-// ESP8266 example: GPIO12 (D6), GPIO14 (D5 conflicts with CLK — use D6 or D7)
+// Connect CC1101 GDO2 to any free GPIO. Avoid SPI bus pins and GDO0:
+//   ESP8266 SPI bus: GPIO12 (D6)=MISO, GPIO13 (D7)=MOSI, GPIO14 (D5)=SCK, GPIO15 (D8)=CS
+// ESP8266 example: GPIO4 (D2) when GDO0 uses GPIO5 (D1), or GPIO5 (D1) when GDO0 uses GPIO4
 // ESP32 example:   GPIO27, GPIO26
-// #define GDO2 12
+// #define GDO2 4
 
 // Radio protocol debug output
 // 1 = enable verbose CC1101 / RADIAN logging

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1642,7 +1642,10 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
         // Final underflow check: if FIFO underflowed during the wait, abort TX loop.
         uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
         if (txbytes_reg & 0x80)
+        {
+          marcstate = halRfReadReg(MARCSTATE_ADDR); // refresh so tx_aborted check below is accurate
           break; // TXFIFO_UNDERFLOW already occurred
+        }
       }
       else
       {

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -88,7 +88,7 @@ static const uint8_t debug_out = (uint8_t)(DEBUG_CC1101);
 /*-------------------------[CC1100 - Register Values]----------------------------*/
 // IOCFG2 - GDO2 Output Pin Configuration
 #define IOCFG2_SERIAL_DATA_OUTPUT 0x0D // GDO2: Serial Data Output (kept for reference, not used)
-#define IOCFG2_TX_FIFO_THR        0x02 // GDO2: asserts HIGH when TX FIFO >= threshold; de-asserts LOW when below threshold
+#define IOCFG2_TX_FIFO_THR 0x02        // GDO2: asserts HIGH when TX FIFO >= threshold; de-asserts LOW when below threshold
 
 // IOCFG0 - GDO0 Output Pin Configuration
 #define IOCFG0_SYNC_WORD_DETECT 0x06 // Asserts when sync word detected, deasserts at end of packet
@@ -547,11 +547,11 @@ void cc1101_configureRF_0(float freq)
   // GDO2: TX FIFO threshold signal when pin is wired; falls back to IOCFG2_SERIAL_DATA_OUTPUT
   // if not connected (output floats harmlessly). Using IOCFG2_TX_FIFO_THR lets the TX feeding
   // loop replace SPI TXBYTES polling with a fast digitalRead() for proactive underflow prevention.
-  halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);        // GDO2: TX FIFO at/above threshold
-  halRfWriteReg(IOCFG0, IOCFG0_SYNC_WORD_DETECT);   // GDO0: Sync word detection
-  halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_25_40);   // FIFO thresholds: TX=25 bytes, RX=40 bytes
-  halRfWriteReg(SYNC1, SYNC1_PATTERN_55);           // Sync word MSB: 0x55
-  halRfWriteReg(SYNC0, SYNC0_PATTERN_00);           // Sync word LSB: 0x00
+  halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);      // GDO2: TX FIFO at/above threshold
+  halRfWriteReg(IOCFG0, IOCFG0_SYNC_WORD_DETECT); // GDO0: Sync word detection
+  halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_25_40); // FIFO thresholds: TX=25 bytes, RX=40 bytes
+  halRfWriteReg(SYNC1, SYNC1_PATTERN_55);         // Sync word MSB: 0x55
+  halRfWriteReg(SYNC0, SYNC0_PATTERN_00);         // Sync word LSB: 0x00
 
   halRfWriteReg(PKTCTRL1, PKTCTRL1_NO_ADDR_CHECK); // No address check
   halRfWriteReg(PKTCTRL0, PKTCTRL0_FIXED_LENGTH);  // Fixed packet length

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1644,7 +1644,7 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
         if (txbytes_reg & 0x80)
         {
           marcstate = halRfReadReg(MARCSTATE_ADDR); // refresh so tx_aborted check below is accurate
-          break; // TXFIFO_UNDERFLOW already occurred
+          break;                                    // TXFIFO_UNDERFLOW already occurred
         }
       }
       else

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -544,9 +544,9 @@ void cc1101_configureRF_0(float freq)
   //
   // RF settings for CC1101 - RADIAN protocol (Itron EverBlu)
   //
-  // GDO2: TX FIFO threshold signal when pin is wired; falls back to IOCFG2_SERIAL_DATA_OUTPUT
-  // if not connected (output floats harmlessly). Using IOCFG2_TX_FIFO_THR lets the TX feeding
-  // loop replace SPI TXBYTES polling with a fast digitalRead() for proactive underflow prevention.
+  // GDO2: always configured as TX FIFO threshold signal (IOCFG2_TX_FIFO_THR = 0x02).
+  // When GDO2 is not physically wired, the output is unused; the TX feeding loop falls back
+  // to SPI TXBYTES polling instead of digitalRead(). IOCFG2_SERIAL_DATA_OUTPUT is not restored.
   halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);      // GDO2: TX FIFO at/above threshold
   halRfWriteReg(IOCFG0, IOCFG0_SYNC_WORD_DETECT); // GDO0: Sync word detection
   halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_25_40); // FIFO thresholds: TX=25 bytes, RX=40 bytes

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1626,6 +1626,9 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
     else
     {
       // Wait for TX FIFO to drain enough to fit the 39-byte interrogation frame.
+      // Only write when FIFO space is confirmed; skip and retry the outer TX loop if
+      // the safety limit fires before the FIFO drains (avoids write with no headroom).
+      bool fifo_ready = false;
       if (GET_GDO2_PIN() >= 0)
       {
         // With FIFOTHR_FIFO_THR_25_40: GDO2 de-asserts (LOW) when FIFO < 25 bytes,
@@ -1646,6 +1649,8 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
           marcstate = halRfReadReg(MARCSTATE_ADDR); // refresh so tx_aborted check below is accurate
           break;                                    // TXFIFO_UNDERFLOW already occurred
         }
+        // Confirm GDO2 is actually LOW (FIFO drained), not merely timed out with FIFO still full.
+        fifo_ready = (digitalRead(GET_GDO2_PIN()) == LOW);
       }
       else
       {
@@ -1656,23 +1661,29 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
         {
           uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
           if (txbytes_reg & 0x80)
-            break; // TXFIFO_UNDERFLOW already occurred
+            break; // TXFIFO_UNDERFLOW — marcstate check at loop bottom will abort
           uint8_t num_txbytes = txbytes_reg & 0x7F;
           if (num_txbytes <= 25)
-            break; // 64 - 25 = 39 free bytes available
+          {
+            fifo_ready = true; // 64 - 25 = 39 free bytes confirmed
+            break;
+          }
           delay(5);
           wait_count++;
           if (wait_count % 10 == 0)
             FEED_WDT();
         }
       }
-      SPIWriteBurstReg(TX_FIFO_ADDR, txbuffer, 39);
-      if (debug_out && 0)
+      if (fifo_ready)
       {
-        echo_debug(debug_out, "txbuffer:\n");
-        show_in_hex_array(&txbuffer[0], 39);
+        SPIWriteBurstReg(TX_FIFO_ADDR, txbuffer, 39);
+        if (debug_out && 0)
+        {
+          echo_debug(debug_out, "txbuffer:\n");
+          show_in_hex_array(&txbuffer[0], 39);
+        }
+        wup2send = 0xFF;
       }
-      wup2send = 0xFF;
     }
     delay(10);
     tmo++;

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -87,13 +87,18 @@ static const uint8_t debug_out = (uint8_t)(DEBUG_CC1101);
 
 /*-------------------------[CC1100 - Register Values]----------------------------*/
 // IOCFG2 - GDO2 Output Pin Configuration
-#define IOCFG2_SERIAL_DATA_OUTPUT 0x0D // GDO2: Serial Data Output
+#define IOCFG2_SERIAL_DATA_OUTPUT 0x0D // GDO2: Serial Data Output (kept for reference, not used)
+#define IOCFG2_TX_FIFO_THR        0x02 // GDO2: asserts HIGH when TX FIFO >= threshold; de-asserts LOW when below threshold
 
 // IOCFG0 - GDO0 Output Pin Configuration
 #define IOCFG0_SYNC_WORD_DETECT 0x06 // Asserts when sync word detected, deasserts at end of packet
 
 // FIFOTHR - RX FIFO and TX FIFO Thresholds
-#define FIFOTHR_FIFO_THR_33_32 0x47 // RX FIFO threshold: 33 bytes, TX FIFO threshold: 32 bytes
+// FIFO_THR=9 (0x49): TX threshold=25 bytes — de-assertion guarantees >=40 free bytes, safely fits both
+//                    the 8-byte WUP buffer and the 39-byte interrogation frame with a single GDO2 check.
+//                    RX threshold shifts to 40 bytes (no impact: RX loop uses GDO0 + RXBYTES, not FIFO signal).
+#define FIFOTHR_FIFO_THR_33_32 0x47 // FIFO_THR=7: TX threshold 33 bytes, RX threshold 33 bytes (legacy)
+#define FIFOTHR_FIFO_THR_25_40 0x49 // FIFO_THR=9: TX threshold 25 bytes, RX threshold 40 bytes
 
 // SYNC1/SYNC0 - Sync Word Configuration
 #define SYNC1_PATTERN_55 0x55 // Sync word pattern: 0x55 (01010101)
@@ -219,6 +224,7 @@ using CC1101SpiDevice = esphome::spi::SPIDevice<esphome::spi::BIT_ORDER_MSB_FIRS
                                                 esphome::spi::DATA_RATE_1MHZ>;
 static CC1101SpiDevice *_spi_device = nullptr;
 static int _gdo0_pin = -1;
+static int _gdo2_pin = -1;
 
 void cc1101_set_spi_device(void *device)
 {
@@ -231,11 +237,22 @@ void cc1101_set_gdo0_pin(int gdo0_pin)
   _gdo0_pin = gdo0_pin;
 }
 
-// Macro to get GDO0 pin - use variable in ESPHome mode, build flag otherwise
+void cc1101_set_gdo2_pin(int gdo2_pin)
+{
+  _gdo2_pin = gdo2_pin;
+}
+
+// Macros to get GDO pin numbers - use variables in ESPHome mode, build flags otherwise
 #define GET_GDO0_PIN() (_gdo0_pin)
+#define GET_GDO2_PIN() (_gdo2_pin)
 #else
-// Non-ESPHome mode: GDO0 comes from build flag
+// Non-ESPHome mode: GDO0 comes from build flag; GDO2 is optional
 #define GET_GDO0_PIN() (GDO0)
+#ifdef GDO2
+#define GET_GDO2_PIN() (GDO2)
+#else
+#define GET_GDO2_PIN() (-1)
+#endif
 #endif
 
 // Change these define according to your ESP8266 board
@@ -527,9 +544,12 @@ void cc1101_configureRF_0(float freq)
   //
   // RF settings for CC1101 - RADIAN protocol (Itron EverBlu)
   //
-  halRfWriteReg(IOCFG2, IOCFG2_SERIAL_DATA_OUTPUT); // GDO2: Serial data output
+  // GDO2: TX FIFO threshold signal when pin is wired; falls back to IOCFG2_SERIAL_DATA_OUTPUT
+  // if not connected (output floats harmlessly). Using IOCFG2_TX_FIFO_THR lets the TX feeding
+  // loop replace SPI TXBYTES polling with a fast digitalRead() for proactive underflow prevention.
+  halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);        // GDO2: TX FIFO at/above threshold
   halRfWriteReg(IOCFG0, IOCFG0_SYNC_WORD_DETECT);   // GDO0: Sync word detection
-  halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_33_32);   // FIFO thresholds
+  halRfWriteReg(FIFOTHR, FIFOTHR_FIFO_THR_25_40);   // FIFO thresholds: TX=25 bytes, RX=40 bytes
   halRfWriteReg(SYNC1, SYNC1_PATTERN_55);           // Sync word MSB: 0x55
   halRfWriteReg(SYNC0, SYNC0_PATTERN_00);           // Sync word LSB: 0x00
 
@@ -573,6 +593,13 @@ bool cc1101_init(float freq)
 #endif
 
   pinMode(GET_GDO0_PIN(), INPUT_PULLUP);
+
+  // GDO2 is optional; configure as input only when a pin is assigned.
+  if (GET_GDO2_PIN() >= 0)
+  {
+    pinMode(GET_GDO2_PIN(), INPUT);
+    echo_debug(debug_out, "[CC1101] GDO2 pin %d configured as TX FIFO threshold input\n", GET_GDO2_PIN());
+  }
 
   // Initialize SPI transport for CC1101 communication.
   // Standalone builds configure Arduino SPI here at 500 kHz.
@@ -1569,26 +1596,58 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
     {
       if (wup2send < 0xFF)
       {
-        if (CC1101_status_FIFO_FreeByte <= 10)
-        { // this gives 10+20ms from previous frame : 8*8/2.4k=26.6ms  time to send a wupbuffer
-          delay(20);
-          tmo++;
-          tmo++;
+        if (GET_GDO2_PIN() >= 0)
+        {
+          // GDO2 configured: asserts HIGH when TX FIFO >= 25 bytes (FIFOTHR_FIFO_THR_25_40).
+          // Only refill when GDO2 de-asserts LOW (FIFO below threshold, >= 40 free bytes).
+          // This replaces the stale CC1101_status_FIFO_FreeByte check + fixed delay(20) with
+          // a real-time hardware signal, preventing underflows under ESPHome scheduler load.
+          if (digitalRead(GET_GDO2_PIN()) == LOW)
+          {
+            SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+            wup2send--;
+          }
+          // else: FIFO still above threshold — skip write this iteration
         }
-        SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
-        wup2send--;
+        else
+        {
+          // Fallback: use SPI status byte FIFO level (may be stale by one transaction).
+          if (CC1101_status_FIFO_FreeByte <= 10)
+          { // this gives 10+20ms from previous frame : 8*8/2.4k=26.6ms  time to send a wupbuffer
+            delay(20);
+            tmo++;
+            tmo++;
+          }
+          SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+          wup2send--;
+        }
       }
     }
     else
     {
-      // Wait for enough FIFO space for the 39-byte interrogation frame.
-      // Poll TXBYTES register instead of fixed delay(130) to prevent
-      // TXFIFO_UNDERFLOW when FIFO level is low. This commonly occurs in
-      // ESPHome builds where yield()/delay() service heavy background tasks
-      // (WiFi, API server, OTA, logger, mDNS, web_server) causing the FIFO
-      // feeding loop to fall behind the 2.4 kbps TX drain rate.
-      // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/58
+      // Wait for TX FIFO to drain enough to fit the 39-byte interrogation frame.
+      if (GET_GDO2_PIN() >= 0)
       {
+        // With FIFOTHR_FIFO_THR_25_40: GDO2 de-asserts (LOW) when FIFO < 25 bytes,
+        // guaranteeing >= 40 free bytes — safely fits the 39-byte frame.
+        // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/83
+        uint8_t wait_count = 0;
+        while (digitalRead(GET_GDO2_PIN()) == HIGH && wait_count < 100) // Safety limit ~500ms
+        {
+          delay(5);
+          wait_count++;
+          if (wait_count % 10 == 0)
+            FEED_WDT();
+        }
+        // Final underflow check: if FIFO underflowed during the wait, abort TX loop.
+        uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
+        if (txbytes_reg & 0x80)
+          break; // TXFIFO_UNDERFLOW already occurred
+      }
+      else
+      {
+        // Fallback: poll TXBYTES register until <= 25 bytes remain (39 free bytes).
+        // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/58
         uint8_t wait_count = 0;
         while (wait_count < 100) // Safety limit ~500ms
         {

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -31,6 +31,18 @@ void cc1101_set_spi_device(void *device);
  * @param gdo0_pin GPIO pin number for GDO0 interrupt signal
  */
 void cc1101_set_gdo0_pin(int gdo0_pin);
+
+/**
+ * @brief Set GDO2 pin for ESPHome mode (optional)
+ *
+ * When configured, GDO2 is read as a hardware TX FIFO threshold signal
+ * (IOCFG2 = 0x02), replacing SPI-based TXBYTES polling in the TX feeding loop.
+ * If not called (or called with -1), the driver falls back to the legacy
+ * CC1101_status_FIFO_FreeByte + delay(20) approach.
+ *
+ * @param gdo2_pin GPIO pin number connected to CC1101 GDO2, or -1 to disable
+ */
+void cc1101_set_gdo2_pin(int gdo2_pin);
 #endif
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1954,6 +1954,12 @@ bool validateConfiguration()
   valid = false;
 #endif
 
+#ifdef GDO2
+  Serial.printf("✓ GDO2 Pin: GPIO %d (TX FIFO threshold - hardware-assisted underflow prevention)\n", GDO2);
+#else
+  Serial.println("  GDO2 Pin: not defined (TX FIFO managed via SPI polling fallback)");
+#endif
+
   // Validate reading schedule
   if (!isValidReadingSchedule(readingSchedule))
   {


### PR DESCRIPTION
This pull request adds optional support for connecting the CC1101 radio's GDO2 pin to both the ESPHome and standalone MQTT builds, enabling hardware-assisted TX FIFO threshold detection. It also adjusts `FIFOTHR` from `0x47` → `0x49`, shifting the TX threshold from 33 → 25 bytes to guarantee ≥ 40 bytes of FIFO headroom — enough to safely write both the 8-byte WUP buffer and the 39-byte interrogation frame with a single GDO2 check. When GDO2 is wired and configured, the driver uses it to proactively manage the transmit buffer, preventing `TXFIFO_UNDERFLOW` errors that occur under heavy ESPHome scheduler load. The fallback to SPI-based polling remains fully functional if GDO2 is not connected.

**Hardware TX FIFO threshold support via GDO2:**

- Added optional `gdo2_pin` configuration parameter to both the Python and C++ ESPHome integration, allowing users to specify the GDO2 pin for hardware TX FIFO threshold detection. If not set, the driver uses the legacy SPI polling fallback.
- Updated the C++ driver and component to store, configure, and log the optional GDO2 pin, and to call the appropriate setup functions at runtime.

**CC1101 driver enhancements:**

- Implemented `cc1101_set_gdo2_pin()`, `GET_GDO2_PIN()` macro, and the `#ifdef GDO2` fallback for non-ESPHome builds so both deployment targets benefit from the same logic.
- Changed `FIFOTHR` from `FIFOTHR_FIFO_THR_33_32` (`0x47`) to `FIFOTHR_FIFO_THR_25_40` (`0x49`). This change is always applied regardless of GDO2 wiring.
- TX WUP feeding loop and interrogation frame gate now use `digitalRead(GDO2) == LOW` when available, replacing the stale `CC1101_status_FIFO_FreeByte` check and unreliable `delay(20)`.

**WiFi serial output enhancements:**

- The WiFi serial monitor now uses a non-blocking ring buffer for all TCP output, preventing main loop stalls due to slow or full TCP buffers. Dropped byte counts are reported to the client on overrun.

**Robustness:**

- Added a sanity check rejecting physically impossible meter volume readings (> 1 billion litres) to guard against corrupted decode alignment.

**Documentation and configuration:**

- Updated `ESPHOME/README.md` with `gdo2_pin` parameter table entry and corrected wiring tables.
- Updated all `ESPHOME/example-*.yaml` files to show safe free-GPIO examples for `gdo2_pin` (avoids SPI bus pins GPIO12/13/14 on ESP8266).
- Updated `include/private.example.h` with SPI bus pin warning and safe GDO2 example pin.
- Added `docs/GDO2_FIFO_MANAGEMENT.md` design document covering the TX path (Part 1 — implemented) and the planned RX path (Parts 2 & 3 — future work, tracked in issue [#84](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/84)).