### PR TITLE
Omit oldest monthly_usage entry and share history publishing

### DIFF
--- a/ESPHOME-release/everblu_meter/meter_history.cpp
+++ b/ESPHOME-release/everblu_meter/meter_history.cpp
@@ -105,9 +105,13 @@ int MeterHistory::generateHistoryJson(const uint32_t history[13], uint32_t curre
 
     pos += snprintf(outputBuffer + pos, remaining, "],\"monthly_usage\":[");
 
-    for (int i = 0; i < monthCount; i++)
+    // Start at the second month: the oldest month has no earlier baseline, so we
+    // omit it entirely rather than publishing a misleading value. monthly_usage
+    // holds (monthCount - 1) real month-over-month deltas, aligned so
+    // monthly_usage[k] pairs with history[k+1].
+    for (int i = 1; i < monthCount; i++)
     {
-        uint32_t usage = calculateUsage(history[i], (i > 0) ? history[i - 1] : 0);
+        uint32_t usage = calculateUsage(history[i], history[i - 1]);
 
         remaining = bufferSize - pos;
         if (remaining <= 1)
@@ -115,7 +119,7 @@ int MeterHistory::generateHistoryJson(const uint32_t history[13], uint32_t curre
             break;
         }
         pos += snprintf(outputBuffer + pos, remaining, "%s%u",
-                        (i > 0 ? "," : ""), usage);
+                        (i > 1 ? "," : ""), usage);
     }
 
     // Calculate current month usage
@@ -176,14 +180,14 @@ void MeterHistory::printToSerial(const uint32_t history[13], uint32_t currentVol
     LOG_I("everblu_meter", "%s Month  Volume (L)  Usage (L)", headerPrefix);
     LOG_I("everblu_meter", "%s -----  ----------  ---------", headerPrefix);
 
-    // Print each historical month
+    // Print each historical month. The oldest month has no earlier baseline, so
+    // its usage is unknown and shown as 0 (matching the published monthly_usage).
+    // Rows are labelled "-NN" months-ago; the live reading is printed separately
+    // below as "Now".
     for (int i = 0; i < monthCount; i++)
     {
-        char monthLabel[6];
-        getMonthLabel(i, monthCount, monthLabel, sizeof(monthLabel));
-
-        uint32_t usage = calculateUsage(history[i], (i > 0) ? history[i - 1] : 0);
-        LOG_I("everblu_meter", "%s  %s   %10u  %9u", headerPrefix, monthLabel, history[i], usage);
+        uint32_t usage = (i > 0) ? calculateUsage(history[i], history[i - 1]) : 0;
+        LOG_I("everblu_meter", "%s  -%02d   %10u  %9u", headerPrefix, monthCount - i, history[i], usage);
     }
 
     // Print current month usage

--- a/ESPHOME-release/everblu_meter/meter_history.h
+++ b/ESPHOME-release/everblu_meter/meter_history.h
@@ -59,6 +59,10 @@ public:
      * Creates a JSON object with historical volumes and calculated monthly usage.
      * Format: {"history":[...], "monthly_usage":[...], "current_month_usage":X, "months_available":Y}
      *
+     * Note: monthly_usage omits the oldest month (no earlier baseline to subtract
+     * from), so it contains (months_available - 1) real month-over-month deltas,
+     * aligned so monthly_usage[k] pairs with history[k+1].
+     *
      * @param history Array of 13 uint32_t values
      * @param currentVolume Current meter reading
      * @param outputBuffer Buffer to write JSON to

--- a/docs/HISTORICAL_DATA.md
+++ b/docs/HISTORICAL_DATA.md
@@ -72,7 +72,6 @@ Historical readings (bytes 66-117):
     713744   // Month -1 (most recent complete month)
   ],
   "monthly_usage": [
-    0,       // Unknown (no baseline for oldest month)
     6699,    // Month -12 usage
     7381,    // Month -11 usage
     8010,    // Month -10 usage
@@ -110,10 +109,11 @@ Access historical data in automations and templates:
 {{ state_attr('sensor.water_meter_value', 'current_month_usage') }}
 
 # Get previous month's total usage
-{{ state_attr('sensor.water_meter_value', 'monthly_usage')[12] }}
+{{ state_attr('sensor.water_meter_value', 'monthly_usage')[-1] }}
 
-# Calculate average monthly consumption over last 12 months (excluding oldest which has no baseline)
-{% set monthly = state_attr('sensor.water_meter_value', 'monthly_usage')[1:] %}
+# Calculate average monthly consumption over the available months
+# monthly_usage already excludes the oldest month (which has no baseline)
+{% set monthly = state_attr('sensor.water_meter_value', 'monthly_usage') %}
 {{ (monthly | sum / monthly | length) | round(0) }}
 ```
 
@@ -136,7 +136,7 @@ template:
         unit_of_measurement: "L"
         state: >
           {% set monthly = state_attr('sensor.water_meter_value', 'monthly_usage') %}
-          {{ monthly[12] | int(0) if monthly else 0 }}
+          {{ monthly[-1] | int(0) if monthly else 0 }}
         icon: mdi:water-pump
 
       - name: "Water Usage Average (12 months)"
@@ -145,8 +145,7 @@ template:
         state: >
           {% set monthly = state_attr('sensor.water_meter_value', 'monthly_usage') %}
           {% if monthly %}
-            {% set valid_months = monthly[1:] %}
-            {{ (valid_months | sum / valid_months | length) | round(0) }}
+            {{ (monthly | sum / monthly | length) | round(0) }}
           {% else %}
             0
           {% endif %}
@@ -168,10 +167,10 @@ series:
     name: Monthly Usage
     type: column
     data_generator: |
-      const monthly = entity.attributes.monthly_usage.slice(1); // Skip first (unknown)
+      const monthly = entity.attributes.monthly_usage; // already excludes oldest month
       const now = new Date();
       return monthly.map((usage, i) => {
-        const date = new Date(now.getFullYear(), now.getMonth() - (12 - i), 1);
+        const date = new Date(now.getFullYear(), now.getMonth() - (monthly.length - i), 1);
 
         return [date.getTime(), usage];
       });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 #include "core/meter_code_parser.h"    // Shared METER_CODE parser
 #include "core/utils.h"                 // Utility functions
 #include "services/schedule_manager.h"  // Schedule management
+#include "services/meter_history.h"      // Shared historical data processing (JSON + serial)
 #include "services/frequency_manager.h" // Shared frequency calibration (scan/adaptive/storage)
 #if defined(ESP8266)
 #include <ESP8266WiFi.h> // Wi-Fi library for ESP8266
@@ -651,160 +652,37 @@ void onUpdateData()
   mqtt.publish(String(mqttBaseTopic) + "/liters", valueBuffer, true);
   delay(5);
 
-  // Publish historical data as JSON attributes for Home Assistant
-  // This provides 13 months of historical volume readings that can be accessed as attributes
-  // in Home Assistant. Each value represents the total volume at the end of that month.
-  // The meter stores these internally with timestamps, but the RADIAN protocol only
-  // returns the volume values without dates.
-  int num_history = 0;
-  if (meter_data.history_available)
+  // Publish historical data as JSON attributes for Home Assistant.
+  // The 13-month history table, monthly-usage math and JSON formatting all live
+  // in the shared MeterHistory service (src/services/meter_history.cpp) - the
+  // SAME code the ESPHome build uses - so the published format stays
+  // single-sourced across both targets.
+  if (meter_data.history_available && MeterHistory::isHistoryValid(meter_data.history))
   {
-    // Count valid historical values (non-zero)
-    for (int i = 0; i < 13; i++)
-    {
-      if (meter_data.history[i] == 0)
-        break;
-      num_history++;
-    }
+    const uint32_t currentVolume = static_cast<uint32_t>(meter_data.volume);
 
-    // If the history block was marked available but contained no
-    // non‑zero entries, treat it as unavailable for this frame.
-    if (num_history == 0)
-    {
-      TS_PRINTLN("[WARN] history_available=true but no non-zero history entries found - skipping history publish for this frame");
-      meter_data.history_available = false;
-    }
-  }
+    // Human-readable table to the serial console
+    MeterHistory::printToSerial(meter_data.history, currentVolume, "[HISTORY]");
 
-  if (meter_data.history_available)
-  {
-
-    Serial.printf("\n=== HISTORICAL DATA (%d months) ===\n", num_history);
-    TS_PRINTLN("[HISTORY] Month  Volume (L)  Usage (L)");
-    TS_PRINTLN("[HISTORY] -----  ----------  ---------");
-
-    // Calculate monthly consumption from the historical data
-    // Format: {"history": [oldest_volume, ..., newest_volume], "monthly_usage": [month1_usage, ..., month13_usage]}
-    // The attributes JSON can become relatively large when all 13 history
-    // slots are populated. Use a sufficiently large buffer and carefully
-    // track remaining space to avoid truncation that would yield malformed
-    // JSON on MQTT.
+    // Build and publish the JSON attributes payload
     char historyJson[1024];
-    int pos = 0;
-
-    // Start JSON object
-    int remaining = sizeof(historyJson) - pos;
-    if (remaining <= 1)
+    int written = MeterHistory::generateHistoryJson(meter_data.history, currentVolume,
+                                                    historyJson, sizeof(historyJson));
+    if (written > 0)
     {
-      TS_PRINTLN("[ERROR] historyJson buffer too small before writing header - skipping history publish");
-      // Nothing written, just bail out of history publishing for this frame.
-      return;
-    }
-    pos += snprintf(historyJson + pos, remaining, "{\"history\":[");
-
-    // Add historical volumes and print to serial
-    for (int i = 0; i < num_history; i++)
-    {
-      remaining = sizeof(historyJson) - pos;
-      if (remaining <= 1)
-      {
-        TS_PRINTLN("[ERROR] historyJson buffer full while writing history array - truncating");
-        break;
-      }
-      pos += snprintf(historyJson + pos, remaining, "%s%u",
-                      (i > 0 ? "," : ""), meter_data.history[i]);
-
-      // Calculate and display monthly usage
-      uint32_t usage = 0;
-      if (i > 0 && meter_data.history[i] > meter_data.history[i - 1])
-      {
-        usage = meter_data.history[i] - meter_data.history[i - 1];
-      }
-      TS_PRINTF("[HISTORY]  -%02d   %10u  %9u\n", num_history - i, meter_data.history[i], usage);
-    }
-
-    // Calculate current month usage (difference from most recent historical reading).
-    // Declare these outside of any goto targets to avoid crossing initialisation
-    // when jumping to finalize_history_json.
-    uint32_t currentMonthUsage = 0;
-    uint32_t currentVolume = static_cast<uint32_t>(meter_data.volume);
-    if (num_history > 0 && currentVolume > meter_data.history[num_history - 1])
-    {
-      currentMonthUsage = currentVolume - meter_data.history[num_history - 1];
-    }
-    TS_PRINTF("[HISTORY]   Now  %10u  %9u (current month usage: %u L)\n", currentVolume, currentMonthUsage, currentMonthUsage);
-    Serial.println("===================================\n");
-
-    // Add monthly usage calculations to JSON
-    remaining = sizeof(historyJson) - pos;
-    if (remaining <= 1)
-    {
-      TS_PRINTLN("[ERROR] historyJson buffer full before monthly_usage - truncating");
-      // Close what we have so far and publish best-effort JSON.
-      historyJson[sizeof(historyJson) - 1] = '\0';
-      TS_PRINTF("[MQTT] Publishing JSON attributes (%d bytes): %s\n\n", strlen(historyJson), historyJson);
+      TS_PRINTF("[MQTT] Publishing JSON attributes (%d bytes): %s\n\n", written, historyJson);
       mqtt.publish(String(mqttBaseTopic) + "/liters_attributes", historyJson, true);
       delay(5);
+
+      HistoryStats stats = MeterHistory::calculateStats(meter_data.history, currentVolume);
       TS_PRINTF("[MQTT] Published %d months historical data (current month usage: %u L)\n",
-                    num_history, currentMonthUsage);
-      goto skip_history_publish;
+                stats.monthCount, stats.currentMonthUsage);
     }
-    pos += snprintf(historyJson + pos, remaining, "],\"monthly_usage\":[");
-    for (int i = 0; i < num_history; i++)
+    else
     {
-      uint32_t usage;
-      if (i == 0)
-      {
-        // For oldest month, we can't calculate usage without an older baseline
-        usage = 0;
-      }
-      else if (meter_data.history[i] > meter_data.history[i - 1])
-      {
-        // Calculate consumption as difference between consecutive months
-        usage = meter_data.history[i] - meter_data.history[i - 1];
-      }
-      else
-      {
-        usage = 0; // Sanity check - shouldn't go backwards
-      }
-      remaining = sizeof(historyJson) - pos;
-      if (remaining <= 1)
-      {
-        TS_PRINTLN("[ERROR] historyJson buffer full while writing monthly_usage - truncating");
-        break;
-      }
-      pos += snprintf(historyJson + pos, remaining, "%s%u",
-                      (i > 0 ? "," : ""), usage);
+      TS_PRINTLN("[WARN] No historical data JSON generated - skipping history publish for this frame");
     }
-
-    remaining = sizeof(historyJson) - pos;
-    if (remaining <= 1)
-    {
-      TS_PRINTLN("[ERROR] historyJson buffer full before tail - truncating");
-      historyJson[sizeof(historyJson) - 1] = '\0';
-      TS_PRINTF("[MQTT] Publishing JSON attributes (%d bytes): %s\n\n", strlen(historyJson), historyJson);
-      mqtt.publish(String(mqttBaseTopic) + "/liters_attributes", historyJson, true);
-      delay(5);
-      TS_PRINTF("[MQTT] Published %d months historical data (current month usage: %u L)\n",
-                    num_history, currentMonthUsage);
-      goto skip_history_publish;
-    }
-    pos += snprintf(historyJson + pos, remaining,
-                    "],\"current_month_usage\":%u,\"months_available\":%d}",
-                    currentMonthUsage, num_history);
-
-    // Ensure null termination even if we had to truncate early.
-    historyJson[sizeof(historyJson) - 1] = '\0';
-
-    TS_PRINTF("[MQTT] Publishing JSON attributes (%d bytes): %s\n\n", strlen(historyJson), historyJson);
-    mqtt.publish(String(mqttBaseTopic) + "/liters_attributes", historyJson, true);
-    delay(5);
-
-    TS_PRINTF("[MQTT] Published %d months historical data (current month usage: %u L)\n",
-                  num_history, currentMonthUsage);
   }
-
-skip_history_publish:;
 
   snprintf(valueBuffer, sizeof(valueBuffer), "%d", meter_data.reads_counter);
   mqtt.publish(String(mqttBaseTopic) + "/counter", valueBuffer, true);

--- a/src/services/meter_history.cpp
+++ b/src/services/meter_history.cpp
@@ -105,9 +105,13 @@ int MeterHistory::generateHistoryJson(const uint32_t history[13], uint32_t curre
 
     pos += snprintf(outputBuffer + pos, remaining, "],\"monthly_usage\":[");
 
-    for (int i = 0; i < monthCount; i++)
+    // Start at the second month: the oldest month has no earlier baseline, so we
+    // omit it entirely rather than publishing a misleading value. monthly_usage
+    // holds (monthCount - 1) real month-over-month deltas, aligned so
+    // monthly_usage[k] pairs with history[k+1].
+    for (int i = 1; i < monthCount; i++)
     {
-        uint32_t usage = calculateUsage(history[i], (i > 0) ? history[i - 1] : 0);
+        uint32_t usage = calculateUsage(history[i], history[i - 1]);
 
         remaining = bufferSize - pos;
         if (remaining <= 1)
@@ -115,7 +119,7 @@ int MeterHistory::generateHistoryJson(const uint32_t history[13], uint32_t curre
             break;
         }
         pos += snprintf(outputBuffer + pos, remaining, "%s%u",
-                        (i > 0 ? "," : ""), usage);
+                        (i > 1 ? "," : ""), usage);
     }
 
     // Calculate current month usage
@@ -176,14 +180,14 @@ void MeterHistory::printToSerial(const uint32_t history[13], uint32_t currentVol
     LOG_I("everblu_meter", "%s Month  Volume (L)  Usage (L)", headerPrefix);
     LOG_I("everblu_meter", "%s -----  ----------  ---------", headerPrefix);
 
-    // Print each historical month
+    // Print each historical month. The oldest month has no earlier baseline, so
+    // its usage is unknown and shown as 0 (matching the published monthly_usage).
+    // Rows are labelled "-NN" months-ago; the live reading is printed separately
+    // below as "Now".
     for (int i = 0; i < monthCount; i++)
     {
-        char monthLabel[6];
-        getMonthLabel(i, monthCount, monthLabel, sizeof(monthLabel));
-
-        uint32_t usage = calculateUsage(history[i], (i > 0) ? history[i - 1] : 0);
-        LOG_I("everblu_meter", "%s  %s   %10u  %9u", headerPrefix, monthLabel, history[i], usage);
+        uint32_t usage = (i > 0) ? calculateUsage(history[i], history[i - 1]) : 0;
+        LOG_I("everblu_meter", "%s  -%02d   %10u  %9u", headerPrefix, monthCount - i, history[i], usage);
     }
 
     // Print current month usage

--- a/src/services/meter_history.cpp
+++ b/src/services/meter_history.cpp
@@ -181,7 +181,8 @@ void MeterHistory::printToSerial(const uint32_t history[13], uint32_t currentVol
     LOG_I("everblu_meter", "%s -----  ----------  ---------", headerPrefix);
 
     // Print each historical month. The oldest month has no earlier baseline, so
-    // its usage is unknown and shown as 0 (matching the published monthly_usage).
+    // its usage is unknown and shown as 0.
+    // Note: the JSON monthly_usage array omits this oldest-month usage value.
     // Rows are labelled "-NN" months-ago; the live reading is printed separately
     // below as "Now".
     for (int i = 0; i < monthCount; i++)

--- a/src/services/meter_history.h
+++ b/src/services/meter_history.h
@@ -59,6 +59,10 @@ public:
      * Creates a JSON object with historical volumes and calculated monthly usage.
      * Format: {"history":[...], "monthly_usage":[...], "current_month_usage":X, "months_available":Y}
      *
+     * Note: monthly_usage omits the oldest month (no earlier baseline to subtract
+     * from), so it contains (months_available - 1) real month-over-month deltas,
+     * aligned so monthly_usage[k] pairs with history[k+1].
+     *
      * @param history Array of 13 uint32_t values
      * @param currentVolume Current meter reading
      * @param outputBuffer Buffer to write JSON to


### PR DESCRIPTION
This updates historical meter publishing so `monthly_usage` only includes real month-over-month deltas and no longer emits a placeholder entry for the oldest month, which has no earlier baseline.

It also removes the MQTT build's inline history JSON/table generation and reuses the shared `MeterHistory` service instead, keeping MQTT and ESPHome history formatting single-sourced.

What changed:
- omit the oldest `monthly_usage` element instead of publishing a misleading `0`
- switch `src/main.cpp` to `MeterHistory::printToSerial()` and `MeterHistory::generateHistoryJson()`
- restore the detailed serial/MQTT history logging after the refactor
- update docs and regenerate `ESPHOME-release/` to match the shared source
