### PR TITLE
Suppress verbose per-attempt logging during frequency scans

### DIFF
--- a/ESPHOME-release/everblu_meter/frequency_manager.cpp
+++ b/ESPHOME-release/everblu_meter/frequency_manager.cpp
@@ -5,6 +5,7 @@
 
 #include "frequency_manager.h"
 #include "logging.h"
+#include "utils.h"
 #include "storage_abstraction.h"
 #if defined(ESP32)
 #include <esp_task_wdt.h>
@@ -147,6 +148,11 @@ void FrequencyManager::performFrequencyScan(void (*statusCallback)(const char *,
     LOG_I("everblu_meter", "Starting frequency scan...");
     LOG_I("everblu_meter", "[NOTE] Wi-Fi/MQTT connections may temporarily drop and reconnect. This is expected.");
 
+    // Suppress the verbose per-attempt radio/meter read logging for the whole
+    // scan. Each frequency step performs a full read sequence whose detailed
+    // output is irrelevant noise here; high-level scan progress (LOG_*) remains.
+    EchoDebugQuietGuard quietGuard;
+
     // Reset adaptive tracking so the new offset has a chance to stabilize
     resetAdaptiveTracking();
 
@@ -232,6 +238,11 @@ void FrequencyManager::performFrequencyScan(void (*statusCallback)(const char *,
 void FrequencyManager::performWideInitialScan(void (*statusCallback)(const char *, const char *))
 {
     Serial.println("[FREQ] Performing wide initial scan (first boot - no saved offset)...");
+
+    // Suppress the verbose per-attempt radio/meter read logging for the whole
+    // scan. Each frequency step performs a full read sequence whose detailed
+    // output is irrelevant noise here; high-level scan progress (LOG_*) remains.
+    EchoDebugQuietGuard quietGuard;
 
     // Reset adaptive tracking so the new offset has a chance to stabilize
     resetAdaptiveTracking();

--- a/ESPHOME-release/everblu_meter/utils.cpp
+++ b/ESPHOME-release/everblu_meter/utils.cpp
@@ -25,6 +25,9 @@
 
 #include <string.h>
 
+// When true, echo_debug() output is suppressed (see utils.h).
+bool g_echo_debug_quiet = false;
+
 // Consolidated hex display function with optional formatting
 // mode: 0=16 per line with newlines, 1=array format, 2=single line, 3=single line with 'S' separator
 void show_in_hex_formatted(const uint8_t *buffer, size_t len, int mode)
@@ -185,7 +188,7 @@ void printMeterDataSummary(const struct tmeter_data *meter_data, bool isMeterGas
 }
 void echo_debug(bool l_flag, const char *fmt, ...)
 {
-	if (!l_flag)
+	if (!l_flag || g_echo_debug_quiet)
 		return;
 
 	va_list args;

--- a/ESPHOME-release/everblu_meter/utils.h
+++ b/ESPHOME-release/everblu_meter/utils.h
@@ -74,6 +74,11 @@ struct EchoDebugQuietGuard
 	bool previous;
 	EchoDebugQuietGuard() : previous(g_echo_debug_quiet) { g_echo_debug_quiet = true; }
 	~EchoDebugQuietGuard() { g_echo_debug_quiet = previous; }
+
+	// Non-copyable / non-movable: copying would run the restore logic in more
+	// than one destructor and could leave g_echo_debug_quiet in the wrong state.
+	EchoDebugQuietGuard(const EchoDebugQuietGuard &) = delete;
+	EchoDebugQuietGuard &operator=(const EchoDebugQuietGuard &) = delete;
 };
 
 /**

--- a/ESPHOME-release/everblu_meter/utils.h
+++ b/ESPHOME-release/everblu_meter/utils.h
@@ -55,6 +55,28 @@ void show_in_bin(const uint8_t *buffer, size_t len);
 void echo_debug(bool l_flag, const char *fmt, ...);
 
 /**
+ * @brief When true, echo_debug() output is suppressed.
+ *
+ * Used to silence the verbose per-attempt radio/meter read sequence logging
+ * during frequency scans, where dozens of read attempts would otherwise flood
+ * the log with irrelevant detail. High-level scan progress messages use LOG_*
+ * directly and are unaffected.
+ */
+extern bool g_echo_debug_quiet;
+
+/**
+ * @brief RAII helper that suppresses echo_debug() output for the current scope.
+ *
+ * Restores the previous quiet state on destruction so nested uses are safe.
+ */
+struct EchoDebugQuietGuard
+{
+	bool previous;
+	EchoDebugQuietGuard() : previous(g_echo_debug_quiet) { g_echo_debug_quiet = true; }
+	~EchoDebugQuietGuard() { g_echo_debug_quiet = previous; }
+};
+
+/**
  * @brief Print current timestamp for debugging
  */
 void print_time(void);

--- a/extra/deploy-esphome-to-ha.ps1
+++ b/extra/deploy-esphome-to-ha.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Build the ESPHome component release and deploy it to the Home Assistant instance.
+
+.DESCRIPTION
+    1. Runs prepare-component-release.ps1 to regenerate ESPHOME-release\everblu_meter.
+    2. Mirrors the generated component to the HA external_components share.
+
+    Uses robocopy /MIR instead of Remove-Item + Copy-Item because the prepared
+    release files are marked read-only, which caused the old command to abort
+    partway and leave a partially-copied (broken) component on the share.
+
+.EXAMPLE
+    .\extra\deploy-esphome-to-ha.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Destination = '\\192.168.10.21\config\esphome\external_components\everblu_meter'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve repo root (parent of this script's folder) and work from there.
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+# 1. Regenerate the release package.
+& .\ESPHOME\prepare-component-release.ps1
+
+$source = (Resolve-Path '.\ESPHOME-release\everblu_meter').Path
+
+# 2. Clear read-only attributes on any existing deployed files so they can be replaced.
+if (Test-Path $Destination) {
+    Get-ChildItem $Destination -Recurse -File -Force | ForEach-Object { $_.IsReadOnly = $false }
+}
+
+# 3. Mirror the component to the share (adds new, overwrites changed, removes stale).
+robocopy $source $Destination /MIR /R:2 /W:1 | Out-Null
+
+# robocopy exit codes < 8 indicate success (0-7). 8+ means at least one failure.
+if ($LASTEXITCODE -ge 8) {
+    throw "robocopy failed with exit code $LASTEXITCODE"
+}
+
+$srcCount = (Get-ChildItem $source -File).Count
+$dstCount = (Get-ChildItem $Destination -File).Count
+Write-Host "Deploy complete: $dstCount/$srcCount files mirrored to $Destination" -ForegroundColor Green

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -25,6 +25,9 @@
 
 #include <string.h>
 
+// When true, echo_debug() output is suppressed (see utils.h).
+bool g_echo_debug_quiet = false;
+
 // Consolidated hex display function with optional formatting
 // mode: 0=16 per line with newlines, 1=array format, 2=single line, 3=single line with 'S' separator
 void show_in_hex_formatted(const uint8_t *buffer, size_t len, int mode)
@@ -185,7 +188,7 @@ void printMeterDataSummary(const struct tmeter_data *meter_data, bool isMeterGas
 }
 void echo_debug(bool l_flag, const char *fmt, ...)
 {
-	if (!l_flag)
+	if (!l_flag || g_echo_debug_quiet)
 		return;
 
 	va_list args;

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -74,6 +74,11 @@ struct EchoDebugQuietGuard
 	bool previous;
 	EchoDebugQuietGuard() : previous(g_echo_debug_quiet) { g_echo_debug_quiet = true; }
 	~EchoDebugQuietGuard() { g_echo_debug_quiet = previous; }
+
+	// Non-copyable / non-movable: copying would run the restore logic in more
+	// than one destructor and could leave g_echo_debug_quiet in the wrong state.
+	EchoDebugQuietGuard(const EchoDebugQuietGuard &) = delete;
+	EchoDebugQuietGuard &operator=(const EchoDebugQuietGuard &) = delete;
 };
 
 /**

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -55,6 +55,28 @@ void show_in_bin(const uint8_t *buffer, size_t len);
 void echo_debug(bool l_flag, const char *fmt, ...);
 
 /**
+ * @brief When true, echo_debug() output is suppressed.
+ *
+ * Used to silence the verbose per-attempt radio/meter read sequence logging
+ * during frequency scans, where dozens of read attempts would otherwise flood
+ * the log with irrelevant detail. High-level scan progress messages use LOG_*
+ * directly and are unaffected.
+ */
+extern bool g_echo_debug_quiet;
+
+/**
+ * @brief RAII helper that suppresses echo_debug() output for the current scope.
+ *
+ * Restores the previous quiet state on destruction so nested uses are safe.
+ */
+struct EchoDebugQuietGuard
+{
+	bool previous;
+	EchoDebugQuietGuard() : previous(g_echo_debug_quiet) { g_echo_debug_quiet = true; }
+	~EchoDebugQuietGuard() { g_echo_debug_quiet = previous; }
+};
+
+/**
  * @brief Print current timestamp for debugging
  */
 void print_time(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1639,6 +1639,12 @@ void performFrequencyScan()
 {
   Serial.println("[FREQ] Starting frequency scan...");
   Serial.println("[FREQ] [NOTE] Wi-Fi/MQTT connections may temporarily drop and reconnect while the scan is running. This is expected.");
+
+  // Suppress the verbose per-attempt radio/meter read logging for the whole
+  // scan. Each frequency step performs a full read sequence whose detailed
+  // output is irrelevant noise here; high-level scan progress messages remain.
+  EchoDebugQuietGuard quietGuard;
+
   char topicBuffer[MQTT_TOPIC_BUFFER_SIZE];
   snprintf(topicBuffer, sizeof(topicBuffer), "%s/cc1101_state", mqttBaseTopic);
   mqtt.publish(topicBuffer, "Frequency Scanning", true);
@@ -1720,6 +1726,12 @@ void performFrequencyScan()
 void performWideInitialScan()
 {
   Serial.println("[FREQ] Performing wide initial scan (first boot - no saved offset)...");
+
+  // Suppress the verbose per-attempt radio/meter read logging for the whole
+  // scan. Each frequency step performs a full read sequence whose detailed
+  // output is irrelevant noise here; high-level scan progress messages remain.
+  EchoDebugQuietGuard quietGuard;
+
   char topicBuffer[MQTT_TOPIC_BUFFER_SIZE];
   snprintf(topicBuffer, sizeof(topicBuffer), "%s/cc1101_state", mqttBaseTopic);
   mqtt.publish(topicBuffer, "Initial Frequency Scan", true);

--- a/src/services/frequency_manager.cpp
+++ b/src/services/frequency_manager.cpp
@@ -5,6 +5,7 @@
 
 #include "frequency_manager.h"
 #include "../core/logging.h"
+#include "../core/utils.h"
 #include "storage_abstraction.h"
 #if defined(ESP32)
 #include <esp_task_wdt.h>
@@ -147,6 +148,11 @@ void FrequencyManager::performFrequencyScan(void (*statusCallback)(const char *,
     LOG_I("everblu_meter", "Starting frequency scan...");
     LOG_I("everblu_meter", "[NOTE] Wi-Fi/MQTT connections may temporarily drop and reconnect. This is expected.");
 
+    // Suppress the verbose per-attempt radio/meter read logging for the whole
+    // scan. Each frequency step performs a full read sequence whose detailed
+    // output is irrelevant noise here; high-level scan progress (LOG_*) remains.
+    EchoDebugQuietGuard quietGuard;
+
     // Reset adaptive tracking so the new offset has a chance to stabilize
     resetAdaptiveTracking();
 
@@ -232,6 +238,11 @@ void FrequencyManager::performFrequencyScan(void (*statusCallback)(const char *,
 void FrequencyManager::performWideInitialScan(void (*statusCallback)(const char *, const char *))
 {
     Serial.println("[FREQ] Performing wide initial scan (first boot - no saved offset)...");
+
+    // Suppress the verbose per-attempt radio/meter read logging for the whole
+    // scan. Each frequency step performs a full read sequence whose detailed
+    // output is irrelevant noise here; high-level scan progress (LOG_*) remains.
+    EchoDebugQuietGuard quietGuard;
 
     // Reset adaptive tracking so the new offset has a chance to stabilize
     resetAdaptiveTracking();


### PR DESCRIPTION
Frequency scans invoke a full meter-read sequence at every step, flooding the log with irrelevant [METER]/[CC1101]/[RX] detail. Add a g_echo_debug_quiet flag honored by echo_debug() plus an EchoDebugQuietGuard RAII helper, and wrap the wide/narrow scan functions in both the ESPHome and standalone builds. High-level scan progress (LOG_*) remains visible.