### PR TITLE
Fix wake-up burst truncated to ~60ms on retry reads (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 
 Releases are created manually by tagging commits with version tags matching `v*.*.*` (e.g., `v2.1.0`). Users should build from source and configure `private.h` with their own meter settings.
 
-## [Unreleased]
 
 ## AI Notes For Maintainers And Tools
 
@@ -12,6 +11,15 @@ Releases are created manually by tagging commits with version tags matching `v*.
 - The `Unreleased` section is for in-progress work and may be rewritten before tagging.
 - If an item was introduced and later superseded in the same release branch, keep only the final behavior in Added/Changed/Fixed/Removed and record superseded work in the AI metadata block.
 - Keep PR coverage explicit per release so branch-only work is auditable against merge history.
+- Add new versions below, not above this section.
+
+## [Unreleased]
+
+### Fixed
+
+- **Wake-up burst truncated to ~60ms on the second and later reads** ([#127](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127)): `receive_radian_frame()` reprograms `MDMCFG4` to its 4x-oversampled 9.6 kbps RX rate, and `get_meter_data_for_meter()` never restored the 2.4 kbps TX data rate before transmitting. The first read after boot worked because `cc1101_init()` had just set 2.4 kbps, but every subsequent read inherited the stale 9.6 kbps rate and clocked the wake-up burst out 4x too fast — draining the pre-filled TX FIFO in ~47ms and hitting `TXFIFO_UNDERFLOW` (MARCSTATE 0x16) after ~60ms instead of sending the full ~2s burst. The TX phase now rewrites `MDMCFG4`/`MDMCFG3` to 2.4 kbps on every read, so retries transmit the complete wake-up burst.
+
+
 
 ## [v3.1.0] - 2026-07-07
 

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1663,6 +1663,18 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
   if (GET_GDO2_PIN() >= 0)
     halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);
 
+  // Restore the 2.4 kbps data rate for this transmit phase. receive_radian_frame()
+  // reprograms MDMCFG4 to MDMCFG4_RX_BW_58KHZ_9_6KBPS (0xF8) for its 4x-oversampled
+  // RX stage, which raises the data-rate exponent to 9.6 kbps. cc1101_init() leaves
+  // MDMCFG4 at the 2.4 kbps value, so the FIRST read after boot transmits correctly,
+  // but every subsequent read would otherwise inherit the stale 9.6 kbps rate and
+  // clock the wake-up burst out 4x too fast - draining the pre-filled TX FIFO in
+  // ~47ms and triggering TXFIFO_UNDERFLOW after ~60ms instead of the full ~2s burst.
+  // Rewriting MDMCFG4/MDMCFG3 here makes every attempt transmit at 2.4 kbps.
+  // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127
+  halRfWriteReg(MDMCFG4, MDMCFG4_RX_BW_270KHZ);  // TX data rate exponent: 2.4 kbps
+  halRfWriteReg(MDMCFG3, MDMCFG3_DRATE_2_4KBPS); // TX data rate mantissa: 2.4 kbps
+
   halRfWriteReg(MDMCFG2, MDMCFG2_NO_PREAMBLE_SYNC);  // No preamble/sync for WUP
   halRfWriteReg(PKTCTRL0, PKTCTRL0_INFINITE_LENGTH); // Infinite packet length
 

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1670,9 +1670,13 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
   // but every subsequent read would otherwise inherit the stale 9.6 kbps rate and
   // clock the wake-up burst out 4x too fast - draining the pre-filled TX FIFO in
   // ~47ms and triggering TXFIFO_UNDERFLOW after ~60ms instead of the full ~2s burst.
-  // Rewriting MDMCFG4/MDMCFG3 here makes every attempt transmit at 2.4 kbps.
+  // Only the DRATE_E (low) nibble of MDMCFG4 sets the data rate; the upper CHANBW
+  // nibble is RX-only, so preserve it via read-modify-write and rewrite just the
+  // low nibble to the 2.4 kbps exponent. This makes every attempt transmit at 2.4 kbps.
   // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127
-  halRfWriteReg(MDMCFG4, MDMCFG4_RX_BW_270KHZ);  // TX data rate exponent: 2.4 kbps
+  uint8_t mdmcfg4 = halRfReadReg(MDMCFG4);
+  mdmcfg4 = (mdmcfg4 & 0xF0) | (MDMCFG4_RX_BW_270KHZ & 0x0F); // DRATE_E -> 2.4 kbps
+  halRfWriteReg(MDMCFG4, mdmcfg4);               // TX data rate exponent: 2.4 kbps
   halRfWriteReg(MDMCFG3, MDMCFG3_DRATE_2_4KBPS); // TX data rate mantissa: 2.4 kbps
 
   halRfWriteReg(MDMCFG2, MDMCFG2_NO_PREAMBLE_SYNC);  // No preamble/sync for WUP

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1663,6 +1663,18 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
   if (GET_GDO2_PIN() >= 0)
     halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);
 
+  // Restore the 2.4 kbps data rate for this transmit phase. receive_radian_frame()
+  // reprograms MDMCFG4 to MDMCFG4_RX_BW_58KHZ_9_6KBPS (0xF8) for its 4x-oversampled
+  // RX stage, which raises the data-rate exponent to 9.6 kbps. cc1101_init() leaves
+  // MDMCFG4 at the 2.4 kbps value, so the FIRST read after boot transmits correctly,
+  // but every subsequent read would otherwise inherit the stale 9.6 kbps rate and
+  // clock the wake-up burst out 4x too fast - draining the pre-filled TX FIFO in
+  // ~47ms and triggering TXFIFO_UNDERFLOW after ~60ms instead of the full ~2s burst.
+  // Rewriting MDMCFG4/MDMCFG3 here makes every attempt transmit at 2.4 kbps.
+  // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127
+  halRfWriteReg(MDMCFG4, MDMCFG4_RX_BW_270KHZ);  // TX data rate exponent: 2.4 kbps
+  halRfWriteReg(MDMCFG3, MDMCFG3_DRATE_2_4KBPS); // TX data rate mantissa: 2.4 kbps
+
   halRfWriteReg(MDMCFG2, MDMCFG2_NO_PREAMBLE_SYNC);  // No preamble/sync for WUP
   halRfWriteReg(PKTCTRL0, PKTCTRL0_INFINITE_LENGTH); // Infinite packet length
 

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1670,9 +1670,13 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
   // but every subsequent read would otherwise inherit the stale 9.6 kbps rate and
   // clock the wake-up burst out 4x too fast - draining the pre-filled TX FIFO in
   // ~47ms and triggering TXFIFO_UNDERFLOW after ~60ms instead of the full ~2s burst.
-  // Rewriting MDMCFG4/MDMCFG3 here makes every attempt transmit at 2.4 kbps.
+  // Only the DRATE_E (low) nibble of MDMCFG4 sets the data rate; the upper CHANBW
+  // nibble is RX-only, so preserve it via read-modify-write and rewrite just the
+  // low nibble to the 2.4 kbps exponent. This makes every attempt transmit at 2.4 kbps.
   // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127
-  halRfWriteReg(MDMCFG4, MDMCFG4_RX_BW_270KHZ);  // TX data rate exponent: 2.4 kbps
+  uint8_t mdmcfg4 = halRfReadReg(MDMCFG4);
+  mdmcfg4 = (mdmcfg4 & 0xF0) | (MDMCFG4_RX_BW_270KHZ & 0x0F); // DRATE_E -> 2.4 kbps
+  halRfWriteReg(MDMCFG4, mdmcfg4);               // TX data rate exponent: 2.4 kbps
   halRfWriteReg(MDMCFG3, MDMCFG3_DRATE_2_4KBPS); // TX data rate mantissa: 2.4 kbps
 
   halRfWriteReg(MDMCFG2, MDMCFG2_NO_PREAMBLE_SYNC);  // No preamble/sync for WUP


### PR DESCRIPTION
## Summary

Fixes #127. The CC1101 wake-up burst was transmitted correctly (~2 s) only on the first read after boot; every subsequent read within a retry cycle was truncated to ~60ms, which structurally cannot wake a meter that requires the full ~2 s burst.

## Root cause

`receive_radian_frame()` reprograms `MDMCFG4` to `MDMCFG4_RX_BW_58KHZ_9_6KBPS` (`0xF8`) for its 4×-oversampled RX stage, which raises the data-rate exponent to 9.6 kbps. `get_meter_data_for_meter()` restored `MDMCFG2`/`PKTCTRL0`/`IOCFG2` before transmitting but **never restored the TX data rate**.

- **First read after boot:** works — `cc1101_init()` had just set 2.4 kbps.
- **Every later read / retry:** inherits the stale 9.6 kbps rate → the wake-up burst clocks out 4× too fast → the pre-filled 56-byte TX FIFO drains in ~47ms → `TXFIFO_UNDERFLOW` (MARCSTATE `0x16`) at `tmo=6` (~60ms) instead of the full ~2 s burst.

This matches the reported logs exactly (`tmo=204` / 2040ms on attempt 1 vs `tmo=6` / 60ms on attempt 2).

## Fix

The TX phase in `get_meter_data_for_meter()` now rewrites `MDMCFG4`/`MDMCFG3` to 2.4 kbps on every read, so all attempts transmit the complete wake-up burst.

## Files changed

- `src/core/cc1101.cpp` — restore 2.4 kbps TX data rate before the wake-up burst.
- `ESPHOME-release/everblu_meter/cc1101.cpp` — regenerated release copy.
- `CHANGELOG.md` — `Unreleased` → `Fixed` entry.

## Notes

- Does not affect the RX bandwidth (that nibble of `MDMCFG4` is RX-only); only the TX data-rate exponent matters here.
- This does **not** by itself fix a silent meter (see #126) — it only guarantees retries 2–5 send the full wake-up burst, removing the truncated burst as a contributing factor.
- ESP8266 firmware builds clean (`huzzah` SUCCESS).