### PR TITLE
Run ESPHome CI on shared-source changes (fix trigger gap)

### DIFF
--- a/.github/prompts/review-code.prompt.md
+++ b/.github/prompts/review-code.prompt.md
@@ -50,7 +50,6 @@ Provide feedback as:
 
 For each issue:
 
-
 - Specific line references
 - Clear explanation of the problem
 - Suggested solution with code example

--- a/.github/prompts/review-code.prompt.md
+++ b/.github/prompts/review-code.prompt.md
@@ -3,6 +3,8 @@ agent: 'agent'
 description: 'Perform a comprehensive code review'
 ---
 
+# Code Review
+
 ## Role
 
 You're a senior software engineer conducting a thorough code review. Provide constructive, actionable feedback.

--- a/.github/workflows/esphome-external-component.yml
+++ b/.github/workflows/esphome-external-component.yml
@@ -9,6 +9,15 @@ on:
       - ESPHOME/example-*.yaml
       - ESPHOME/README.md
       - .github/workflows/esphome-external-component.yml
+      # Shared source: the ESPHome component compiles the src/ tree (via the
+      # flattened ESPHOME-release/ bundle and component includes), so changes
+      # there must trigger this job too - otherwise a shared-source change that
+      # breaks only the ESPHome build (e.g. an ESPHome-only logging path) slips
+      # through because the ESP8266/ESP32 build jobs compile only the MQTT firmware.
+      - src/**
+      - include/**
+      - platformio.ini
+      - ESPHOME-release/**
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
@@ -17,6 +26,11 @@ on:
       - ESPHOME/example-*.yaml
       - ESPHOME/README.md
       - .github/workflows/esphome-external-component.yml
+      # Shared source (see the push trigger above for the rationale).
+      - src/**
+      - include/**
+      - platformio.ini
+      - ESPHOME-release/**
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

The **ESPHome External Component Integration** workflow only triggered on changes under `ESPHOME/`, `.ci/esphome/`, or its own workflow file — it did **not** include `src/**`, `include/**`, `platformio.ini`, or `ESPHOME-release/**`.

But the ESPHome component compiles the shared `src/` tree (via the flattened `ESPHOME-release/` bundle and component includes). So a shared-source change that breaks **only** the ESPHome build slips straight through CI: the ESP8266/ESP32 build jobs *do* fire on `src/**`, but they compile only the MQTT firmware and don't exercise the ESPHome code paths.

This exact gap let a real regression reach `develop` undetected — `TS_PRINTLN`/`TS_PRINTF` were defined only in the MQTT branch of `src/core/logging.h`, so shared files failed to compile for ESPHome, but no ESPHome CI job ran because the change touched only `src/**`.

## Change

Add the shared-source paths to both the `push` and `pull_request` `paths:` filters of `.github/workflows/esphome-external-component.yml`:

```yaml
- src/**
- include/**
- platformio.ini
- ESPHOME-release/**
```

Now any change to shared source runs the ESPHome compile fixtures pre-merge, catching this class of regression before it lands.

## Verification

- Workflow YAML parses cleanly (`yaml.safe_load`).
- No behavioural change to the jobs themselves — only the trigger `paths:` were widened.