### PR TITLE
fix(cc1101): harden GDO2 FIFO management (non-breaking follow-up to #91, v3.0.1)

### DIFF
--- a/.ci/esphome/everblu_meter/common-full.yaml
+++ b/.ci/esphome/everblu_meter/common-full.yaml
@@ -74,6 +74,8 @@ everblu_meter:
     name: "CI Reads OK"
   failed_reads:
     name: "CI Reads Fail"
+  gdo2_timeouts:
+    name: "CI GDO2 Timeouts"
   frequency_offset:
     name: "CI Freq Offset"
   tuned_frequency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Non-breaking hardening follow-up to the v3.0.0 GDO2 changes. The default and bot
 ### Added
 
 - **Stuck-GDO2 diagnostics.** When the TX interrogation-frame gate waits the full safety window with GDO2 still HIGH, the driver now logs an explicit "GDO2 still HIGH - check wiring" warning and increments a lifetime counter (`cc1101_get_gdo2_timeout_count()`), so a wiring fault is no longer silently misread as "meter asleep / out of range".
+- **Boot-time GDO2 wiring self-test.** `cc1101_init()` performs a one-time check that GDO2 reads LOW with an empty TX FIFO and HIGH once the FIFO is filled past the threshold. A failed toggle logs a warning and bumps the same diagnostic counter, so a miswired GDO2 is flagged at boot instead of only after the first failed read.
 - **ESPHome `gdo2_timeouts` diagnostic sensor** (optional) exposing that counter to Home Assistant.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 Releases are created manually by tagging commits with version tags matching `v*.*.*` (e.g., `v2.1.0`). Users should build from source and configure `private.h` with their own meter settings.
 
+## [v3.0.1] - 2026-06-26
+
+Non-breaking hardening follow-up to the v3.0.0 GDO2 changes. The default and both opt-out paths are unchanged; correctly-wired setups behave identically to v3.0.0.
+
+### Fixed
+
+- **TX FIFO overflow guard (GDO2 path).** The wake-up FIFO feed loop in `get_meter_data_for_meter()` now verifies real TX free space via `TXBYTES` before writing in GDO2 mode, matching the safety the SPI-polling fallback already had. A miswired / stuck-LOW GDO2 can no longer drive the 64-byte TX FIFO into overflow.
+
+### Added
+
+- **Stuck-GDO2 diagnostics.** When the TX interrogation-frame gate waits the full safety window with GDO2 still HIGH, the driver now logs an explicit "GDO2 still HIGH - check wiring" warning and increments a lifetime counter (`cc1101_get_gdo2_timeout_count()`), so a wiring fault is no longer silently misread as "meter asleep / out of range".
+- **ESPHome `gdo2_timeouts` diagnostic sensor** (optional) exposing that counter to Home Assistant.
+
+### Changed
+
+- **GDO2 input now uses a pull-up** (matching GDO0), so a disconnected/miswired GDO2 reads HIGH and fails loudly via the stuck-HIGH path instead of floating. ESP8266 has internal pull-ups on every GPIO except GPIO16.
+- **ESPHome config validation** now rejects setting both `gdo2_pin:` and `disable_gdo2_fifo_management: true` (previously the opt-out was silently ignored when a pin was also present).
+
 ## [v3.0.0] - 2026-06-24
 
 > **⚠️ BREAKING CHANGE** - CC1101 GDO2 hardware-assisted FIFO threshold management is now the **default** mechanism for talking to the radio on **both** the standalone (MQTT) and ESPHome targets. You must wire CC1101 GDO2 to a free GPIO and configure it, **or** explicitly opt out. Existing setups that did not wire GDO2 require migration (see below).

--- a/ESPHOME-release/everblu_meter/__init__.py
+++ b/ESPHOME-release/everblu_meter/__init__.py
@@ -94,6 +94,7 @@ CONF_RADIO_CONNECTED = "radio_connected"
 CONF_TOTAL_ATTEMPTS = "total_attempts"
 CONF_SUCCESSFUL_READS = "successful_reads"
 CONF_FAILED_READS = "failed_reads"
+CONF_GDO2_TIMEOUTS = "gdo2_timeouts"
 CONF_FREQUENCY_OFFSET = "frequency_offset"
 CONF_TUNED_FREQUENCY = "tuned_frequency"
 CONF_FREQUENCY_ESTIMATE = "frequency_estimate"
@@ -277,6 +278,12 @@ CONFIG_SCHEMA = (
                 icon="mdi:alert-circle",
                 entity_category="diagnostic",
             ),
+            cv.Optional(CONF_GDO2_TIMEOUTS): sensor.sensor_schema(
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+                icon="mdi:pulse",
+                entity_category="diagnostic",
+            ),
             cv.Optional(CONF_FREQUENCY_OFFSET): sensor.sensor_schema(
                 unit_of_measurement="kHz",
                 accuracy_decimals=3,
@@ -374,9 +381,24 @@ def validate_gdo2_required(config):
 
     GDO2 hardware-assisted FIFO management is now the default mechanism for talking to
     the CC1101. Users must wire CC1101 GDO2 to a free GPIO and set ``gdo2_pin:``, or
-    explicitly opt out with ``disable_gdo2_fifo_management: true``.
+    explicitly opt out with ``disable_gdo2_fifo_management: true``. Setting both is
+    contradictory and is rejected so the opt-out can never be silently ignored.
     """
-    if not config.get(CONF_DISABLE_GDO2, False) and CONF_GDO2_PIN not in config:
+    disabled = config.get(CONF_DISABLE_GDO2, False)
+    has_pin = CONF_GDO2_PIN in config
+    if disabled and has_pin:
+        raise cv.Invalid(
+            "'gdo2_pin:' and 'disable_gdo2_fifo_management: true' are mutually exclusive.\n"
+            "\n"
+            "  - To USE GDO2 hardware-assisted FIFO management (recommended): keep "
+            "'gdo2_pin:' and remove 'disable_gdo2_fifo_management'.\n"
+            "  - To keep the legacy SPI-polling behaviour: remove 'gdo2_pin:' and keep "
+            "'disable_gdo2_fifo_management: true'.\n"
+            "\n"
+            "See ESPHOME/README.md (Wiring) and docs/GDO2_FIFO_MANAGEMENT.md for details.",
+            path=[CONF_DISABLE_GDO2],
+        )
+    if not disabled and not has_pin:
         raise cv.Invalid(
             "BREAKING CHANGE (v3.0.0): CC1101 GDO2 hardware-assisted FIFO management is now "
             "enabled by default and 'gdo2_pin:' is required.\n"
@@ -525,6 +547,10 @@ async def to_code(config):
     if CONF_FAILED_READS in config:
         sens = await sensor.new_sensor(config[CONF_FAILED_READS])
         cg.add(var.set_failed_reads_sensor(sens))
+
+    if CONF_GDO2_TIMEOUTS in config:
+        sens = await sensor.new_sensor(config[CONF_GDO2_TIMEOUTS])
+        cg.add(var.set_gdo2_timeouts_sensor(sens))
 
     if CONF_FREQUENCY_OFFSET in config:
         sens = await sensor.new_sensor(config[CONF_FREQUENCY_OFFSET])

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1706,7 +1706,10 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
             // via TXBYTES before writing, and abort on an existing underflow.
             uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
             if (txbytes_reg & 0x80)
-              break; // TXFIFO_UNDERFLOW already occurred - loop-bottom marcstate check aborts
+            {
+              marcstate = halRfReadReg(MARCSTATE_ADDR); // refresh so the post-loop abort check/diagnostics are accurate
+              break;                                    // TXFIFO_UNDERFLOW already occurred
+            }
             if ((txbytes_reg & 0x7F) <= 56) // room for the 8-byte WUP buffer
             {
               SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -271,6 +271,18 @@ void cc1101_set_gdo2_pin(int gdo2_pin)
 #endif
 #endif
 
+// Diagnostic counter shared by both build targets: number of times the TX
+// interrogation-frame gate waited the full safety limit with GDO2 still HIGH (the FIFO
+// never reported below threshold). A non-zero, growing value almost always means GDO2
+// is miswired / on the wrong GPIO / not connected, rather than an RF/meter problem.
+// Monotonic (lifetime) counter; surfaced via cc1101_get_gdo2_timeout_count() for telemetry.
+static uint32_t _gdo2_stuck_timeouts = 0;
+
+uint32_t cc1101_get_gdo2_timeout_count(void)
+{
+  return _gdo2_stuck_timeouts;
+}
+
 // Change these define according to your ESP8266 board
 #if defined(ESP8266) && !defined(USE_ESPHOME)
 #define SPI_CSK PIN_SPI_SCK
@@ -615,8 +627,13 @@ bool cc1101_init(float freq)
   // GDO2 is optional; configure as input only when a pin is assigned.
   if (GET_GDO2_PIN() >= 0)
   {
-    pinMode(GET_GDO2_PIN(), INPUT);
-    echo_debug(debug_out, "[CC1101] GDO2 pin %d configured as TX FIFO threshold input\n", GET_GDO2_PIN());
+    // Use a pull-up (matching GDO0) so a disconnected/miswired GDO2 reads HIGH. A HIGH
+    // GDO2 means "TX FIFO at/above threshold - do not feed", which makes the fault fail
+    // loudly and quickly via the interrogation-frame gate timeout (see _gdo2_stuck_timeouts)
+    // instead of silently driving the FIFO. ESP8266 has internal pull-ups on every GPIO
+    // except GPIO16; ESP32 supports INPUT_PULLUP on all input-capable pins.
+    pinMode(GET_GDO2_PIN(), INPUT_PULLUP);
+    echo_debug(debug_out, "[CC1101] GDO2 pin %d configured as FIFO threshold input (pull-up)\n", GET_GDO2_PIN());
   }
 
   // Initialize SPI transport for CC1101 communication.
@@ -1647,8 +1664,19 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
           // a real-time hardware signal, preventing underflows under ESPHome scheduler load.
           if (digitalRead(GET_GDO2_PIN()) == LOW)
           {
-            SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
-            wup2send--;
+            // Safety guard: GDO2 LOW should mean the FIFO is below threshold (>= 40 free
+            // bytes). A miswired / stuck-LOW GDO2 would otherwise let this loop write
+            // unconditionally and overflow the 64-byte TX FIFO. Confirm real free space
+            // via TXBYTES before writing, and abort on an existing underflow.
+            uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
+            if (txbytes_reg & 0x80)
+              break; // TXFIFO_UNDERFLOW already occurred - loop-bottom marcstate check aborts
+            if ((txbytes_reg & 0x7F) <= 56) // room for the 8-byte WUP buffer
+            {
+              SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+              wup2send--;
+            }
+            // else: GDO2 claims below-threshold but FIFO is nearly full (stuck-LOW miswire) - skip
           }
           // else: FIFO still above threshold - skip write this iteration
         }
@@ -1694,6 +1722,16 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
         }
         // Confirm GDO2 is actually LOW (FIFO drained), not merely timed out with FIFO still full.
         fifo_ready = (digitalRead(GET_GDO2_PIN()) == LOW);
+        if (!fifo_ready && wait_count >= 100)
+        {
+          // GDO2 never went LOW within the safety window. With FIFOTHR_FIFO_THR_25_40 the
+          // FIFO drains in well under 500ms, so a persistent HIGH almost always means GDO2
+          // is miswired / on the wrong GPIO / not connected. Warn loudly and count it so a
+          // wiring fault is not silently misread as "meter asleep / out of range".
+          _gdo2_stuck_timeouts++;
+          echo_debug(1, "[CC1101] WARNING: GDO2 still HIGH after 500ms (TXBYTES=%u, count=%u) - check GDO2 wiring/pin or set the opt-out (DISABLE_GDO2_FIFO_MANAGEMENT / disable_gdo2_fifo_management)\n",
+                     txbytes_reg & 0x7F, _gdo2_stuck_timeouts);
+        }
       }
       else
       {

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -679,6 +679,42 @@ bool cc1101_init(float freq)
 
   echo_debug(debug_out, "[CC1101] Frequency synthesizer calibrated for %.6f MHz\n", freq);
 
+  // One-time GDO2 wiring self-test. With IOCFG2 in TX-FIFO-threshold mode (0x02, set by
+  // cc1101_configureRF_0) GDO2 must read LOW with an empty TX FIFO and HIGH once the FIFO
+  // is filled past the 25-byte threshold. If it does not toggle across that known
+  // transition, GDO2 is almost certainly miswired / on the wrong GPIO / not connected.
+  // Runs once per boot (skipped on the repeated cc1101_init() calls made by frequency
+  // scans). A failure increments the same diagnostic counter as the runtime stuck-HIGH
+  // detection, so the fault surfaces in telemetry from boot without waiting for a read.
+  if (GET_GDO2_PIN() >= 0)
+  {
+    static bool s_gdo2_selftest_done = false;
+    if (!s_gdo2_selftest_done)
+    {
+      s_gdo2_selftest_done = true;
+      halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR); // ensure GDO2 = TX FIFO threshold signal
+      CC1101_CMD(SFTX);                          // empty TX FIFO -> GDO2 expected LOW
+      delayMicroseconds(50);
+      bool low_when_empty = (digitalRead(GET_GDO2_PIN()) == LOW);
+      uint8_t selftest_buf[40] = {0};            // > 25-byte threshold -> GDO2 expected HIGH
+      SPIWriteBurstReg(TX_FIFO_ADDR, selftest_buf, sizeof(selftest_buf));
+      delayMicroseconds(50);
+      bool high_when_filled = (digitalRead(GET_GDO2_PIN()) == HIGH);
+      CC1101_CMD(SFTX);                          // restore empty FIFO for normal operation
+      if (low_when_empty && high_when_filled)
+      {
+        echo_debug(debug_out, "[CC1101] GDO2 self-test passed (LOW when empty / HIGH when filled)\n");
+      }
+      else
+      {
+        _gdo2_stuck_timeouts++;
+        LOG_W("everblu_meter",
+              "GDO2 self-test FAILED (empty read=%s, filled read=%s; expected LOW then HIGH) - check GDO2 wiring/pin. Reads may fail until fixed; opt out via DISABLE_GDO2_FIFO_MANAGEMENT / disable_gdo2_fifo_management to use legacy SPI polling.",
+              low_when_empty ? "LOW" : "HIGH", high_when_filled ? "HIGH" : "LOW");
+      }
+    }
+  }
+
   // Put radio into RX listening mode so it can receive meter data
   cc1101_rec_mode();
 

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -55,12 +55,15 @@ void cc1101_set_gdo2_pin(int gdo2_pin);
 #endif
 
 /**
- * @brief Number of GDO2 "stuck HIGH" timeouts observed during transmit.
+ * @brief Number of GDO2 FIFO-threshold faults observed (stuck-HIGH timeouts + failed self-test).
  *
- * Lifetime (monotonic) diagnostic counter. The TX interrogation-frame gate waits for
- * GDO2 to indicate the FIFO has drained below threshold; if it never does within the
- * safety window the counter increments. A non-zero, growing value strongly indicates a
- * miswired / wrong-GPIO / disconnected GDO2 rather than an RF or meter problem.
+ * Lifetime (monotonic) diagnostic counter incremented from two sources:
+ *   - the boot-time GDO2 wiring self-test in cc1101_init() when GDO2 does not toggle
+ *     LOW->HIGH across a known empty->filled TX FIFO transition; and
+ *   - the runtime TX interrogation-frame gate, when GDO2 never indicates the FIFO has
+ *     drained below threshold within the safety window.
+ * A non-zero, growing value strongly indicates a miswired / wrong-GPIO / disconnected
+ * GDO2 rather than an RF or meter problem.
  *
  * @return Cumulative count since boot. Always 0 when GDO2 is not configured.
  */

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -55,6 +55,18 @@ void cc1101_set_gdo2_pin(int gdo2_pin);
 #endif
 
 /**
+ * @brief Number of GDO2 "stuck HIGH" timeouts observed during transmit.
+ *
+ * Lifetime (monotonic) diagnostic counter. The TX interrogation-frame gate waits for
+ * GDO2 to indicate the FIFO has drained below threshold; if it never does within the
+ * safety window the counter increments. A non-zero, growing value strongly indicates a
+ * miswired / wrong-GPIO / disconnected GDO2 rather than an RF or meter problem.
+ *
+ * @return Cumulative count since boot. Always 0 when GDO2 is not configured.
+ */
+uint32_t cc1101_get_gdo2_timeout_count(void);
+
+/**
  * @struct tmeter_data
  * @brief Meter data structure containing current readings and metadata
  *

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -275,6 +275,16 @@ void EverbluMeterComponent::loop() {
 
     this->meter_reader_->loop();
   }
+
+  // Publish the GDO2 stuck-timeout diagnostic only when it changes. A rising value
+  // indicates a miswired / disconnected GDO2 rather than an RF/meter problem.
+  if (this->gdo2_timeouts_sensor_ != nullptr) {
+    uint32_t timeouts = cc1101_get_gdo2_timeout_count();
+    if (timeouts != this->last_gdo2_timeouts_published_) {
+      this->last_gdo2_timeouts_published_ = timeouts;
+      this->gdo2_timeouts_sensor_->publish_state(static_cast<float>(timeouts));
+    }
+  }
 }
 
 void EverbluMeterComponent::request_manual_read() {

--- a/ESPHOME-release/everblu_meter/everblu_meter.h
+++ b/ESPHOME-release/everblu_meter/everblu_meter.h
@@ -115,6 +115,7 @@ class EverbluMeterComponent final : public PollingComponent,
   void set_total_attempts_sensor(sensor::Sensor *sensor) { this->total_attempts_sensor_ = sensor; }
   void set_successful_reads_sensor(sensor::Sensor *sensor) { this->successful_reads_sensor_ = sensor; }
   void set_failed_reads_sensor(sensor::Sensor *sensor) { this->failed_reads_sensor_ = sensor; }
+  void set_gdo2_timeouts_sensor(sensor::Sensor *sensor) { this->gdo2_timeouts_sensor_ = sensor; }
   void set_frequency_offset_sensor(sensor::Sensor *sensor) { this->frequency_offset_sensor_ = sensor; }
   void set_tuned_frequency_sensor(sensor::Sensor *sensor) { this->tuned_frequency_sensor_ = sensor; }
   void set_frequency_estimate_sensor(sensor::Sensor *sensor) { this->frequency_estimate_sensor_ = sensor; }
@@ -184,6 +185,8 @@ class EverbluMeterComponent final : public PollingComponent,
   sensor::Sensor *total_attempts_sensor_{nullptr};
   sensor::Sensor *successful_reads_sensor_{nullptr};
   sensor::Sensor *failed_reads_sensor_{nullptr};
+  sensor::Sensor *gdo2_timeouts_sensor_{nullptr};
+  uint32_t last_gdo2_timeouts_published_{0xFFFFFFFFu};  // sentinel: force first publish
   sensor::Sensor *frequency_offset_sensor_{nullptr};
   sensor::Sensor *tuned_frequency_sensor_{nullptr};
   sensor::Sensor *frequency_estimate_sensor_{nullptr};

--- a/ESPHOME-release/everblu_meter/version.h
+++ b/ESPHOME-release/everblu_meter/version.h
@@ -6,5 +6,5 @@
  */
 
 #ifndef EVERBLU_FW_VERSION
-#define EVERBLU_FW_VERSION "3.0.0"
+#define EVERBLU_FW_VERSION "3.0.1"
 #endif

--- a/ESPHOME/components/everblu_meter/__init__.py
+++ b/ESPHOME/components/everblu_meter/__init__.py
@@ -94,6 +94,7 @@ CONF_RADIO_CONNECTED = "radio_connected"
 CONF_TOTAL_ATTEMPTS = "total_attempts"
 CONF_SUCCESSFUL_READS = "successful_reads"
 CONF_FAILED_READS = "failed_reads"
+CONF_GDO2_TIMEOUTS = "gdo2_timeouts"
 CONF_FREQUENCY_OFFSET = "frequency_offset"
 CONF_TUNED_FREQUENCY = "tuned_frequency"
 CONF_FREQUENCY_ESTIMATE = "frequency_estimate"
@@ -277,6 +278,12 @@ CONFIG_SCHEMA = (
                 icon="mdi:alert-circle",
                 entity_category="diagnostic",
             ),
+            cv.Optional(CONF_GDO2_TIMEOUTS): sensor.sensor_schema(
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+                icon="mdi:pulse",
+                entity_category="diagnostic",
+            ),
             cv.Optional(CONF_FREQUENCY_OFFSET): sensor.sensor_schema(
                 unit_of_measurement="kHz",
                 accuracy_decimals=3,
@@ -374,9 +381,24 @@ def validate_gdo2_required(config):
 
     GDO2 hardware-assisted FIFO management is now the default mechanism for talking to
     the CC1101. Users must wire CC1101 GDO2 to a free GPIO and set ``gdo2_pin:``, or
-    explicitly opt out with ``disable_gdo2_fifo_management: true``.
+    explicitly opt out with ``disable_gdo2_fifo_management: true``. Setting both is
+    contradictory and is rejected so the opt-out can never be silently ignored.
     """
-    if not config.get(CONF_DISABLE_GDO2, False) and CONF_GDO2_PIN not in config:
+    disabled = config.get(CONF_DISABLE_GDO2, False)
+    has_pin = CONF_GDO2_PIN in config
+    if disabled and has_pin:
+        raise cv.Invalid(
+            "'gdo2_pin:' and 'disable_gdo2_fifo_management: true' are mutually exclusive.\n"
+            "\n"
+            "  - To USE GDO2 hardware-assisted FIFO management (recommended): keep "
+            "'gdo2_pin:' and remove 'disable_gdo2_fifo_management'.\n"
+            "  - To keep the legacy SPI-polling behaviour: remove 'gdo2_pin:' and keep "
+            "'disable_gdo2_fifo_management: true'.\n"
+            "\n"
+            "See ESPHOME/README.md (Wiring) and docs/GDO2_FIFO_MANAGEMENT.md for details.",
+            path=[CONF_DISABLE_GDO2],
+        )
+    if not disabled and not has_pin:
         raise cv.Invalid(
             "BREAKING CHANGE (v3.0.0): CC1101 GDO2 hardware-assisted FIFO management is now "
             "enabled by default and 'gdo2_pin:' is required.\n"
@@ -525,6 +547,10 @@ async def to_code(config):
     if CONF_FAILED_READS in config:
         sens = await sensor.new_sensor(config[CONF_FAILED_READS])
         cg.add(var.set_failed_reads_sensor(sens))
+
+    if CONF_GDO2_TIMEOUTS in config:
+        sens = await sensor.new_sensor(config[CONF_GDO2_TIMEOUTS])
+        cg.add(var.set_gdo2_timeouts_sensor(sens))
 
     if CONF_FREQUENCY_OFFSET in config:
         sens = await sensor.new_sensor(config[CONF_FREQUENCY_OFFSET])

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -275,6 +275,16 @@ void EverbluMeterComponent::loop() {
 
     this->meter_reader_->loop();
   }
+
+  // Publish the GDO2 stuck-timeout diagnostic only when it changes. A rising value
+  // indicates a miswired / disconnected GDO2 rather than an RF/meter problem.
+  if (this->gdo2_timeouts_sensor_ != nullptr) {
+    uint32_t timeouts = cc1101_get_gdo2_timeout_count();
+    if (timeouts != this->last_gdo2_timeouts_published_) {
+      this->last_gdo2_timeouts_published_ = timeouts;
+      this->gdo2_timeouts_sensor_->publish_state(static_cast<float>(timeouts));
+    }
+  }
 }
 
 void EverbluMeterComponent::request_manual_read() {

--- a/ESPHOME/components/everblu_meter/everblu_meter.h
+++ b/ESPHOME/components/everblu_meter/everblu_meter.h
@@ -115,6 +115,7 @@ class EverbluMeterComponent final : public PollingComponent,
   void set_total_attempts_sensor(sensor::Sensor *sensor) { this->total_attempts_sensor_ = sensor; }
   void set_successful_reads_sensor(sensor::Sensor *sensor) { this->successful_reads_sensor_ = sensor; }
   void set_failed_reads_sensor(sensor::Sensor *sensor) { this->failed_reads_sensor_ = sensor; }
+  void set_gdo2_timeouts_sensor(sensor::Sensor *sensor) { this->gdo2_timeouts_sensor_ = sensor; }
   void set_frequency_offset_sensor(sensor::Sensor *sensor) { this->frequency_offset_sensor_ = sensor; }
   void set_tuned_frequency_sensor(sensor::Sensor *sensor) { this->tuned_frequency_sensor_ = sensor; }
   void set_frequency_estimate_sensor(sensor::Sensor *sensor) { this->frequency_estimate_sensor_ = sensor; }
@@ -184,6 +185,8 @@ class EverbluMeterComponent final : public PollingComponent,
   sensor::Sensor *total_attempts_sensor_{nullptr};
   sensor::Sensor *successful_reads_sensor_{nullptr};
   sensor::Sensor *failed_reads_sensor_{nullptr};
+  sensor::Sensor *gdo2_timeouts_sensor_{nullptr};
+  uint32_t last_gdo2_timeouts_published_{0xFFFFFFFFu};  // sentinel: force first publish
   sensor::Sensor *frequency_offset_sensor_{nullptr};
   sensor::Sensor *tuned_frequency_sensor_{nullptr};
   sensor::Sensor *frequency_estimate_sensor_{nullptr};

--- a/ESPHOME/example-advanced.yaml
+++ b/ESPHOME/example-advanced.yaml
@@ -171,6 +171,10 @@ everblu_meter:
   failed_reads:
     name: "Failed Reads"
 
+  # Rising only when GDO2 is miswired/disconnected; stays 0 on healthy wiring
+  gdo2_timeouts:
+    name: "GDO2 Timeouts"
+
   frequency_offset:
     name: "Frequency Offset"
 

--- a/include/private.example.h
+++ b/include/private.example.h
@@ -183,6 +183,10 @@
 //   ESP8266 SPI bus: GPIO12 (D6)=MISO, GPIO13 (D7)=MOSI, GPIO14 (D5)=SCK, GPIO15 (D8)=CS
 // ESP8266 example: GPIO4 (D2) when GDO0 uses GPIO5 (D1), or GPIO5 (D1) when GDO0 uses GPIO4
 // ESP32 example:   GPIO27, GPIO26
+//
+// The pin is configured as INPUT_PULLUP, so a disconnected/miswired GDO2 reads HIGH and
+// fails loudly (watch for a "GDO2 still HIGH - check wiring" warning) instead of floating.
+// Prefer a GPIO with a usable internal pull-up: on ESP8266 every GPIO except GPIO16 has one.
 #define GDO2 4
 //
 // To OPT OUT and keep the legacy SPI-polling behaviour, comment out the #define GDO2 line

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1706,7 +1706,10 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
             // via TXBYTES before writing, and abort on an existing underflow.
             uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
             if (txbytes_reg & 0x80)
-              break; // TXFIFO_UNDERFLOW already occurred - loop-bottom marcstate check aborts
+            {
+              marcstate = halRfReadReg(MARCSTATE_ADDR); // refresh so the post-loop abort check/diagnostics are accurate
+              break;                                    // TXFIFO_UNDERFLOW already occurred
+            }
             if ((txbytes_reg & 0x7F) <= 56) // room for the 8-byte WUP buffer
             {
               SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -271,6 +271,18 @@ void cc1101_set_gdo2_pin(int gdo2_pin)
 #endif
 #endif
 
+// Diagnostic counter shared by both build targets: number of times the TX
+// interrogation-frame gate waited the full safety limit with GDO2 still HIGH (the FIFO
+// never reported below threshold). A non-zero, growing value almost always means GDO2
+// is miswired / on the wrong GPIO / not connected, rather than an RF/meter problem.
+// Monotonic (lifetime) counter; surfaced via cc1101_get_gdo2_timeout_count() for telemetry.
+static uint32_t _gdo2_stuck_timeouts = 0;
+
+uint32_t cc1101_get_gdo2_timeout_count(void)
+{
+  return _gdo2_stuck_timeouts;
+}
+
 // Change these define according to your ESP8266 board
 #if defined(ESP8266) && !defined(USE_ESPHOME)
 #define SPI_CSK PIN_SPI_SCK
@@ -615,8 +627,13 @@ bool cc1101_init(float freq)
   // GDO2 is optional; configure as input only when a pin is assigned.
   if (GET_GDO2_PIN() >= 0)
   {
-    pinMode(GET_GDO2_PIN(), INPUT);
-    echo_debug(debug_out, "[CC1101] GDO2 pin %d configured as TX FIFO threshold input\n", GET_GDO2_PIN());
+    // Use a pull-up (matching GDO0) so a disconnected/miswired GDO2 reads HIGH. A HIGH
+    // GDO2 means "TX FIFO at/above threshold - do not feed", which makes the fault fail
+    // loudly and quickly via the interrogation-frame gate timeout (see _gdo2_stuck_timeouts)
+    // instead of silently driving the FIFO. ESP8266 has internal pull-ups on every GPIO
+    // except GPIO16; ESP32 supports INPUT_PULLUP on all input-capable pins.
+    pinMode(GET_GDO2_PIN(), INPUT_PULLUP);
+    echo_debug(debug_out, "[CC1101] GDO2 pin %d configured as FIFO threshold input (pull-up)\n", GET_GDO2_PIN());
   }
 
   // Initialize SPI transport for CC1101 communication.
@@ -1647,8 +1664,19 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
           // a real-time hardware signal, preventing underflows under ESPHome scheduler load.
           if (digitalRead(GET_GDO2_PIN()) == LOW)
           {
-            SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
-            wup2send--;
+            // Safety guard: GDO2 LOW should mean the FIFO is below threshold (>= 40 free
+            // bytes). A miswired / stuck-LOW GDO2 would otherwise let this loop write
+            // unconditionally and overflow the 64-byte TX FIFO. Confirm real free space
+            // via TXBYTES before writing, and abort on an existing underflow.
+            uint8_t txbytes_reg = halRfReadReg(TXBYTES_ADDR);
+            if (txbytes_reg & 0x80)
+              break; // TXFIFO_UNDERFLOW already occurred - loop-bottom marcstate check aborts
+            if ((txbytes_reg & 0x7F) <= 56) // room for the 8-byte WUP buffer
+            {
+              SPIWriteBurstReg(TX_FIFO_ADDR, wupbuffer, 8);
+              wup2send--;
+            }
+            // else: GDO2 claims below-threshold but FIFO is nearly full (stuck-LOW miswire) - skip
           }
           // else: FIFO still above threshold - skip write this iteration
         }
@@ -1694,6 +1722,16 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
         }
         // Confirm GDO2 is actually LOW (FIFO drained), not merely timed out with FIFO still full.
         fifo_ready = (digitalRead(GET_GDO2_PIN()) == LOW);
+        if (!fifo_ready && wait_count >= 100)
+        {
+          // GDO2 never went LOW within the safety window. With FIFOTHR_FIFO_THR_25_40 the
+          // FIFO drains in well under 500ms, so a persistent HIGH almost always means GDO2
+          // is miswired / on the wrong GPIO / not connected. Warn loudly and count it so a
+          // wiring fault is not silently misread as "meter asleep / out of range".
+          _gdo2_stuck_timeouts++;
+          echo_debug(1, "[CC1101] WARNING: GDO2 still HIGH after 500ms (TXBYTES=%u, count=%u) - check GDO2 wiring/pin or set the opt-out (DISABLE_GDO2_FIFO_MANAGEMENT / disable_gdo2_fifo_management)\n",
+                     txbytes_reg & 0x7F, _gdo2_stuck_timeouts);
+        }
       }
       else
       {

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -679,6 +679,42 @@ bool cc1101_init(float freq)
 
   echo_debug(debug_out, "[CC1101] Frequency synthesizer calibrated for %.6f MHz\n", freq);
 
+  // One-time GDO2 wiring self-test. With IOCFG2 in TX-FIFO-threshold mode (0x02, set by
+  // cc1101_configureRF_0) GDO2 must read LOW with an empty TX FIFO and HIGH once the FIFO
+  // is filled past the 25-byte threshold. If it does not toggle across that known
+  // transition, GDO2 is almost certainly miswired / on the wrong GPIO / not connected.
+  // Runs once per boot (skipped on the repeated cc1101_init() calls made by frequency
+  // scans). A failure increments the same diagnostic counter as the runtime stuck-HIGH
+  // detection, so the fault surfaces in telemetry from boot without waiting for a read.
+  if (GET_GDO2_PIN() >= 0)
+  {
+    static bool s_gdo2_selftest_done = false;
+    if (!s_gdo2_selftest_done)
+    {
+      s_gdo2_selftest_done = true;
+      halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR); // ensure GDO2 = TX FIFO threshold signal
+      CC1101_CMD(SFTX);                          // empty TX FIFO -> GDO2 expected LOW
+      delayMicroseconds(50);
+      bool low_when_empty = (digitalRead(GET_GDO2_PIN()) == LOW);
+      uint8_t selftest_buf[40] = {0};            // > 25-byte threshold -> GDO2 expected HIGH
+      SPIWriteBurstReg(TX_FIFO_ADDR, selftest_buf, sizeof(selftest_buf));
+      delayMicroseconds(50);
+      bool high_when_filled = (digitalRead(GET_GDO2_PIN()) == HIGH);
+      CC1101_CMD(SFTX);                          // restore empty FIFO for normal operation
+      if (low_when_empty && high_when_filled)
+      {
+        echo_debug(debug_out, "[CC1101] GDO2 self-test passed (LOW when empty / HIGH when filled)\n");
+      }
+      else
+      {
+        _gdo2_stuck_timeouts++;
+        LOG_W("everblu_meter",
+              "GDO2 self-test FAILED (empty read=%s, filled read=%s; expected LOW then HIGH) - check GDO2 wiring/pin. Reads may fail until fixed; opt out via DISABLE_GDO2_FIFO_MANAGEMENT / disable_gdo2_fifo_management to use legacy SPI polling.",
+              low_when_empty ? "LOW" : "HIGH", high_when_filled ? "HIGH" : "LOW");
+      }
+    }
+  }
+
   // Put radio into RX listening mode so it can receive meter data
   cc1101_rec_mode();
 

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -55,12 +55,15 @@ void cc1101_set_gdo2_pin(int gdo2_pin);
 #endif
 
 /**
- * @brief Number of GDO2 "stuck HIGH" timeouts observed during transmit.
+ * @brief Number of GDO2 FIFO-threshold faults observed (stuck-HIGH timeouts + failed self-test).
  *
- * Lifetime (monotonic) diagnostic counter. The TX interrogation-frame gate waits for
- * GDO2 to indicate the FIFO has drained below threshold; if it never does within the
- * safety window the counter increments. A non-zero, growing value strongly indicates a
- * miswired / wrong-GPIO / disconnected GDO2 rather than an RF or meter problem.
+ * Lifetime (monotonic) diagnostic counter incremented from two sources:
+ *   - the boot-time GDO2 wiring self-test in cc1101_init() when GDO2 does not toggle
+ *     LOW->HIGH across a known empty->filled TX FIFO transition; and
+ *   - the runtime TX interrogation-frame gate, when GDO2 never indicates the FIFO has
+ *     drained below threshold within the safety window.
+ * A non-zero, growing value strongly indicates a miswired / wrong-GPIO / disconnected
+ * GDO2 rather than an RF or meter problem.
  *
  * @return Cumulative count since boot. Always 0 when GDO2 is not configured.
  */

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -55,6 +55,18 @@ void cc1101_set_gdo2_pin(int gdo2_pin);
 #endif
 
 /**
+ * @brief Number of GDO2 "stuck HIGH" timeouts observed during transmit.
+ *
+ * Lifetime (monotonic) diagnostic counter. The TX interrogation-frame gate waits for
+ * GDO2 to indicate the FIFO has drained below threshold; if it never does within the
+ * safety window the counter increments. A non-zero, growing value strongly indicates a
+ * miswired / wrong-GPIO / disconnected GDO2 rather than an RF or meter problem.
+ *
+ * @return Cumulative count since boot. Always 0 when GDO2 is not configured.
+ */
+uint32_t cc1101_get_gdo2_timeout_count(void);
+
+/**
  * @struct tmeter_data
  * @brief Meter data structure containing current readings and metadata
  *

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -6,5 +6,5 @@
  */
 
 #ifndef EVERBLU_FW_VERSION
-#define EVERBLU_FW_VERSION "3.0.0"
+#define EVERBLU_FW_VERSION "3.0.1"
 #endif


### PR DESCRIPTION
## Summary

Non-breaking hardening follow-up to #91 (v3.0.0, which made CC1101 **GDO2** hardware-assisted FIFO management the default). This PR makes the GDO2 path robust against miswiring and intermittent signals, and closes an MQTTâ†”ESPHome opt-out parity gap.

**No breaking changes:** GDO2 stays the default, both opt-out paths are unchanged, and correctly-wired setups behave identically to v3.0.0. Ships as **v3.0.1**.

## Why

The v3.0.0 GDO2 fast paths trusted `digitalRead(GDO2)` without the miswire/overflow safety net that the SPI-polling fallback already had. The most likely new user error introduced by the breaking change â€” wiring GDO2 to the wrong/loose GPIO â€” could either overflow the TX FIFO (stuck-LOW) or silently fail every read and look like "meter asleep" (stuck-HIGH).

## Changes

### Fixed
- **TX FIFO overflow guard (HIGH).** The wake-up FIFO feed loop in `get_meter_data_for_meter()` now verifies real TX free space via `TXBYTES` before writing in GDO2 mode (and aborts on an existing underflow), matching the safety the SPI-polling fallback already had. A miswired / stuck-LOW GDO2 can no longer drive the 64-byte TX FIFO into overflow.

### Added
- **Boot-time GDO2 wiring self-test (MEDIUM).** `cc1101_init()` runs a one-time check that GDO2 reads LOW with an empty TX FIFO and HIGH once the FIFO is filled past the threshold. A failed toggle logs a warning and increments the diagnostic counter, so a miswired/disconnected GDO2 is flagged at boot instead of only after the first failed read. Runs once per boot (skipped on the repeated `cc1101_init()` calls made by frequency scans).
- **Stuck-GDO2 runtime diagnostics (HIGH).** When the TX interrogation-frame gate waits the full safety window with GDO2 still HIGH, the driver logs an explicit `GDO2 still HIGH â€¦ check wiring` warning and increments a lifetime counter (`cc1101_get_gdo2_timeout_count()`), so a wiring fault is no longer silently misread as "meter asleep / out of range". (Warn + counter only â€” no runtime behavior change.)
- **ESPHome `gdo2_timeouts` diagnostic sensor (optional)** exposing that counter to Home Assistant (wired into the advanced example and the CI full fixture). The boot self-test feeds the same counter, so the sensor flags a miswire from boot.

### Changed
- **GDO2 input now uses `INPUT_PULLUP`** (matching GDO0), so a disconnected/miswired GDO2 reads HIGH and fails loudly via the stuck-HIGH path instead of floating. ESP8266 has internal pull-ups on every GPIO except GPIO16.
- **ESPHome config validation** now rejects setting both `gdo2_pin:` and `disable_gdo2_fifo_management: true` (previously the opt-out was silently ignored when a pin was also present). MQTT precedence is unchanged.

## Files
- `src/core/cc1101.cpp` / `cc1101.h` â€” TX overflow guard, boot-time GDO2 self-test, stuck-HIGH warning + counter, `INPUT_PULLUP`, `cc1101_get_gdo2_timeout_count()` (defined for both targets, outside the `USE_ESPHOME` guard).
- `ESPHOME/components/everblu_meter/__init__.py` â€” mutually-exclusive validation, `gdo2_timeouts` sensor schema + codegen.
- `ESPHOME/components/everblu_meter/everblu_meter.{h,cpp}` â€” sensor member/setter, publish-on-change in `loop()`.
- `include/private.example.h` â€” pull-up wiring note.
- `ESPHOME/example-advanced.yaml`, `.ci/esphome/everblu_meter/common-full.yaml` â€” new sensor coverage.
- `CHANGELOG.md`, `src/core/version.h` â€” v3.0.1.
- `ESPHOME-release/` â€” regenerated via `prepare-component-release.ps1` (generated output, do not hand-edit).

## Validation
- ESP8266 `pio run -e huzzah` builds clean (real compile of `cc1101.cpp`).
- ESPHome legacy opt-out fixture (`test.esp8266-legacy-gdo2.yaml`, opt-out only, no pin) still passes the updated validator.
- Language-server error check clean on all edited C++ files.

## Checklist
- [x] Happy-path GDO2 behavior unchanged vs v3.0.0
- [x] TX overflow guard added to the GDO2 WUP feed path
- [x] Boot-time GDO2 self-test flags miswiring at init
- [x] Stuck-HIGH GDO2 logs a wiring warning + increments `gdo2_timeouts`
- [x] ESPHome rejects `gdo2_pin` + `disable_gdo2_fifo_management` together
- [x] Opt-out paths (MQTT/ESPHome) compile & validate unchanged
- [x] ESP8266 build green; `ESPHOME-release/` regenerated
- [ ] On-hardware confirmation of self-test + stuck-pin warning + overflow guard (reviewer, optional)

Refs #91, #83, #84.
