### PR TITLE
ci: add CodeQL security scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: "CodeQL"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 18 * * 4" # Thursday 18:30 UTC
+  push:
+    branches: [main, develop]
+
+# Deny by default; the analyze job opts in to exactly what it needs.
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload CodeQL SARIF results to the Code Scanning API
+      packages: read          # fetch internal or private CodeQL query packs
+      actions: read           # required by codeql-action when run from a private repo
+      contents: read          # actions/checkout to scan the repository
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          # C/C++ analysis requires a full toolchain build via PlatformIO.
+          # Uncomment and configure the manual build step below to enable it.
+          # - language: c-cpp
+          #   build-mode: manual
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # If you enable c-cpp above, replace this step with the PlatformIO build:
+      # - name: Build C/C++ for CodeQL
+      #   if: matrix.build-mode == 'manual'
+      #   run: |
+      #     pip install platformio
+      #     cp include/private.example.h include/private.h
+      #     sed -i 's/#define METER_CODE "xx-xxxxxxx-xxx"/#define METER_CODE "99-1234567-000"/g' include/private.h
+      #     pio run -e huzzah
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/matchers/gcc.json
+++ b/.github/workflows/matchers/gcc.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "gcc",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^src/(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds GitHub's CodeQL security scanning to the repository, targeting `main` so it's active immediately.

## Changes

- **`.github/workflows/codeql.yml`** — scans Python code on a weekly schedule (Thursday 18:30 UTC) and on every push to `main`/`develop`. Uses `build-mode: none` for Python (no build step required). C/C++ scanning is included as commented-out instructions for when PlatformIO build wiring is added.
- **`.github/workflows/matchers/gcc.json`** — GCC problem matcher (from ESPHome's CI) that surfaces compiler warnings as inline annotations in the PR diff view.

## Notes

CodeQL results appear under the **Security → Code scanning** tab once the first scan completes. Results are also shown as inline annotations on PRs.