### PR TITLE
fix(esphome): publish static config + idle states at boot (issue #69)

### DIFF
--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -137,7 +137,37 @@ void EverbluMeterComponent::setup() {
   // Create meter reader with all adapters (but don't initialize yet)
   this->meter_reader_ = new MeterReader(this->config_provider_, this->time_provider_, this->data_publisher_);
 
+  // Publish static configuration and clean initial states at boot so consumers
+  // (display lambdas, automations, other components) never read uninitialised
+  // sensor values before the meter reader is initialised / the first read (issue #69).
+  this->publish_boot_states();
+
   ESP_LOGCONFIG(TAG, "Setup complete; meter init deferred until connected");
+}
+
+void EverbluMeterComponent::publish_boot_states() {
+  if (this->data_publisher_ == nullptr) {
+    return;
+  }
+
+  ESP_LOGD(TAG, "Publishing boot-time states (static config + idle placeholders)");
+
+  // Static configuration values are known at boot and never change. Publishing
+  // them here ensures meter year/serial/schedule/frequency are valid from the
+  // start rather than holding uninitialised state.
+  char reading_time_buf[6];
+  snprintf(reading_time_buf, sizeof(reading_time_buf), "%02d:%02d", this->read_hour_, this->read_minute_);
+  this->data_publisher_->publishMeterSettings(this->meter_year_, this->meter_serial_, this->reading_schedule_.c_str(),
+                                              reading_time_buf, this->frequency_);
+  this->data_publisher_->publishFirmwareVersion(EVERBLU_FW_VERSION);
+
+  // Sensible idle placeholders for status text sensors until the radio is
+  // initialised and the first read completes. If radio init later fails,
+  // begin()/republish_initial_states() will overwrite these with the error state.
+  this->data_publisher_->publishRadioState("Idle");
+  this->data_publisher_->publishStatusMessage("Ready");
+  this->data_publisher_->publishError("None");
+  this->data_publisher_->publishActiveReading(false);
 }
 
 void EverbluMeterComponent::republish_initial_states() {

--- a/ESPHOME-release/everblu_meter/everblu_meter.h
+++ b/ESPHOME-release/everblu_meter/everblu_meter.h
@@ -156,6 +156,7 @@ class EverbluMeterComponent final : public PollingComponent,
   int adaptive_threshold_{1};
 
   // Internal state tracking
+  void publish_boot_states();
   void republish_initial_states();
   void apply_radio_context();
   bool gdo0_error_logged_{false};  // One-shot flag to prevent log flooding

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -137,7 +137,37 @@ void EverbluMeterComponent::setup() {
   // Create meter reader with all adapters (but don't initialize yet)
   this->meter_reader_ = new MeterReader(this->config_provider_, this->time_provider_, this->data_publisher_);
 
+  // Publish static configuration and clean initial states at boot so consumers
+  // (display lambdas, automations, other components) never read uninitialised
+  // sensor values before the meter reader is initialised / the first read (issue #69).
+  this->publish_boot_states();
+
   ESP_LOGCONFIG(TAG, "Setup complete; meter init deferred until connected");
+}
+
+void EverbluMeterComponent::publish_boot_states() {
+  if (this->data_publisher_ == nullptr) {
+    return;
+  }
+
+  ESP_LOGD(TAG, "Publishing boot-time states (static config + idle placeholders)");
+
+  // Static configuration values are known at boot and never change. Publishing
+  // them here ensures meter year/serial/schedule/frequency are valid from the
+  // start rather than holding uninitialised state.
+  char reading_time_buf[6];
+  snprintf(reading_time_buf, sizeof(reading_time_buf), "%02d:%02d", this->read_hour_, this->read_minute_);
+  this->data_publisher_->publishMeterSettings(this->meter_year_, this->meter_serial_, this->reading_schedule_.c_str(),
+                                              reading_time_buf, this->frequency_);
+  this->data_publisher_->publishFirmwareVersion(EVERBLU_FW_VERSION);
+
+  // Sensible idle placeholders for status text sensors until the radio is
+  // initialised and the first read completes. If radio init later fails,
+  // begin()/republish_initial_states() will overwrite these with the error state.
+  this->data_publisher_->publishRadioState("Idle");
+  this->data_publisher_->publishStatusMessage("Ready");
+  this->data_publisher_->publishError("None");
+  this->data_publisher_->publishActiveReading(false);
 }
 
 void EverbluMeterComponent::republish_initial_states() {

--- a/ESPHOME/components/everblu_meter/everblu_meter.h
+++ b/ESPHOME/components/everblu_meter/everblu_meter.h
@@ -156,6 +156,7 @@ class EverbluMeterComponent final : public PollingComponent,
   int adaptive_threshold_{1};
 
   // Internal state tracking
+  void publish_boot_states();
   void republish_initial_states();
   void apply_radio_context();
   bool gdo0_error_logged_{false};  // One-shot flag to prevent log flooding


### PR DESCRIPTION
## Summary

Fixes #69 — junk/uninitialised values in sensors before the first read.

In the ESPHome path, `MeterReader::begin()` is deferred until Home Assistant connects, and initial state publishing happens in `republish_initial_states()` (also on HA connect). Between boot and HA connection, the config/status **text sensors** (`meter_year`, `meter_serial`, `meter_status`, `radio_state`, etc.) were never published, so display lambdas and other components read uninitialised/empty sensor state.

This follows the maintainer's chosen approach in the issue thread (option 2 — publish sensors from boot rather than adding HA-centric getters).

## Changes

- Add `EverbluMeterComponent::publish_boot_states()`, called at the end of `setup()`.
- Publishes known-at-boot configuration: meter year/serial, schedule, reading time, frequency, firmware version.
- Publishes sensible idle placeholders for status text sensors: radio `Idle`, status `Ready`, error `None`, active-reading `false`.

## Notes

- Numeric sensors with restored history (`volume`, `counter`, …) are intentionally **not** published here, so HA-restored values are not overwritten — this preserves the original intent of the `begin()` guard.
- If radio init later fails, `begin()` / `republish_initial_states()` overwrite the placeholders with the error state, so final state remains correct.
- The hex garbage seen in the reporter's display lambda is a separate user-side issue (passing a `std::string` `.state` to `printf("%s", …)` is UB — use `.c_str()`), as noted by the maintainer.
- `ESPHOME-release/` was regenerated via the pre-commit `prepare-component-release` hook.