### PR TITLE
Feat/radio crystal calibration

### DIFF
--- a/ESPHOME-release/everblu_meter/__init__.py
+++ b/ESPHOME-release/everblu_meter/__init__.py
@@ -99,6 +99,7 @@ CONF_TUNED_FREQUENCY = "tuned_frequency"
 CONF_FREQUENCY_ESTIMATE = "frequency_estimate"
 CONF_REQUEST_READING_BUTTON = "request_reading_button"
 CONF_FREQUENCY_SCAN_BUTTON = "frequency_scan_button"
+CONF_WIDE_FREQUENCY_SCAN_BUTTON = "wide_frequency_scan_button"
 CONF_RESET_FREQUENCY_BUTTON = "reset_frequency_button"
 
 # Meter types
@@ -353,6 +354,11 @@ CONFIG_SCHEMA = (
                 icon="mdi:magnify-scan",
                 entity_category="config",
             ),
+            cv.Optional(CONF_WIDE_FREQUENCY_SCAN_BUTTON): button.button_schema(
+                EverbluMeterTriggerButton,
+                icon="mdi:radar",
+                entity_category="config",
+            ),
             cv.Optional(CONF_RESET_FREQUENCY_BUTTON): button.button_schema(
                 EverbluMeterTriggerButton, icon="mdi:restore", entity_category="config"
             ),
@@ -586,16 +592,26 @@ async def to_code(config):
         btn = await button.new_button(config[CONF_REQUEST_READING_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(btn.set_frequency_scan(False))
+        cg.add(btn.set_wide_frequency_scan(False))
         cg.add(btn.set_reset_frequency(False))
 
     if CONF_FREQUENCY_SCAN_BUTTON in config:
         btn = await button.new_button(config[CONF_FREQUENCY_SCAN_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(btn.set_frequency_scan(True))
+        cg.add(btn.set_wide_frequency_scan(False))
+        cg.add(btn.set_reset_frequency(False))
+
+    if CONF_WIDE_FREQUENCY_SCAN_BUTTON in config:
+        btn = await button.new_button(config[CONF_WIDE_FREQUENCY_SCAN_BUTTON])
+        cg.add(btn.set_parent(var))
+        cg.add(btn.set_frequency_scan(False))
+        cg.add(btn.set_wide_frequency_scan(True))
         cg.add(btn.set_reset_frequency(False))
 
     if CONF_RESET_FREQUENCY_BUTTON in config:
         btn = await button.new_button(config[CONF_RESET_FREQUENCY_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(btn.set_frequency_scan(False))
+        cg.add(btn.set_wide_frequency_scan(False))
         cg.add(btn.set_reset_frequency(True))

--- a/ESPHOME-release/everblu_meter/esphome_data_publisher.cpp
+++ b/ESPHOME-release/everblu_meter/esphome_data_publisher.cpp
@@ -18,6 +18,10 @@ static const char *const TAG_PUB = "everblu_publisher";
 esphome::sensor::Sensor *ESPHomeDataPublisher::frequency_offset_sensor_ = nullptr;
 esphome::sensor::Sensor *ESPHomeDataPublisher::tuned_frequency_sensor_ = nullptr;
 esphome::sensor::Sensor *ESPHomeDataPublisher::frequency_estimate_sensor_ = nullptr;
+// Device-level sensors shared across all meter instances (one radio, one firmware).
+esphome::text_sensor::TextSensor *ESPHomeDataPublisher::radio_state_sensor_ = nullptr;
+esphome::text_sensor::TextSensor *ESPHomeDataPublisher::version_sensor_ = nullptr;
+esphome::binary_sensor::BinarySensor *ESPHomeDataPublisher::radio_connected_sensor_ = nullptr;
 #endif
 
 ESPHomeDataPublisher::ESPHomeDataPublisher()

--- a/ESPHOME-release/everblu_meter/esphome_data_publisher.cpp
+++ b/ESPHOME-release/everblu_meter/esphome_data_publisher.cpp
@@ -12,6 +12,12 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/core/log.h"
 static const char *const TAG_PUB = "everblu_publisher";
+
+// Global (per-radio) frequency calibration sensors. Static so every meter
+// instance publishes the single shared offset to one set of HA entities.
+esphome::sensor::Sensor *ESPHomeDataPublisher::frequency_offset_sensor_ = nullptr;
+esphome::sensor::Sensor *ESPHomeDataPublisher::tuned_frequency_sensor_ = nullptr;
+esphome::sensor::Sensor *ESPHomeDataPublisher::frequency_estimate_sensor_ = nullptr;
 #endif
 
 ESPHomeDataPublisher::ESPHomeDataPublisher()

--- a/ESPHOME-release/everblu_meter/esphome_data_publisher.h
+++ b/ESPHOME-release/everblu_meter/esphome_data_publisher.h
@@ -67,9 +67,25 @@ public:
     void set_total_attempts_sensor(esphome::sensor::Sensor *sensor) { total_attempts_sensor_ = sensor; }
     void set_successful_reads_sensor(esphome::sensor::Sensor *sensor) { successful_reads_sensor_ = sensor; }
     void set_failed_reads_sensor(esphome::sensor::Sensor *sensor) { failed_reads_sensor_ = sensor; }
-    void set_frequency_offset_sensor(esphome::sensor::Sensor *sensor) { frequency_offset_sensor_ = sensor; }
-    void set_tuned_frequency_sensor(esphome::sensor::Sensor *sensor) { tuned_frequency_sensor_ = sensor; }
-    void set_frequency_estimate_sensor(esphome::sensor::Sensor *sensor) { frequency_estimate_sensor_ = sensor; }
+    // Frequency calibration sensors are GLOBAL (per-radio, not per-meter): the
+    // pointers are static and shared by every everblu_meter instance, so the
+    // single offset is reflected in one sensor regardless of which meter is read.
+    // First non-null registration wins; define these on a single meter in YAML.
+    void set_frequency_offset_sensor(esphome::sensor::Sensor *sensor)
+    {
+        if (sensor != nullptr && frequency_offset_sensor_ == nullptr)
+            frequency_offset_sensor_ = sensor;
+    }
+    void set_tuned_frequency_sensor(esphome::sensor::Sensor *sensor)
+    {
+        if (sensor != nullptr && tuned_frequency_sensor_ == nullptr)
+            tuned_frequency_sensor_ = sensor;
+    }
+    void set_frequency_estimate_sensor(esphome::sensor::Sensor *sensor)
+    {
+        if (sensor != nullptr && frequency_estimate_sensor_ == nullptr)
+            frequency_estimate_sensor_ = sensor;
+    }
     void set_uptime_sensor(esphome::sensor::Sensor *sensor) { uptime_sensor_ = sensor; }
 
     // Text sensors
@@ -129,9 +145,10 @@ private:
     esphome::sensor::Sensor *total_attempts_sensor_{nullptr};
     esphome::sensor::Sensor *successful_reads_sensor_{nullptr};
     esphome::sensor::Sensor *failed_reads_sensor_{nullptr};
-    esphome::sensor::Sensor *frequency_offset_sensor_{nullptr};
-    esphome::sensor::Sensor *tuned_frequency_sensor_{nullptr};
-    esphome::sensor::Sensor *frequency_estimate_sensor_{nullptr};
+    // Global (per-radio) frequency calibration sensors - shared across all instances.
+    static esphome::sensor::Sensor *frequency_offset_sensor_;
+    static esphome::sensor::Sensor *tuned_frequency_sensor_;
+    static esphome::sensor::Sensor *frequency_estimate_sensor_;
     esphome::sensor::Sensor *uptime_sensor_{nullptr};
 
     // Text sensors

--- a/ESPHOME-release/everblu_meter/esphome_data_publisher.h
+++ b/ESPHOME-release/everblu_meter/esphome_data_publisher.h
@@ -91,10 +91,20 @@ public:
     // Text sensors
     void set_status_sensor(esphome::text_sensor::TextSensor *sensor) { status_sensor_ = sensor; }
     void set_error_sensor(esphome::text_sensor::TextSensor *sensor) { error_sensor_ = sensor; }
-    void set_radio_state_sensor(esphome::text_sensor::TextSensor *sensor) { radio_state_sensor_ = sensor; }
+    // CC1101 State reflects the single shared radio - register once (first non-null wins).
+    void set_radio_state_sensor(esphome::text_sensor::TextSensor *sensor)
+    {
+        if (sensor != nullptr && radio_state_sensor_ == nullptr)
+            radio_state_sensor_ = sensor;
+    }
     void set_timestamp_sensor(esphome::text_sensor::TextSensor *sensor) { timestamp_sensor_ = sensor; }
     void set_history_sensor(esphome::text_sensor::TextSensor *sensor) { history_sensor_ = sensor; }
-    void set_version_sensor(esphome::text_sensor::TextSensor *sensor) { version_sensor_ = sensor; }
+    // Firmware Version is device-level - register once (first non-null wins).
+    void set_version_sensor(esphome::text_sensor::TextSensor *sensor)
+    {
+        if (sensor != nullptr && version_sensor_ == nullptr)
+            version_sensor_ = sensor;
+    }
     void set_meter_serial_sensor(esphome::text_sensor::TextSensor *sensor) { meter_serial_sensor_ = sensor; }
     void set_meter_year_sensor(esphome::text_sensor::TextSensor *sensor) { meter_year_sensor_ = sensor; }
     void set_reading_schedule_sensor(esphome::text_sensor::TextSensor *sensor) { reading_schedule_sensor_ = sensor; }
@@ -102,7 +112,12 @@ public:
 
     // Binary sensors
     void set_active_reading_sensor(esphome::binary_sensor::BinarySensor *sensor) { active_reading_sensor_ = sensor; }
-    void set_radio_connected_sensor(esphome::binary_sensor::BinarySensor *sensor) { radio_connected_sensor_ = sensor; }
+    // CC1101 Connected reflects the single shared radio - register once (first non-null wins).
+    void set_radio_connected_sensor(esphome::binary_sensor::BinarySensor *sensor)
+    {
+        if (sensor != nullptr && radio_connected_sensor_ == nullptr)
+            radio_connected_sensor_ = sensor;
+    }
 #endif
 
     // IDataPublisher interface implementation
@@ -154,10 +169,12 @@ private:
     // Text sensors
     esphome::text_sensor::TextSensor *status_sensor_{nullptr};
     esphome::text_sensor::TextSensor *error_sensor_{nullptr};
-    esphome::text_sensor::TextSensor *radio_state_sensor_{nullptr};
+    // Device-level (shared radio) - static so all meter instances share one entity.
+    static esphome::text_sensor::TextSensor *radio_state_sensor_;
     esphome::text_sensor::TextSensor *timestamp_sensor_{nullptr};
     esphome::text_sensor::TextSensor *history_sensor_{nullptr};
-    esphome::text_sensor::TextSensor *version_sensor_{nullptr};
+    // Device-level (one firmware) - shared across all meter instances.
+    static esphome::text_sensor::TextSensor *version_sensor_;
     esphome::text_sensor::TextSensor *meter_serial_sensor_{nullptr};
     esphome::text_sensor::TextSensor *meter_year_sensor_{nullptr};
     esphome::text_sensor::TextSensor *reading_schedule_sensor_{nullptr};
@@ -165,7 +182,8 @@ private:
 
     // Binary sensors
     esphome::binary_sensor::BinarySensor *active_reading_sensor_{nullptr};
-    esphome::binary_sensor::BinarySensor *radio_connected_sensor_{nullptr};
+    // Device-level (shared radio) - static so all meter instances share one entity.
+    static esphome::binary_sensor::BinarySensor *radio_connected_sensor_;
 #endif
 
     // Helper methods

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -23,7 +23,9 @@ void EverbluMeterTriggerButton::press_action() {
     return;
   }
 
-  if (this->is_frequency_scan_) {
+  if (this->is_wide_frequency_scan_) {
+    this->parent_->request_wide_frequency_scan();
+  } else if (this->is_frequency_scan_) {
     this->parent_->request_frequency_scan();
   } else if (this->is_reset_frequency_) {
     this->parent_->request_reset_frequency();
@@ -295,6 +297,17 @@ void EverbluMeterComponent::request_frequency_scan() {
   ESP_LOGI(TAG, "Frequency scan requested via button");
   this->apply_radio_context();
   this->meter_reader_->performFrequencyScan(false);
+}
+
+void EverbluMeterComponent::request_wide_frequency_scan() {
+  if (this->meter_reader_ == nullptr) {
+    ESP_LOGW(TAG, "Wide frequency scan ignored: meter reader not ready");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Wide frequency scan requested via button");
+  this->apply_radio_context();
+  this->meter_reader_->performFrequencyScan(true);
 }
 
 void EverbluMeterComponent::request_reset_frequency() {

--- a/ESPHOME-release/everblu_meter/everblu_meter.h
+++ b/ESPHOME-release/everblu_meter/everblu_meter.h
@@ -46,6 +46,7 @@ class EverbluMeterTriggerButton final : public button::Button {
  public:
   void set_parent(EverbluMeterComponent *parent) { this->parent_ = parent; }
   void set_frequency_scan(bool is_frequency_scan) { this->is_frequency_scan_ = is_frequency_scan; }
+  void set_wide_frequency_scan(bool is_wide_frequency_scan) { this->is_wide_frequency_scan_ = is_wide_frequency_scan; }
   void set_reset_frequency(bool is_reset) { this->is_reset_frequency_ = is_reset; }
 
  protected:
@@ -54,6 +55,7 @@ class EverbluMeterTriggerButton final : public button::Button {
  private:
   EverbluMeterComponent *parent_{nullptr};
   bool is_frequency_scan_{false};
+  bool is_wide_frequency_scan_{false};
   bool is_reset_frequency_{false};
 };
 
@@ -134,6 +136,7 @@ class EverbluMeterComponent final : public PollingComponent,
   // External actions
   void request_manual_read();
   void request_frequency_scan();
+  void request_wide_frequency_scan();
   void request_reset_frequency();
 
  protected:

--- a/ESPHOME-release/everblu_meter/frequency_manager.cpp
+++ b/ESPHOME-release/everblu_meter/frequency_manager.cpp
@@ -76,8 +76,25 @@ float FrequencyManager::begin(float baseFrequency)
     // Initialize storage
     StorageAbstraction::begin();
 
-    // Load stored offset
-    s_storedOffset = loadFrequencyOffset();
+    // Load the persisted offset using a NaN sentinel as the "not found" default so a
+    // genuinely stored value of 0.0 can be distinguished from "nothing saved". This
+    // gives an unambiguous boot-time confirmation of whether calibration survived a reboot.
+    float loaded = StorageAbstraction::loadFloat(STORAGE_KEY, NAN, STORAGE_MAGIC, MIN_OFFSET, MAX_OFFSET);
+    bool persisted = !isnan(loaded);
+    s_storedOffset = persisted ? loaded : 0.0f;
+
+    if (persisted)
+    {
+        LOG_I("everblu_meter",
+              "Frequency calibration RESTORED from storage: offset %.3f kHz (tuned %.6f MHz)",
+              s_storedOffset * 1000.0, s_baseFrequency + s_storedOffset);
+    }
+    else
+    {
+        LOG_W("everblu_meter",
+              "No frequency calibration stored - using default 0.000 kHz "
+              "(run a Wide Frequency Scan to calibrate the radio)");
+    }
 
     LOG_I("everblu_meter", "Initialized: base=%.6f MHz, offset=%.6f MHz",
           s_baseFrequency, s_storedOffset);

--- a/ESPHOME-release/everblu_meter/frequency_manager.cpp
+++ b/ESPHOME-release/everblu_meter/frequency_manager.cpp
@@ -5,6 +5,7 @@
 
 #include "frequency_manager.h"
 #include "logging.h"
+#include "utils.h"
 #include "storage_abstraction.h"
 #if defined(ESP32)
 #include <esp_task_wdt.h>
@@ -147,6 +148,11 @@ void FrequencyManager::performFrequencyScan(void (*statusCallback)(const char *,
     LOG_I("everblu_meter", "Starting frequency scan...");
     LOG_I("everblu_meter", "[NOTE] Wi-Fi/MQTT connections may temporarily drop and reconnect. This is expected.");
 
+    // Suppress the verbose per-attempt radio/meter read logging for the whole
+    // scan. Each frequency step performs a full read sequence whose detailed
+    // output is irrelevant noise here; high-level scan progress (LOG_*) remains.
+    EchoDebugQuietGuard quietGuard;
+
     // Reset adaptive tracking so the new offset has a chance to stabilize
     resetAdaptiveTracking();
 
@@ -232,6 +238,11 @@ void FrequencyManager::performFrequencyScan(void (*statusCallback)(const char *,
 void FrequencyManager::performWideInitialScan(void (*statusCallback)(const char *, const char *))
 {
     Serial.println("[FREQ] Performing wide initial scan (first boot - no saved offset)...");
+
+    // Suppress the verbose per-attempt radio/meter read logging for the whole
+    // scan. Each frequency step performs a full read sequence whose detailed
+    // output is irrelevant noise here; high-level scan progress (LOG_*) remains.
+    EchoDebugQuietGuard quietGuard;
 
     // Reset adaptive tracking so the new offset has a chance to stabilize
     resetAdaptiveTracking();

--- a/ESPHOME-release/everblu_meter/meter_reader.cpp
+++ b/ESPHOME-release/everblu_meter/meter_reader.cpp
@@ -139,6 +139,11 @@ void MeterReader::begin()
         snprintf(utc_time_buf, sizeof(utc_time_buf), "%02d:%02d", utcHour, utcMinute);
         m_publisher->publishMeterSettings(m_config->getMeterYear(), m_config->getMeterSerial(), m_config->getReadingSchedule(), utc_time_buf, m_config->getFrequency());
 
+        // Publish the restored calibration at boot so it is visible in Home Assistant
+        // immediately - this confirms the offset survived the reboot without waiting for a read.
+        m_publisher->publishFrequencyOffset(FrequencyManager::getOffset());
+        m_publisher->publishTunedFrequency(FrequencyManager::getTunedFrequency());
+
         // Publish radio failure state immediately (success state published in republish_initial_states)
         if (!radio_ok)
         {

--- a/ESPHOME-release/everblu_meter/meter_reader.cpp
+++ b/ESPHOME-release/everblu_meter/meter_reader.cpp
@@ -92,7 +92,11 @@ void MeterReader::begin()
     FrequencyManager::setRadioInitCallback(MeterReader::radioInitCallback);
     FrequencyManager::setMeterReadCallback(MeterReader::meterReadCallback);
 
-    // Initialize FrequencyManager with configured frequency
+    // Initialize FrequencyManager with configured frequency.
+    // NOTE: The frequency offset is a property of the RADIO, not the meter. It is held in
+    // FrequencyManager's static state and persisted under a single storage key, so it is shared
+    // by every meter that uses the same CC1101. In multi-meter setups all meters on one radio must
+    // therefore be configured with the same base `frequency` for the shared offset to be valid.
     float frequency = m_config->getFrequency();
     FrequencyManager::begin(frequency);
     FrequencyManager::setAutoScanEnabled(m_config->isAutoScanEnabled());

--- a/ESPHOME-release/everblu_meter/storage_abstraction.cpp
+++ b/ESPHOME-release/everblu_meter/storage_abstraction.cpp
@@ -336,9 +336,14 @@ bool StorageAbstraction::clearKey(const char *key)
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
     uint32_t hash = esphome::fnv1_hash(key);
-    esphome::ESPPreferenceObject pref = esphome::global_preferences->make_preference<float>(hash);
-    float zero = 0.0f;
-    return pref.save(&zero);
+    // Reuse the same cached, flash-backed preference object as save/load (see getFloatPref)
+    // so we invalidate the exact slot loadFloat reads from. Write a zeroed magic so a
+    // subsequent loadFloat fails its magic check and returns the caller's default.
+    esphome::ESPPreferenceObject &pref = getFloatPref(hash);
+    FloatStorage storage;
+    storage.magic_number = 0;
+    storage.data = 0.0f;
+    return pref.save(&storage);
 
 #elif defined(ESP8266)
     // Clear by setting magic to 0

--- a/ESPHOME-release/everblu_meter/storage_abstraction.cpp
+++ b/ESPHOME-release/everblu_meter/storage_abstraction.cpp
@@ -6,6 +6,9 @@
 #include "storage_abstraction.h"
 #include "logging.h"
 
+#include <utility>
+#include <vector>
+
 // Fallback to ESPHome preferences
 #if defined(USE_ESPHOME) || (__has_include("esphome/core/preferences.h"))
 #include "esphome/core/preferences.h"
@@ -15,6 +18,47 @@
 #elif defined(ESP32)
 #include <Preferences.h>
 static Preferences preferences;
+#endif
+
+#ifdef EVERBLU_USE_ESPHOME_PREFS
+namespace
+{
+// Storage layout shared by save and load. Defined once at file scope so the type
+// (and therefore its size) is identical for every access: ESPHome validates a
+// preference by length + CRC, so the struct must never change shape between a
+// save and a later load.
+struct FloatStorage
+{
+    uint16_t magic_number;
+    float data;
+};
+
+// Return a cached ESPPreferenceObject for the given key hash, creating it once.
+//
+// Why caching + in_flash is REQUIRED for values to survive a reboot on ESP8266:
+//  * ESPHome assigns each preference a storage slot in make_preference() CALL
+//    ORDER, not by hash. Creating a fresh object on every save/load would point
+//    save and load at DIFFERENT slots, so a saved value is never found again
+//    after a reboot. (The immediate post-save read-back still passes only
+//    because it reuses the very same object from the save.)
+//  * Default ESP8266 preferences live in RTC memory, which is wiped on a full
+//    power cycle. Passing in_flash=true stores the value in the flash sector so
+//    it survives power loss. The flag is ignored on ESP32 (NVS keys by hash and
+//    already persists correctly).
+esphome::ESPPreferenceObject &getFloatPref(uint32_t hash)
+{
+    static std::vector<std::pair<uint32_t, esphome::ESPPreferenceObject>> cache;
+    for (auto &entry : cache)
+    {
+        if (entry.first == hash)
+        {
+            return entry.second;
+        }
+    }
+    cache.emplace_back(hash, esphome::global_preferences->make_preference<FloatStorage>(hash, true));
+    return cache.back().second;
+}
+} // namespace
 #endif
 
 bool StorageAbstraction::begin()
@@ -47,19 +91,13 @@ bool StorageAbstraction::saveFloat(const char *key, float value, uint16_t magic)
     uint32_t hash = esphome::fnv1_hash(key);
     LOG_D("everblu_meter", "Saving %s (hash: 0x%08X) = %.6f", key, hash, value);
 
-    // Use struct wrapper to ensure proper storage format
-    struct FloatStorage
-    {
-        uint16_t magic_number;
-        float data;
-    };
-
     FloatStorage storage;
     storage.magic_number = magic;
     storage.data = value;
 
-    // Use ESPHome's standard flash-based preferences storage
-    esphome::ESPPreferenceObject pref = esphome::global_preferences->make_preference<FloatStorage>(hash);
+    // Reuse a single cached, flash-backed preference object for this key so the
+    // saved value is written to a stable slot and survives reboots (see getFloatPref).
+    esphome::ESPPreferenceObject &pref = getFloatPref(hash);
     bool success = pref.save(&storage);
 
     if (success)
@@ -166,15 +204,8 @@ float StorageAbstraction::loadFloat(const char *key, float defaultValue, uint16_
     uint32_t hash = esphome::fnv1_hash(key);
     LOG_D("everblu_meter", "Loading %s (hash: 0x%08X)", key, hash);
 
-    // Use struct wrapper matching the save format
-    struct FloatStorage
-    {
-        uint16_t magic_number;
-        float data;
-    };
-
-    // Use ESPHome's standard flash-based preferences storage
-    esphome::ESPPreferenceObject pref = esphome::global_preferences->make_preference<FloatStorage>(hash);
+    // Reuse the same cached, flash-backed preference object as save (see getFloatPref).
+    esphome::ESPPreferenceObject &pref = getFloatPref(hash);
 
     FloatStorage storage;
     storage.magic_number = 0;
@@ -280,9 +311,9 @@ bool StorageAbstraction::hasKey(const char *key)
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
     uint32_t hash = esphome::fnv1_hash(key);
-    esphome::ESPPreferenceObject pref = esphome::global_preferences->make_preference<float>(hash);
-    float tmp = 0.0f;
-    return pref.load(&tmp);
+    esphome::ESPPreferenceObject &pref = getFloatPref(hash);
+    FloatStorage storage;
+    return pref.load(&storage);
 
 #elif defined(ESP8266)
     // For ESP8266, check if magic number is valid

--- a/ESPHOME-release/everblu_meter/storage_abstraction.cpp
+++ b/ESPHOME-release/everblu_meter/storage_abstraction.cpp
@@ -310,10 +310,18 @@ float StorageAbstraction::loadFloat(const char *key, float defaultValue, uint16_
 bool StorageAbstraction::hasKey(const char *key)
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
+    if (esphome::global_preferences == nullptr)
+    {
+        return false;
+    }
     uint32_t hash = esphome::fnv1_hash(key);
     esphome::ESPPreferenceObject &pref = getFloatPref(hash);
     FloatStorage storage;
-    return pref.load(&storage);
+    storage.magic_number = 0;
+    // A successful load is not enough: clearKey() writes a zeroed magic to the
+    // same slot, which still loads successfully. Treat a zeroed magic as absent
+    // so hasKey() stays consistent with clearKey() and the other platforms.
+    return pref.load(&storage) && storage.magic_number != 0;
 
 #elif defined(ESP8266)
     // For ESP8266, check if magic number is valid
@@ -335,6 +343,11 @@ bool StorageAbstraction::hasKey(const char *key)
 bool StorageAbstraction::clearKey(const char *key)
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
+    if (esphome::global_preferences == nullptr)
+    {
+        LOG_E("everblu_meter", "Cannot clear %s: global_preferences is null!", key);
+        return false;
+    }
     uint32_t hash = esphome::fnv1_hash(key);
     // Reuse the same cached, flash-backed preference object as save/load (see getFloatPref)
     // so we invalidate the exact slot loadFloat reads from. Write a zeroed magic so a
@@ -343,7 +356,15 @@ bool StorageAbstraction::clearKey(const char *key)
     FloatStorage storage;
     storage.magic_number = 0;
     storage.data = 0.0f;
-    return pref.save(&storage);
+    bool success = pref.save(&storage);
+    if (success)
+    {
+        // Mirror saveFloat(): force the cleared slot out to flash and give the
+        // ESP8266 flash write time to complete so the clear survives a reboot.
+        esphome::global_preferences->sync();
+        delay(100);
+    }
+    return success;
 
 #elif defined(ESP8266)
     // Clear by setting magic to 0

--- a/ESPHOME-release/everblu_meter/utils.cpp
+++ b/ESPHOME-release/everblu_meter/utils.cpp
@@ -25,6 +25,9 @@
 
 #include <string.h>
 
+// When true, echo_debug() output is suppressed (see utils.h).
+bool g_echo_debug_quiet = false;
+
 // Consolidated hex display function with optional formatting
 // mode: 0=16 per line with newlines, 1=array format, 2=single line, 3=single line with 'S' separator
 void show_in_hex_formatted(const uint8_t *buffer, size_t len, int mode)
@@ -185,7 +188,7 @@ void printMeterDataSummary(const struct tmeter_data *meter_data, bool isMeterGas
 }
 void echo_debug(bool l_flag, const char *fmt, ...)
 {
-	if (!l_flag)
+	if (!l_flag || g_echo_debug_quiet)
 		return;
 
 	va_list args;

--- a/ESPHOME-release/everblu_meter/utils.h
+++ b/ESPHOME-release/everblu_meter/utils.h
@@ -74,6 +74,11 @@ struct EchoDebugQuietGuard
 	bool previous;
 	EchoDebugQuietGuard() : previous(g_echo_debug_quiet) { g_echo_debug_quiet = true; }
 	~EchoDebugQuietGuard() { g_echo_debug_quiet = previous; }
+
+	// Non-copyable / non-movable: copying would run the restore logic in more
+	// than one destructor and could leave g_echo_debug_quiet in the wrong state.
+	EchoDebugQuietGuard(const EchoDebugQuietGuard &) = delete;
+	EchoDebugQuietGuard &operator=(const EchoDebugQuietGuard &) = delete;
 };
 
 /**

--- a/ESPHOME-release/everblu_meter/utils.h
+++ b/ESPHOME-release/everblu_meter/utils.h
@@ -55,6 +55,28 @@ void show_in_bin(const uint8_t *buffer, size_t len);
 void echo_debug(bool l_flag, const char *fmt, ...);
 
 /**
+ * @brief When true, echo_debug() output is suppressed.
+ *
+ * Used to silence the verbose per-attempt radio/meter read sequence logging
+ * during frequency scans, where dozens of read attempts would otherwise flood
+ * the log with irrelevant detail. High-level scan progress messages use LOG_*
+ * directly and are unaffected.
+ */
+extern bool g_echo_debug_quiet;
+
+/**
+ * @brief RAII helper that suppresses echo_debug() output for the current scope.
+ *
+ * Restores the previous quiet state on destruction so nested uses are safe.
+ */
+struct EchoDebugQuietGuard
+{
+	bool previous;
+	EchoDebugQuietGuard() : previous(g_echo_debug_quiet) { g_echo_debug_quiet = true; }
+	~EchoDebugQuietGuard() { g_echo_debug_quiet = previous; }
+};
+
+/**
  * @brief Print current timestamp for debugging
  */
 void print_time(void);

--- a/ESPHOME/components/everblu_meter/__init__.py
+++ b/ESPHOME/components/everblu_meter/__init__.py
@@ -99,6 +99,7 @@ CONF_TUNED_FREQUENCY = "tuned_frequency"
 CONF_FREQUENCY_ESTIMATE = "frequency_estimate"
 CONF_REQUEST_READING_BUTTON = "request_reading_button"
 CONF_FREQUENCY_SCAN_BUTTON = "frequency_scan_button"
+CONF_WIDE_FREQUENCY_SCAN_BUTTON = "wide_frequency_scan_button"
 CONF_RESET_FREQUENCY_BUTTON = "reset_frequency_button"
 
 # Meter types
@@ -353,6 +354,11 @@ CONFIG_SCHEMA = (
                 icon="mdi:magnify-scan",
                 entity_category="config",
             ),
+            cv.Optional(CONF_WIDE_FREQUENCY_SCAN_BUTTON): button.button_schema(
+                EverbluMeterTriggerButton,
+                icon="mdi:radar",
+                entity_category="config",
+            ),
             cv.Optional(CONF_RESET_FREQUENCY_BUTTON): button.button_schema(
                 EverbluMeterTriggerButton, icon="mdi:restore", entity_category="config"
             ),
@@ -586,16 +592,26 @@ async def to_code(config):
         btn = await button.new_button(config[CONF_REQUEST_READING_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(btn.set_frequency_scan(False))
+        cg.add(btn.set_wide_frequency_scan(False))
         cg.add(btn.set_reset_frequency(False))
 
     if CONF_FREQUENCY_SCAN_BUTTON in config:
         btn = await button.new_button(config[CONF_FREQUENCY_SCAN_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(btn.set_frequency_scan(True))
+        cg.add(btn.set_wide_frequency_scan(False))
+        cg.add(btn.set_reset_frequency(False))
+
+    if CONF_WIDE_FREQUENCY_SCAN_BUTTON in config:
+        btn = await button.new_button(config[CONF_WIDE_FREQUENCY_SCAN_BUTTON])
+        cg.add(btn.set_parent(var))
+        cg.add(btn.set_frequency_scan(False))
+        cg.add(btn.set_wide_frequency_scan(True))
         cg.add(btn.set_reset_frequency(False))
 
     if CONF_RESET_FREQUENCY_BUTTON in config:
         btn = await button.new_button(config[CONF_RESET_FREQUENCY_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(btn.set_frequency_scan(False))
+        cg.add(btn.set_wide_frequency_scan(False))
         cg.add(btn.set_reset_frequency(True))

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -23,7 +23,9 @@ void EverbluMeterTriggerButton::press_action() {
     return;
   }
 
-  if (this->is_frequency_scan_) {
+  if (this->is_wide_frequency_scan_) {
+    this->parent_->request_wide_frequency_scan();
+  } else if (this->is_frequency_scan_) {
     this->parent_->request_frequency_scan();
   } else if (this->is_reset_frequency_) {
     this->parent_->request_reset_frequency();
@@ -295,6 +297,17 @@ void EverbluMeterComponent::request_frequency_scan() {
   ESP_LOGI(TAG, "Frequency scan requested via button");
   this->apply_radio_context();
   this->meter_reader_->performFrequencyScan(false);
+}
+
+void EverbluMeterComponent::request_wide_frequency_scan() {
+  if (this->meter_reader_ == nullptr) {
+    ESP_LOGW(TAG, "Wide frequency scan ignored: meter reader not ready");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Wide frequency scan requested via button");
+  this->apply_radio_context();
+  this->meter_reader_->performFrequencyScan(true);
 }
 
 void EverbluMeterComponent::request_reset_frequency() {

--- a/ESPHOME/components/everblu_meter/everblu_meter.h
+++ b/ESPHOME/components/everblu_meter/everblu_meter.h
@@ -46,6 +46,7 @@ class EverbluMeterTriggerButton final : public button::Button {
  public:
   void set_parent(EverbluMeterComponent *parent) { this->parent_ = parent; }
   void set_frequency_scan(bool is_frequency_scan) { this->is_frequency_scan_ = is_frequency_scan; }
+  void set_wide_frequency_scan(bool is_wide_frequency_scan) { this->is_wide_frequency_scan_ = is_wide_frequency_scan; }
   void set_reset_frequency(bool is_reset) { this->is_reset_frequency_ = is_reset; }
 
  protected:
@@ -54,6 +55,7 @@ class EverbluMeterTriggerButton final : public button::Button {
  private:
   EverbluMeterComponent *parent_{nullptr};
   bool is_frequency_scan_{false};
+  bool is_wide_frequency_scan_{false};
   bool is_reset_frequency_{false};
 };
 
@@ -134,6 +136,7 @@ class EverbluMeterComponent final : public PollingComponent,
   // External actions
   void request_manual_read();
   void request_frequency_scan();
+  void request_wide_frequency_scan();
   void request_reset_frequency();
 
  protected:

--- a/ESPHOME/example-advanced.yaml
+++ b/ESPHOME/example-advanced.yaml
@@ -123,6 +123,8 @@ everblu_meter:
     name: "Read Meter Now"
   frequency_scan_button:
     name: "Scan Frequency"
+  wide_frequency_scan_button:
+    name: "Wide Frequency Scan"
   reset_frequency_button:
     name: "Reset Frequency Offset"
 

--- a/ESPHOME/example-gas-meter-minimal.yaml
+++ b/ESPHOME/example-gas-meter-minimal.yaml
@@ -84,6 +84,8 @@ everblu_meter:
     name: "Read Gas Meter Now"
   frequency_scan_button:
     name: "Scan Frequency"
+  wide_frequency_scan_button:
+    name: "Wide Frequency Scan"
   reset_frequency_button:
     name: "Reset Frequency Offset"
 

--- a/ESPHOME/example-multi-meter.yaml
+++ b/ESPHOME/example-multi-meter.yaml
@@ -79,6 +79,8 @@ everblu_meter:
       name: "${meter_1_prefix} Read Meter Now"
     frequency_scan_button:
       name: "${meter_1_prefix} Scan Frequency"
+    wide_frequency_scan_button:
+      name: "${meter_1_prefix} Wide Frequency Scan"
     reset_frequency_button:
       name: "${meter_1_prefix} Reset Frequency Offset"
 
@@ -165,6 +167,8 @@ everblu_meter:
       name: "${meter_2_prefix} Read Meter Now"
     frequency_scan_button:
       name: "${meter_2_prefix} Scan Frequency"
+    wide_frequency_scan_button:
+      name: "${meter_2_prefix} Wide Frequency Scan"
     reset_frequency_button:
       name: "${meter_2_prefix} Reset Frequency Offset"
 

--- a/ESPHOME/example-multi-meter.yaml
+++ b/ESPHOME/example-multi-meter.yaml
@@ -135,18 +135,18 @@ everblu_meter:
     error:
       name: "${meter_1_prefix} Last Error"
     radio_state:
-      name: "${meter_1_prefix} CC1101 State"
+      name: "CC1101 State"            # device-level (shared radio) - declare on one meter only
     timestamp:
       name: "${meter_1_prefix} Last Reading Time"
     history_json:
       name: "${meter_1_prefix} Meter History (JSON)"
     firmware_version:
-      name: "${meter_1_prefix} Firmware Version"
+      name: "Firmware Version"        # device-level (one firmware) - declare on one meter only
 
     active_reading:
       name: "${meter_1_prefix} Reading Active"
     radio_connected:
-      name: "${meter_1_prefix} CC1101 Connected"
+      name: "CC1101 Connected"        # device-level (shared radio) - declare on one meter only
 
   - id: hot_water_meter
     meter_code: "20-0257751-000"  # year=20, serial=257751 (dashed form, suffix 000 ignored)
@@ -212,16 +212,12 @@ everblu_meter:
       name: "${meter_2_prefix} Meter Status"
     error:
       name: "${meter_2_prefix} Last Error"
-    radio_state:
-      name: "${meter_2_prefix} CC1101 State"
     timestamp:
       name: "${meter_2_prefix} Last Reading Time"
     history_json:
       name: "${meter_2_prefix} Meter History (JSON)"
-    firmware_version:
-      name: "${meter_2_prefix} Firmware Version"
 
     active_reading:
       name: "${meter_2_prefix} Reading Active"
-    radio_connected:
-      name: "${meter_2_prefix} CC1101 Connected"
+    # CC1101 State, CC1101 Connected and Firmware Version are device-level (one
+    # shared radio / firmware) and are declared on the first meter only above.

--- a/ESPHOME/example-multi-meter.yaml
+++ b/ESPHOME/example-multi-meter.yaml
@@ -77,12 +77,15 @@ everblu_meter:
 
     request_reading_button:
       name: "${meter_1_prefix} Read Meter Now"
+    # Frequency calibration is a property of the shared CC1101 radio, not the meter.
+    # Declare these buttons/sensors on ONE meter only (here, the first). They are
+    # global: any meter's reads/scans update this single set of entities.
     frequency_scan_button:
-      name: "${meter_1_prefix} Scan Frequency"
+      name: "Radio Scan Frequency"
     wide_frequency_scan_button:
-      name: "${meter_1_prefix} Wide Frequency Scan"
+      name: "Radio Wide Frequency Scan"
     reset_frequency_button:
-      name: "${meter_1_prefix} Reset Frequency Offset"
+      name: "Radio Reset Frequency Offset"
 
     volume:
       name: "${meter_1_prefix} Water Volume"
@@ -105,12 +108,13 @@ everblu_meter:
       name: "${meter_1_prefix} Successful Reads"
     failed_reads:
       name: "${meter_1_prefix} Failed Reads"
+    # Global (per-radio) calibration sensors - declared on this meter only.
     frequency_offset:
-      name: "${meter_1_prefix} Frequency Offset"
+      name: "Radio Frequency Offset"
     tuned_frequency:
-      name: "${meter_1_prefix} Tuned Frequency (MHz)"
+      name: "Radio Tuned Frequency (MHz)"
     frequency_estimate:
-      name: "${meter_1_prefix} Frequency Estimate"
+      name: "Radio Frequency Estimate"
 
     meter_serial_sensor:
       name: "${meter_1_prefix} Meter Serial"
@@ -165,12 +169,8 @@ everblu_meter:
 
     request_reading_button:
       name: "${meter_2_prefix} Read Meter Now"
-    frequency_scan_button:
-      name: "${meter_2_prefix} Scan Frequency"
-    wide_frequency_scan_button:
-      name: "${meter_2_prefix} Wide Frequency Scan"
-    reset_frequency_button:
-      name: "${meter_2_prefix} Reset Frequency Offset"
+    # Frequency calibration buttons/sensors are radio-global and declared on the
+    # first meter only (see cold_water_meter above); they act on the shared CC1101.
 
     volume:
       name: "${meter_2_prefix} Water Volume"
@@ -193,12 +193,6 @@ everblu_meter:
       name: "${meter_2_prefix} Successful Reads"
     failed_reads:
       name: "${meter_2_prefix} Failed Reads"
-    frequency_offset:
-      name: "${meter_2_prefix} Frequency Offset"
-    tuned_frequency:
-      name: "${meter_2_prefix} Tuned Frequency (MHz)"
-    frequency_estimate:
-      name: "${meter_2_prefix} Frequency Estimate"
 
     meter_serial_sensor:
       name: "${meter_2_prefix} Meter Serial"

--- a/ESPHOME/example-nano-esp32.yaml
+++ b/ESPHOME/example-nano-esp32.yaml
@@ -93,6 +93,8 @@ everblu_meter:
     name: "Read Meter Now"
   frequency_scan_button:
     name: "Scan Frequency"
+  wide_frequency_scan_button:
+    name: "Wide Frequency Scan"
   reset_frequency_button:
     name: "Reset Frequency Offset"
 

--- a/ESPHOME/example-water-meter.yaml
+++ b/ESPHOME/example-water-meter.yaml
@@ -91,6 +91,8 @@ everblu_meter:
     name: "Read Meter Now"
   frequency_scan_button:
     name: "Scan Frequency"
+  wide_frequency_scan_button:
+    name: "Wide Frequency Scan"
   reset_frequency_button:
     name: "Reset Frequency Offset"
 

--- a/ESPHOME/prepare-component-release.ps1
+++ b/ESPHOME/prepare-component-release.ps1
@@ -10,6 +10,31 @@ $SRC_DIR = "src"
 $RELEASE_ROOT = "ESPHOME-release"
 $RELEASE_DIR = "$RELEASE_ROOT\everblu_meter"
 
+# Retry helper for file operations that can transiently fail when another process
+# (e.g. OneDrive sync or antivirus) briefly holds a handle on a file. Retries the
+# action a few times with a short, increasing delay so the filesystem has time to
+# release the lock before we give up.
+function Invoke-WithRetry {
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [string]$Description = "file operation",
+        [int]$MaxAttempts = 6,
+        [int]$InitialDelayMs = 250
+    )
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            & $Action
+            return
+        }
+        catch {
+            if ($attempt -eq $MaxAttempts) { throw }
+            $delay = $InitialDelayMs * $attempt
+            Write-Host "  Lock on $Description (attempt $attempt/$MaxAttempts); waiting ${delay}ms..." -ForegroundColor DarkYellow
+            Start-Sleep -Milliseconds $delay
+        }
+    }
+}
+
 Write-Host "==========================================" -ForegroundColor Cyan
 Write-Host "EverBlu Meter Component Release Build" -ForegroundColor Cyan
 Write-Host "==========================================" -ForegroundColor Cyan
@@ -27,7 +52,9 @@ if (!(Test-Path $SRC_DIR) -or !(Test-Path $COMPONENT_DIR)) {
 # Clear any existing release output to ensure a clean package
 if (Test-Path $RELEASE_ROOT) {
     Write-Host "Clearing existing release directory..." -ForegroundColor Yellow
-    Remove-Item -Recurse -Force $RELEASE_ROOT
+    Invoke-WithRetry -Description "clearing release directory" -Action {
+        Remove-Item -Recurse -Force $RELEASE_ROOT
+    }
 }
 
 # Create release directory
@@ -36,14 +63,18 @@ New-Item -ItemType Directory -Force -Path "$RELEASE_DIR" | Out-Null
 
 # Copy component base files
 Write-Host "Copying component files..." -ForegroundColor Green
-Copy-Item "$COMPONENT_DIR\__init__.py" "$RELEASE_DIR\"
-Copy-Item "$COMPONENT_DIR\everblu_meter.h" "$RELEASE_DIR\"
-Copy-Item "$COMPONENT_DIR\everblu_meter.cpp" "$RELEASE_DIR\"
-Copy-Item "$COMPONENT_DIR\README.md" "$RELEASE_DIR\" -ErrorAction SilentlyContinue
+Invoke-WithRetry -Description "copying component files" -Action {
+    Copy-Item -Force "$COMPONENT_DIR\__init__.py" "$RELEASE_DIR\"
+    Copy-Item -Force "$COMPONENT_DIR\everblu_meter.h" "$RELEASE_DIR\"
+    Copy-Item -Force "$COMPONENT_DIR\everblu_meter.cpp" "$RELEASE_DIR\"
+    Copy-Item -Force "$COMPONENT_DIR\README.md" "$RELEASE_DIR\" -ErrorAction SilentlyContinue
+}
 
 # Copy entire src/ directory structure as-is (preserves includes)
 Write-Host "Copying source tree..." -ForegroundColor Green
-Copy-Item -Recurse "$SRC_DIR\*" "$RELEASE_DIR\"
+Invoke-WithRetry -Description "copying source tree" -Action {
+    Copy-Item -Recurse -Force "$SRC_DIR\*" "$RELEASE_DIR\"
+}
 
 # Remove main.cpp (standalone-only entry point, not for ESPHome)
 Write-Host "Removing standalone-only files..." -ForegroundColor Yellow
@@ -55,7 +86,10 @@ Write-Host "Flattening sources into a single folder..." -ForegroundColor Green
 $filesToMove = Get-ChildItem -Path $RELEASE_DIR -Recurse -Include *.h,*.hpp,*.c,*.cpp | Where-Object { $_.DirectoryName -ne (Resolve-Path $RELEASE_DIR) }
 foreach ($f in $filesToMove) {
     $dest = Join-Path $RELEASE_DIR $f.Name
-    Move-Item -Force $f.FullName $dest
+    $src = $f.FullName
+    Invoke-WithRetry -Description "moving $($f.Name)" -Action {
+        Move-Item -Force $src $dest
+    }
 }
 
 # Remove MQTT publisher files (not used in ESPHome)
@@ -72,10 +106,12 @@ Write-Host "Rewriting include paths for flattened layout..." -ForegroundColor Gr
 $allFiles = Get-ChildItem -Path $RELEASE_DIR -Filter *.h | Select-Object -ExpandProperty FullName
 $allFiles += Get-ChildItem -Path $RELEASE_DIR -Filter *.cpp | Select-Object -ExpandProperty FullName
 foreach ($file in $allFiles) {
-    $content = Get-Content $file -Raw
-    # Strip any leading path segments like core/, services/, adapters/, src/, adapters/implementations/
-    $content = $content -replace '#include\s+"(?!esphome/)(?:[^"/]+/)+([^"/]+)"', '#include "$1"'
-    Set-Content -Path $file -Value $content -NoNewline
+    Invoke-WithRetry -Description "rewriting includes in $(Split-Path $file -Leaf)" -Action {
+        $content = Get-Content $file -Raw
+        # Strip any leading path segments like core/, services/, adapters/, src/, adapters/implementations/
+        $content = $content -replace '#include\s+"(?!esphome/)(?:[^"/]+/)+([^"/]+)"', '#include "$1"'
+        Set-Content -Path $file -Value $content -NoNewline
+    }
 }
 
 # Add explicit WARNING and DO_NOT_EDIT markers, then mark files read-only
@@ -107,9 +143,12 @@ Set-Content -Path "$RELEASE_DIR\DO_NOT_EDIT.md" -Value $warningText
 Write-Host "Normalizing line endings to LF..." -ForegroundColor Green
 $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 Get-ChildItem -Path $RELEASE_ROOT -Recurse -File | ForEach-Object {
-    $raw = [System.IO.File]::ReadAllText($_.FullName)
-    $lf = $raw -replace "`r`n", "`n" -replace "`r", "`n"
-    [System.IO.File]::WriteAllText($_.FullName, $lf, $utf8NoBom)
+    $target = $_.FullName
+    Invoke-WithRetry -Description "normalizing $($_.Name)" -Action {
+        $raw = [System.IO.File]::ReadAllText($target)
+        $lf = $raw -replace "`r`n", "`n" -replace "`r", "`n"
+        [System.IO.File]::WriteAllText($target, $lf, $utf8NoBom)
+    }
 }
 
 attrib +R "$RELEASE_DIR\*" /S /D

--- a/extra/deploy-esphome-to-ha.ps1
+++ b/extra/deploy-esphome-to-ha.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Build the ESPHome component release and deploy it to the Home Assistant instance.
+
+.DESCRIPTION
+    1. Runs prepare-component-release.ps1 to regenerate ESPHOME-release\everblu_meter.
+    2. Mirrors the generated component to the HA external_components share.
+
+    Uses robocopy /MIR instead of Remove-Item + Copy-Item because the prepared
+    release files are marked read-only, which caused the old command to abort
+    partway and leave a partially-copied (broken) component on the share.
+
+.EXAMPLE
+    .\extra\deploy-esphome-to-ha.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Destination = '\\192.168.10.21\config\esphome\external_components\everblu_meter'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve repo root (parent of this script's folder) and work from there.
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+# 1. Regenerate the release package.
+& .\ESPHOME\prepare-component-release.ps1
+
+$source = (Resolve-Path '.\ESPHOME-release\everblu_meter').Path
+
+# 2. Clear read-only attributes on any existing deployed files so they can be replaced.
+if (Test-Path $Destination) {
+    Get-ChildItem $Destination -Recurse -File -Force | ForEach-Object { $_.IsReadOnly = $false }
+}
+
+# 3. Mirror the component to the share (adds new, overwrites changed, removes stale).
+robocopy $source $Destination /MIR /R:2 /W:1 | Out-Null
+
+# robocopy exit codes < 8 indicate success (0-7). 8+ means at least one failure.
+if ($LASTEXITCODE -ge 8) {
+    throw "robocopy failed with exit code $LASTEXITCODE"
+}
+
+$srcCount = (Get-ChildItem $source -File).Count
+$dstCount = (Get-ChildItem $Destination -File).Count
+Write-Host "Deploy complete: $dstCount/$srcCount files mirrored to $Destination" -ForegroundColor Green

--- a/src/adapters/implementations/esphome_data_publisher.cpp
+++ b/src/adapters/implementations/esphome_data_publisher.cpp
@@ -18,6 +18,10 @@ static const char *const TAG_PUB = "everblu_publisher";
 esphome::sensor::Sensor *ESPHomeDataPublisher::frequency_offset_sensor_ = nullptr;
 esphome::sensor::Sensor *ESPHomeDataPublisher::tuned_frequency_sensor_ = nullptr;
 esphome::sensor::Sensor *ESPHomeDataPublisher::frequency_estimate_sensor_ = nullptr;
+// Device-level sensors shared across all meter instances (one radio, one firmware).
+esphome::text_sensor::TextSensor *ESPHomeDataPublisher::radio_state_sensor_ = nullptr;
+esphome::text_sensor::TextSensor *ESPHomeDataPublisher::version_sensor_ = nullptr;
+esphome::binary_sensor::BinarySensor *ESPHomeDataPublisher::radio_connected_sensor_ = nullptr;
 #endif
 
 ESPHomeDataPublisher::ESPHomeDataPublisher()

--- a/src/adapters/implementations/esphome_data_publisher.cpp
+++ b/src/adapters/implementations/esphome_data_publisher.cpp
@@ -12,6 +12,12 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/core/log.h"
 static const char *const TAG_PUB = "everblu_publisher";
+
+// Global (per-radio) frequency calibration sensors. Static so every meter
+// instance publishes the single shared offset to one set of HA entities.
+esphome::sensor::Sensor *ESPHomeDataPublisher::frequency_offset_sensor_ = nullptr;
+esphome::sensor::Sensor *ESPHomeDataPublisher::tuned_frequency_sensor_ = nullptr;
+esphome::sensor::Sensor *ESPHomeDataPublisher::frequency_estimate_sensor_ = nullptr;
 #endif
 
 ESPHomeDataPublisher::ESPHomeDataPublisher()

--- a/src/adapters/implementations/esphome_data_publisher.h
+++ b/src/adapters/implementations/esphome_data_publisher.h
@@ -67,9 +67,25 @@ public:
     void set_total_attempts_sensor(esphome::sensor::Sensor *sensor) { total_attempts_sensor_ = sensor; }
     void set_successful_reads_sensor(esphome::sensor::Sensor *sensor) { successful_reads_sensor_ = sensor; }
     void set_failed_reads_sensor(esphome::sensor::Sensor *sensor) { failed_reads_sensor_ = sensor; }
-    void set_frequency_offset_sensor(esphome::sensor::Sensor *sensor) { frequency_offset_sensor_ = sensor; }
-    void set_tuned_frequency_sensor(esphome::sensor::Sensor *sensor) { tuned_frequency_sensor_ = sensor; }
-    void set_frequency_estimate_sensor(esphome::sensor::Sensor *sensor) { frequency_estimate_sensor_ = sensor; }
+    // Frequency calibration sensors are GLOBAL (per-radio, not per-meter): the
+    // pointers are static and shared by every everblu_meter instance, so the
+    // single offset is reflected in one sensor regardless of which meter is read.
+    // First non-null registration wins; define these on a single meter in YAML.
+    void set_frequency_offset_sensor(esphome::sensor::Sensor *sensor)
+    {
+        if (sensor != nullptr && frequency_offset_sensor_ == nullptr)
+            frequency_offset_sensor_ = sensor;
+    }
+    void set_tuned_frequency_sensor(esphome::sensor::Sensor *sensor)
+    {
+        if (sensor != nullptr && tuned_frequency_sensor_ == nullptr)
+            tuned_frequency_sensor_ = sensor;
+    }
+    void set_frequency_estimate_sensor(esphome::sensor::Sensor *sensor)
+    {
+        if (sensor != nullptr && frequency_estimate_sensor_ == nullptr)
+            frequency_estimate_sensor_ = sensor;
+    }
     void set_uptime_sensor(esphome::sensor::Sensor *sensor) { uptime_sensor_ = sensor; }
 
     // Text sensors
@@ -129,9 +145,10 @@ private:
     esphome::sensor::Sensor *total_attempts_sensor_{nullptr};
     esphome::sensor::Sensor *successful_reads_sensor_{nullptr};
     esphome::sensor::Sensor *failed_reads_sensor_{nullptr};
-    esphome::sensor::Sensor *frequency_offset_sensor_{nullptr};
-    esphome::sensor::Sensor *tuned_frequency_sensor_{nullptr};
-    esphome::sensor::Sensor *frequency_estimate_sensor_{nullptr};
+    // Global (per-radio) frequency calibration sensors - shared across all instances.
+    static esphome::sensor::Sensor *frequency_offset_sensor_;
+    static esphome::sensor::Sensor *tuned_frequency_sensor_;
+    static esphome::sensor::Sensor *frequency_estimate_sensor_;
     esphome::sensor::Sensor *uptime_sensor_{nullptr};
 
     // Text sensors

--- a/src/adapters/implementations/esphome_data_publisher.h
+++ b/src/adapters/implementations/esphome_data_publisher.h
@@ -91,10 +91,20 @@ public:
     // Text sensors
     void set_status_sensor(esphome::text_sensor::TextSensor *sensor) { status_sensor_ = sensor; }
     void set_error_sensor(esphome::text_sensor::TextSensor *sensor) { error_sensor_ = sensor; }
-    void set_radio_state_sensor(esphome::text_sensor::TextSensor *sensor) { radio_state_sensor_ = sensor; }
+    // CC1101 State reflects the single shared radio - register once (first non-null wins).
+    void set_radio_state_sensor(esphome::text_sensor::TextSensor *sensor)
+    {
+        if (sensor != nullptr && radio_state_sensor_ == nullptr)
+            radio_state_sensor_ = sensor;
+    }
     void set_timestamp_sensor(esphome::text_sensor::TextSensor *sensor) { timestamp_sensor_ = sensor; }
     void set_history_sensor(esphome::text_sensor::TextSensor *sensor) { history_sensor_ = sensor; }
-    void set_version_sensor(esphome::text_sensor::TextSensor *sensor) { version_sensor_ = sensor; }
+    // Firmware Version is device-level - register once (first non-null wins).
+    void set_version_sensor(esphome::text_sensor::TextSensor *sensor)
+    {
+        if (sensor != nullptr && version_sensor_ == nullptr)
+            version_sensor_ = sensor;
+    }
     void set_meter_serial_sensor(esphome::text_sensor::TextSensor *sensor) { meter_serial_sensor_ = sensor; }
     void set_meter_year_sensor(esphome::text_sensor::TextSensor *sensor) { meter_year_sensor_ = sensor; }
     void set_reading_schedule_sensor(esphome::text_sensor::TextSensor *sensor) { reading_schedule_sensor_ = sensor; }
@@ -102,7 +112,12 @@ public:
 
     // Binary sensors
     void set_active_reading_sensor(esphome::binary_sensor::BinarySensor *sensor) { active_reading_sensor_ = sensor; }
-    void set_radio_connected_sensor(esphome::binary_sensor::BinarySensor *sensor) { radio_connected_sensor_ = sensor; }
+    // CC1101 Connected reflects the single shared radio - register once (first non-null wins).
+    void set_radio_connected_sensor(esphome::binary_sensor::BinarySensor *sensor)
+    {
+        if (sensor != nullptr && radio_connected_sensor_ == nullptr)
+            radio_connected_sensor_ = sensor;
+    }
 #endif
 
     // IDataPublisher interface implementation
@@ -154,10 +169,12 @@ private:
     // Text sensors
     esphome::text_sensor::TextSensor *status_sensor_{nullptr};
     esphome::text_sensor::TextSensor *error_sensor_{nullptr};
-    esphome::text_sensor::TextSensor *radio_state_sensor_{nullptr};
+    // Device-level (shared radio) - static so all meter instances share one entity.
+    static esphome::text_sensor::TextSensor *radio_state_sensor_;
     esphome::text_sensor::TextSensor *timestamp_sensor_{nullptr};
     esphome::text_sensor::TextSensor *history_sensor_{nullptr};
-    esphome::text_sensor::TextSensor *version_sensor_{nullptr};
+    // Device-level (one firmware) - shared across all meter instances.
+    static esphome::text_sensor::TextSensor *version_sensor_;
     esphome::text_sensor::TextSensor *meter_serial_sensor_{nullptr};
     esphome::text_sensor::TextSensor *meter_year_sensor_{nullptr};
     esphome::text_sensor::TextSensor *reading_schedule_sensor_{nullptr};
@@ -165,7 +182,8 @@ private:
 
     // Binary sensors
     esphome::binary_sensor::BinarySensor *active_reading_sensor_{nullptr};
-    esphome::binary_sensor::BinarySensor *radio_connected_sensor_{nullptr};
+    // Device-level (shared radio) - static so all meter instances share one entity.
+    static esphome::binary_sensor::BinarySensor *radio_connected_sensor_;
 #endif
 
     // Helper methods

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -25,6 +25,9 @@
 
 #include <string.h>
 
+// When true, echo_debug() output is suppressed (see utils.h).
+bool g_echo_debug_quiet = false;
+
 // Consolidated hex display function with optional formatting
 // mode: 0=16 per line with newlines, 1=array format, 2=single line, 3=single line with 'S' separator
 void show_in_hex_formatted(const uint8_t *buffer, size_t len, int mode)
@@ -185,7 +188,7 @@ void printMeterDataSummary(const struct tmeter_data *meter_data, bool isMeterGas
 }
 void echo_debug(bool l_flag, const char *fmt, ...)
 {
-	if (!l_flag)
+	if (!l_flag || g_echo_debug_quiet)
 		return;
 
 	va_list args;

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -74,6 +74,11 @@ struct EchoDebugQuietGuard
 	bool previous;
 	EchoDebugQuietGuard() : previous(g_echo_debug_quiet) { g_echo_debug_quiet = true; }
 	~EchoDebugQuietGuard() { g_echo_debug_quiet = previous; }
+
+	// Non-copyable / non-movable: copying would run the restore logic in more
+	// than one destructor and could leave g_echo_debug_quiet in the wrong state.
+	EchoDebugQuietGuard(const EchoDebugQuietGuard &) = delete;
+	EchoDebugQuietGuard &operator=(const EchoDebugQuietGuard &) = delete;
 };
 
 /**

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -55,6 +55,28 @@ void show_in_bin(const uint8_t *buffer, size_t len);
 void echo_debug(bool l_flag, const char *fmt, ...);
 
 /**
+ * @brief When true, echo_debug() output is suppressed.
+ *
+ * Used to silence the verbose per-attempt radio/meter read sequence logging
+ * during frequency scans, where dozens of read attempts would otherwise flood
+ * the log with irrelevant detail. High-level scan progress messages use LOG_*
+ * directly and are unaffected.
+ */
+extern bool g_echo_debug_quiet;
+
+/**
+ * @brief RAII helper that suppresses echo_debug() output for the current scope.
+ *
+ * Restores the previous quiet state on destruction so nested uses are safe.
+ */
+struct EchoDebugQuietGuard
+{
+	bool previous;
+	EchoDebugQuietGuard() : previous(g_echo_debug_quiet) { g_echo_debug_quiet = true; }
+	~EchoDebugQuietGuard() { g_echo_debug_quiet = previous; }
+};
+
+/**
  * @brief Print current timestamp for debugging
  */
 void print_time(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1639,6 +1639,12 @@ void performFrequencyScan()
 {
   Serial.println("[FREQ] Starting frequency scan...");
   Serial.println("[FREQ] [NOTE] Wi-Fi/MQTT connections may temporarily drop and reconnect while the scan is running. This is expected.");
+
+  // Suppress the verbose per-attempt radio/meter read logging for the whole
+  // scan. Each frequency step performs a full read sequence whose detailed
+  // output is irrelevant noise here; high-level scan progress messages remain.
+  EchoDebugQuietGuard quietGuard;
+
   char topicBuffer[MQTT_TOPIC_BUFFER_SIZE];
   snprintf(topicBuffer, sizeof(topicBuffer), "%s/cc1101_state", mqttBaseTopic);
   mqtt.publish(topicBuffer, "Frequency Scanning", true);
@@ -1720,6 +1726,12 @@ void performFrequencyScan()
 void performWideInitialScan()
 {
   Serial.println("[FREQ] Performing wide initial scan (first boot - no saved offset)...");
+
+  // Suppress the verbose per-attempt radio/meter read logging for the whole
+  // scan. Each frequency step performs a full read sequence whose detailed
+  // output is irrelevant noise here; high-level scan progress messages remain.
+  EchoDebugQuietGuard quietGuard;
+
   char topicBuffer[MQTT_TOPIC_BUFFER_SIZE];
   snprintf(topicBuffer, sizeof(topicBuffer), "%s/cc1101_state", mqttBaseTopic);
   mqtt.publish(topicBuffer, "Initial Frequency Scan", true);

--- a/src/services/frequency_manager.cpp
+++ b/src/services/frequency_manager.cpp
@@ -5,6 +5,7 @@
 
 #include "frequency_manager.h"
 #include "../core/logging.h"
+#include "../core/utils.h"
 #include "storage_abstraction.h"
 #if defined(ESP32)
 #include <esp_task_wdt.h>
@@ -147,6 +148,11 @@ void FrequencyManager::performFrequencyScan(void (*statusCallback)(const char *,
     LOG_I("everblu_meter", "Starting frequency scan...");
     LOG_I("everblu_meter", "[NOTE] Wi-Fi/MQTT connections may temporarily drop and reconnect. This is expected.");
 
+    // Suppress the verbose per-attempt radio/meter read logging for the whole
+    // scan. Each frequency step performs a full read sequence whose detailed
+    // output is irrelevant noise here; high-level scan progress (LOG_*) remains.
+    EchoDebugQuietGuard quietGuard;
+
     // Reset adaptive tracking so the new offset has a chance to stabilize
     resetAdaptiveTracking();
 
@@ -232,6 +238,11 @@ void FrequencyManager::performFrequencyScan(void (*statusCallback)(const char *,
 void FrequencyManager::performWideInitialScan(void (*statusCallback)(const char *, const char *))
 {
     Serial.println("[FREQ] Performing wide initial scan (first boot - no saved offset)...");
+
+    // Suppress the verbose per-attempt radio/meter read logging for the whole
+    // scan. Each frequency step performs a full read sequence whose detailed
+    // output is irrelevant noise here; high-level scan progress (LOG_*) remains.
+    EchoDebugQuietGuard quietGuard;
 
     // Reset adaptive tracking so the new offset has a chance to stabilize
     resetAdaptiveTracking();

--- a/src/services/frequency_manager.cpp
+++ b/src/services/frequency_manager.cpp
@@ -76,8 +76,25 @@ float FrequencyManager::begin(float baseFrequency)
     // Initialize storage
     StorageAbstraction::begin();
 
-    // Load stored offset
-    s_storedOffset = loadFrequencyOffset();
+    // Load the persisted offset using a NaN sentinel as the "not found" default so a
+    // genuinely stored value of 0.0 can be distinguished from "nothing saved". This
+    // gives an unambiguous boot-time confirmation of whether calibration survived a reboot.
+    float loaded = StorageAbstraction::loadFloat(STORAGE_KEY, NAN, STORAGE_MAGIC, MIN_OFFSET, MAX_OFFSET);
+    bool persisted = !isnan(loaded);
+    s_storedOffset = persisted ? loaded : 0.0f;
+
+    if (persisted)
+    {
+        LOG_I("everblu_meter",
+              "Frequency calibration RESTORED from storage: offset %.3f kHz (tuned %.6f MHz)",
+              s_storedOffset * 1000.0, s_baseFrequency + s_storedOffset);
+    }
+    else
+    {
+        LOG_W("everblu_meter",
+              "No frequency calibration stored - using default 0.000 kHz "
+              "(run a Wide Frequency Scan to calibrate the radio)");
+    }
 
     LOG_I("everblu_meter", "Initialized: base=%.6f MHz, offset=%.6f MHz",
           s_baseFrequency, s_storedOffset);

--- a/src/services/meter_reader.cpp
+++ b/src/services/meter_reader.cpp
@@ -139,6 +139,11 @@ void MeterReader::begin()
         snprintf(utc_time_buf, sizeof(utc_time_buf), "%02d:%02d", utcHour, utcMinute);
         m_publisher->publishMeterSettings(m_config->getMeterYear(), m_config->getMeterSerial(), m_config->getReadingSchedule(), utc_time_buf, m_config->getFrequency());
 
+        // Publish the restored calibration at boot so it is visible in Home Assistant
+        // immediately - this confirms the offset survived the reboot without waiting for a read.
+        m_publisher->publishFrequencyOffset(FrequencyManager::getOffset());
+        m_publisher->publishTunedFrequency(FrequencyManager::getTunedFrequency());
+
         // Publish radio failure state immediately (success state published in republish_initial_states)
         if (!radio_ok)
         {

--- a/src/services/meter_reader.cpp
+++ b/src/services/meter_reader.cpp
@@ -92,7 +92,11 @@ void MeterReader::begin()
     FrequencyManager::setRadioInitCallback(MeterReader::radioInitCallback);
     FrequencyManager::setMeterReadCallback(MeterReader::meterReadCallback);
 
-    // Initialize FrequencyManager with configured frequency
+    // Initialize FrequencyManager with configured frequency.
+    // NOTE: The frequency offset is a property of the RADIO, not the meter. It is held in
+    // FrequencyManager's static state and persisted under a single storage key, so it is shared
+    // by every meter that uses the same CC1101. In multi-meter setups all meters on one radio must
+    // therefore be configured with the same base `frequency` for the shared offset to be valid.
     float frequency = m_config->getFrequency();
     FrequencyManager::begin(frequency);
     FrequencyManager::setAutoScanEnabled(m_config->isAutoScanEnabled());

--- a/src/services/storage_abstraction.cpp
+++ b/src/services/storage_abstraction.cpp
@@ -336,9 +336,14 @@ bool StorageAbstraction::clearKey(const char *key)
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
     uint32_t hash = esphome::fnv1_hash(key);
-    esphome::ESPPreferenceObject pref = esphome::global_preferences->make_preference<float>(hash);
-    float zero = 0.0f;
-    return pref.save(&zero);
+    // Reuse the same cached, flash-backed preference object as save/load (see getFloatPref)
+    // so we invalidate the exact slot loadFloat reads from. Write a zeroed magic so a
+    // subsequent loadFloat fails its magic check and returns the caller's default.
+    esphome::ESPPreferenceObject &pref = getFloatPref(hash);
+    FloatStorage storage;
+    storage.magic_number = 0;
+    storage.data = 0.0f;
+    return pref.save(&storage);
 
 #elif defined(ESP8266)
     // Clear by setting magic to 0

--- a/src/services/storage_abstraction.cpp
+++ b/src/services/storage_abstraction.cpp
@@ -310,10 +310,18 @@ float StorageAbstraction::loadFloat(const char *key, float defaultValue, uint16_
 bool StorageAbstraction::hasKey(const char *key)
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
+    if (esphome::global_preferences == nullptr)
+    {
+        return false;
+    }
     uint32_t hash = esphome::fnv1_hash(key);
     esphome::ESPPreferenceObject &pref = getFloatPref(hash);
     FloatStorage storage;
-    return pref.load(&storage);
+    storage.magic_number = 0;
+    // A successful load is not enough: clearKey() writes a zeroed magic to the
+    // same slot, which still loads successfully. Treat a zeroed magic as absent
+    // so hasKey() stays consistent with clearKey() and the other platforms.
+    return pref.load(&storage) && storage.magic_number != 0;
 
 #elif defined(ESP8266)
     // For ESP8266, check if magic number is valid
@@ -335,6 +343,11 @@ bool StorageAbstraction::hasKey(const char *key)
 bool StorageAbstraction::clearKey(const char *key)
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
+    if (esphome::global_preferences == nullptr)
+    {
+        LOG_E("everblu_meter", "Cannot clear %s: global_preferences is null!", key);
+        return false;
+    }
     uint32_t hash = esphome::fnv1_hash(key);
     // Reuse the same cached, flash-backed preference object as save/load (see getFloatPref)
     // so we invalidate the exact slot loadFloat reads from. Write a zeroed magic so a
@@ -343,7 +356,15 @@ bool StorageAbstraction::clearKey(const char *key)
     FloatStorage storage;
     storage.magic_number = 0;
     storage.data = 0.0f;
-    return pref.save(&storage);
+    bool success = pref.save(&storage);
+    if (success)
+    {
+        // Mirror saveFloat(): force the cleared slot out to flash and give the
+        // ESP8266 flash write time to complete so the clear survives a reboot.
+        esphome::global_preferences->sync();
+        delay(100);
+    }
+    return success;
 
 #elif defined(ESP8266)
     // Clear by setting magic to 0

--- a/src/services/storage_abstraction.cpp
+++ b/src/services/storage_abstraction.cpp
@@ -6,6 +6,9 @@
 #include "storage_abstraction.h"
 #include "../core/logging.h"
 
+#include <utility>
+#include <vector>
+
 // Fallback to ESPHome preferences
 #if defined(USE_ESPHOME) || (__has_include("esphome/core/preferences.h"))
 #include "esphome/core/preferences.h"
@@ -15,6 +18,47 @@
 #elif defined(ESP32)
 #include <Preferences.h>
 static Preferences preferences;
+#endif
+
+#ifdef EVERBLU_USE_ESPHOME_PREFS
+namespace
+{
+// Storage layout shared by save and load. Defined once at file scope so the type
+// (and therefore its size) is identical for every access: ESPHome validates a
+// preference by length + CRC, so the struct must never change shape between a
+// save and a later load.
+struct FloatStorage
+{
+    uint16_t magic_number;
+    float data;
+};
+
+// Return a cached ESPPreferenceObject for the given key hash, creating it once.
+//
+// Why caching + in_flash is REQUIRED for values to survive a reboot on ESP8266:
+//  * ESPHome assigns each preference a storage slot in make_preference() CALL
+//    ORDER, not by hash. Creating a fresh object on every save/load would point
+//    save and load at DIFFERENT slots, so a saved value is never found again
+//    after a reboot. (The immediate post-save read-back still passes only
+//    because it reuses the very same object from the save.)
+//  * Default ESP8266 preferences live in RTC memory, which is wiped on a full
+//    power cycle. Passing in_flash=true stores the value in the flash sector so
+//    it survives power loss. The flag is ignored on ESP32 (NVS keys by hash and
+//    already persists correctly).
+esphome::ESPPreferenceObject &getFloatPref(uint32_t hash)
+{
+    static std::vector<std::pair<uint32_t, esphome::ESPPreferenceObject>> cache;
+    for (auto &entry : cache)
+    {
+        if (entry.first == hash)
+        {
+            return entry.second;
+        }
+    }
+    cache.emplace_back(hash, esphome::global_preferences->make_preference<FloatStorage>(hash, true));
+    return cache.back().second;
+}
+} // namespace
 #endif
 
 bool StorageAbstraction::begin()
@@ -47,19 +91,13 @@ bool StorageAbstraction::saveFloat(const char *key, float value, uint16_t magic)
     uint32_t hash = esphome::fnv1_hash(key);
     LOG_D("everblu_meter", "Saving %s (hash: 0x%08X) = %.6f", key, hash, value);
 
-    // Use struct wrapper to ensure proper storage format
-    struct FloatStorage
-    {
-        uint16_t magic_number;
-        float data;
-    };
-
     FloatStorage storage;
     storage.magic_number = magic;
     storage.data = value;
 
-    // Use ESPHome's standard flash-based preferences storage
-    esphome::ESPPreferenceObject pref = esphome::global_preferences->make_preference<FloatStorage>(hash);
+    // Reuse a single cached, flash-backed preference object for this key so the
+    // saved value is written to a stable slot and survives reboots (see getFloatPref).
+    esphome::ESPPreferenceObject &pref = getFloatPref(hash);
     bool success = pref.save(&storage);
 
     if (success)
@@ -166,15 +204,8 @@ float StorageAbstraction::loadFloat(const char *key, float defaultValue, uint16_
     uint32_t hash = esphome::fnv1_hash(key);
     LOG_D("everblu_meter", "Loading %s (hash: 0x%08X)", key, hash);
 
-    // Use struct wrapper matching the save format
-    struct FloatStorage
-    {
-        uint16_t magic_number;
-        float data;
-    };
-
-    // Use ESPHome's standard flash-based preferences storage
-    esphome::ESPPreferenceObject pref = esphome::global_preferences->make_preference<FloatStorage>(hash);
+    // Reuse the same cached, flash-backed preference object as save (see getFloatPref).
+    esphome::ESPPreferenceObject &pref = getFloatPref(hash);
 
     FloatStorage storage;
     storage.magic_number = 0;
@@ -280,9 +311,9 @@ bool StorageAbstraction::hasKey(const char *key)
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
     uint32_t hash = esphome::fnv1_hash(key);
-    esphome::ESPPreferenceObject pref = esphome::global_preferences->make_preference<float>(hash);
-    float tmp = 0.0f;
-    return pref.load(&tmp);
+    esphome::ESPPreferenceObject &pref = getFloatPref(hash);
+    FloatStorage storage;
+    return pref.load(&storage);
 
 #elif defined(ESP8266)
     // For ESP8266, check if magic number is valid


### PR DESCRIPTION
This pull request introduces several improvements to the Everblu Meter integration, focusing on enhanced frequency calibration handling, improved persistence for calibration data, and the addition of a new "Wide Frequency Scan" feature. The changes ensure that calibration data is reliably shared across all meters using the same radio, persists correctly across reboots, and is immediately visible in Home Assistant after boot. Additionally, a new button and associated logic for wide frequency scans are added.

**Enhancements to frequency calibration and persistence:**

- Frequency calibration sensors and device-level sensors are now defined as static (shared) members in `ESPHomeDataPublisher`, ensuring one set of sensors per radio/firmware, regardless of the number of meter instances. Registration is now "first non-null wins." (`esphome_data_publisher.cpp`, `esphome_data_publisher.h`) [[1]](diffhunk://#diff-a4705912660e7c751bee9f703060d78fa0c306f7fb02af445ad8d46beaee4f71R15-R24) [[2]](diffhunk://#diff-eba8db2a167deb85e652839825ec0b6599a8ce035644af524aa47d86b6f4b9b1L70-R120) [[3]](diffhunk://#diff-eba8db2a167deb85e652839825ec0b6599a8ce035644af524aa47d86b6f4b9b1L132-R186)
- The frequency offset is now loaded using a NaN sentinel, allowing the code to distinguish between "no calibration stored" and a real offset of 0.0. A log message clearly indicates whether calibration survived a reboot. (`frequency_manager.cpp`)
- On boot, the restored calibration values are published immediately to Home Assistant, so the current offset is visible without waiting for a meter read. (`meter_reader.cpp`) [[1]](diffhunk://#diff-2033fcc5f36660b661a960139253eab287029d306f536e194d891cbc4282521bL95-R99) [[2]](diffhunk://#diff-2033fcc5f36660b661a960139253eab287029d306f536e194d891cbc4282521bR142-R146)
- Added detailed comments and documentation clarifying that frequency calibration is a property of the radio, not individual meters, and that all meters on one radio must use the same base frequency. (`meter_reader.cpp`)

**Improvements to ESPHome preferences persistence:**

- ESPHome preferences for calibration data now use a cached, flash-backed preference object for each key, ensuring values are saved and loaded from a stable slot and survive reboots (especially on ESP8266). The storage struct is defined at file scope to guarantee binary compatibility. (`storage_abstraction.cpp`) [[1]](diffhunk://#diff-eaa44861ecda802a0c63f4f8d04d43bb30f9d60bd75691e25b6e0c4444fb8139R9-R11) [[2]](diffhunk://#diff-eaa44861ecda802a0c63f4f8d04d43bb30f9d60bd75691e25b6e0c4444fb8139R23-R63) [[3]](diffhunk://#diff-eaa44861ecda802a0c63f4f8d04d43bb30f9d60bd75691e25b6e0c4444fb8139L50-R100) [[4]](diffhunk://#diff-eaa44861ecda802a0c63f4f8d04d43bb30f9d60bd75691e25b6e0c4444fb8139L169-R208) [[5]](diffhunk://#diff-eaa44861ecda802a0c63f4f8d04d43bb30f9d60bd75691e25b6e0c4444fb8139L283-R316)

**New feature: Wide Frequency Scan button and logic:**

- Added a new `wide_frequency_scan_button` option to the YAML configuration and associated logic to trigger a wide frequency scan via Home Assistant. This includes new schema entries, button handling, and component methods. (`__init__.py`, `everblu_meter.h`, `everblu_meter.cpp`) [[1]](diffhunk://#diff-68a983b3e7b176c5612b65dc28d06c0fab797bdc358b110a5531f3b9616a6e78R102) [[2]](diffhunk://#diff-68a983b3e7b176c5612b65dc28d06c0fab797bdc358b110a5531f3b9616a6e78R357-R361) [[3]](diffhunk://#diff-68a983b3e7b176c5612b65dc28d06c0fab797bdc358b110a5531f3b9616a6e78R595-R616) [[4]](diffhunk://#diff-060d1e4ce02545eb1ad93dbc97806db16f948b004c255106c7bdb6a41d502f45R49) [[5]](diffhunk://#diff-060d1e4ce02545eb1ad93dbc97806db16f948b004c255106c7bdb6a41d502f45R58) [[6]](diffhunk://#diff-060d1e4ce02545eb1ad93dbc97806db16f948b004c255106c7bdb6a41d502f45R139) [[7]](diffhunk://#diff-91a14aec921d7a34f0a80d62a751d8eee5222d035a39e9c1c06176dc837533f3L26-R28) [[8]](diffhunk://#diff-91a14aec921d7a34f0a80d62a751d8eee5222d035a39e9c1c06176dc837533f3R302-R312)

These changes collectively improve reliability, clarity, and usability for users managing multiple Everblu meters on a single radio, and provide better diagnostics and control for frequency calibration.