### PR TITLE
Prepare v3.1.1 release (wake-up burst TX data-rate fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Releases are created manually by tagging commits with version tags matching `v*.
 
 ### Fixed
 
-- **Wake-up burst truncated to ~60ms on the second and later reads** ([#127](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127)): `receive_radian_frame()` reprograms `MDMCFG4` to its 4x-oversampled 9.6 kbps RX rate, and `get_meter_data_for_meter()` never restored the 2.4 kbps TX data rate before transmitting. The first read after boot worked because `cc1101_init()` had just set 2.4 kbps, but every subsequent read inherited the stale 9.6 kbps rate and clocked the wake-up burst out 4x too fast — draining the pre-filled TX FIFO in ~47ms and hitting `TXFIFO_UNDERFLOW` (MARCSTATE 0x16) after ~60ms instead of sending the full ~2s burst. The TX phase now rewrites `MDMCFG4`/`MDMCFG3` to 2.4 kbps on every read, so retries transmit the complete wake-up burst.
+- **Wake-up burst truncated to ~60ms on the second and later reads** ([#127](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127)): `receive_radian_frame()` switches `MDMCFG4` to the 4x-oversampled 9.6 kbps RX rate, but `get_meter_data_for_meter()` never restored the 2.4 kbps TX rate before transmitting. Only the first read after boot worked (fresh from `cc1101_init()`); every later read clocked the wake-up burst out 4x too fast, draining the TX FIFO and hitting `TXFIFO_UNDERFLOW` (MARCSTATE 0x16) after ~60ms instead of the full ~2s burst. The TX phase now rewrites `MDMCFG4`/`MDMCFG3` to 2.4 kbps on every read.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,19 @@ Releases are created manually by tagging commits with version tags matching `v*.
 - Keep PR coverage explicit per release so branch-only work is auditable against merge history.
 - Add new versions below, not above this section.
 
-## [Unreleased]
+## [v3.1.1] - 2026-07-08
+
+### AI Metadata
+
+```yaml
+release_type: patch
+base_branch: main
+release_branch: develop
+includes_prs: [128]
+notable_superseded_work: []
+scope_summary:
+  - "CC1101 TX data-rate restoration fix for reliable wake-up bursts on repeat reads"
+```
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Releases are created manually by tagging commits with version tags matching `v*.
 - Keep PR coverage explicit per release so branch-only work is auditable against merge history.
 - Add new versions below, not above this section.
 
+## [Unreleased]
+
 ## [v3.1.1] - 2026-07-08
 
 ### AI Metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 
 Releases are created manually by tagging commits with version tags matching `v*.*.*` (e.g., `v2.1.0`). Users should build from source and configure `private.h` with their own meter settings.
 
-## [Unreleased]
 
 ## AI Notes For Maintainers And Tools
 
@@ -12,6 +11,15 @@ Releases are created manually by tagging commits with version tags matching `v*.
 - The `Unreleased` section is for in-progress work and may be rewritten before tagging.
 - If an item was introduced and later superseded in the same release branch, keep only the final behavior in Added/Changed/Fixed/Removed and record superseded work in the AI metadata block.
 - Keep PR coverage explicit per release so branch-only work is auditable against merge history.
+- Add new versions below, not above this section.
+
+## [Unreleased]
+
+### Fixed
+
+- **Wake-up burst truncated to ~60ms on the second and later reads** ([#127](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127)): `receive_radian_frame()` reprograms `MDMCFG4` to its 4x-oversampled 9.6 kbps RX rate, and `get_meter_data_for_meter()` never restored the 2.4 kbps TX data rate before transmitting. The first read after boot worked because `cc1101_init()` had just set 2.4 kbps, but every subsequent read inherited the stale 9.6 kbps rate and clocked the wake-up burst out 4x too fast — draining the pre-filled TX FIFO in ~47ms and hitting `TXFIFO_UNDERFLOW` (MARCSTATE 0x16) after ~60ms instead of sending the full ~2s burst. The TX phase now rewrites `MDMCFG4`/`MDMCFG3` to 2.4 kbps on every read, so retries transmit the complete wake-up burst.
+
+
 
 ## [v3.1.0] - 2026-07-07
 

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1663,6 +1663,18 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
   if (GET_GDO2_PIN() >= 0)
     halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);
 
+  // Restore the 2.4 kbps data rate for this transmit phase. receive_radian_frame()
+  // reprograms MDMCFG4 to MDMCFG4_RX_BW_58KHZ_9_6KBPS (0xF8) for its 4x-oversampled
+  // RX stage, which raises the data-rate exponent to 9.6 kbps. cc1101_init() leaves
+  // MDMCFG4 at the 2.4 kbps value, so the FIRST read after boot transmits correctly,
+  // but every subsequent read would otherwise inherit the stale 9.6 kbps rate and
+  // clock the wake-up burst out 4x too fast - draining the pre-filled TX FIFO in
+  // ~47ms and triggering TXFIFO_UNDERFLOW after ~60ms instead of the full ~2s burst.
+  // Rewriting MDMCFG4/MDMCFG3 here makes every attempt transmit at 2.4 kbps.
+  // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127
+  halRfWriteReg(MDMCFG4, MDMCFG4_RX_BW_270KHZ);  // TX data rate exponent: 2.4 kbps
+  halRfWriteReg(MDMCFG3, MDMCFG3_DRATE_2_4KBPS); // TX data rate mantissa: 2.4 kbps
+
   halRfWriteReg(MDMCFG2, MDMCFG2_NO_PREAMBLE_SYNC);  // No preamble/sync for WUP
   halRfWriteReg(PKTCTRL0, PKTCTRL0_INFINITE_LENGTH); // Infinite packet length
 

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1670,9 +1670,13 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
   // but every subsequent read would otherwise inherit the stale 9.6 kbps rate and
   // clock the wake-up burst out 4x too fast - draining the pre-filled TX FIFO in
   // ~47ms and triggering TXFIFO_UNDERFLOW after ~60ms instead of the full ~2s burst.
-  // Rewriting MDMCFG4/MDMCFG3 here makes every attempt transmit at 2.4 kbps.
+  // Only the DRATE_E (low) nibble of MDMCFG4 sets the data rate; the upper CHANBW
+  // nibble is RX-only, so preserve it via read-modify-write and rewrite just the
+  // low nibble to the 2.4 kbps exponent. This makes every attempt transmit at 2.4 kbps.
   // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127
-  halRfWriteReg(MDMCFG4, MDMCFG4_RX_BW_270KHZ);  // TX data rate exponent: 2.4 kbps
+  uint8_t mdmcfg4 = halRfReadReg(MDMCFG4);
+  mdmcfg4 = (mdmcfg4 & 0xF0) | (MDMCFG4_RX_BW_270KHZ & 0x0F); // DRATE_E -> 2.4 kbps
+  halRfWriteReg(MDMCFG4, mdmcfg4);               // TX data rate exponent: 2.4 kbps
   halRfWriteReg(MDMCFG3, MDMCFG3_DRATE_2_4KBPS); // TX data rate mantissa: 2.4 kbps
 
   halRfWriteReg(MDMCFG2, MDMCFG2_NO_PREAMBLE_SYNC);  // No preamble/sync for WUP

--- a/ESPHOME-release/everblu_meter/version.h
+++ b/ESPHOME-release/everblu_meter/version.h
@@ -6,5 +6,5 @@
  */
 
 #ifndef EVERBLU_FW_VERSION
-#define EVERBLU_FW_VERSION "3.1.0"
+#define EVERBLU_FW_VERSION "3.1.1"
 #endif

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1663,6 +1663,18 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
   if (GET_GDO2_PIN() >= 0)
     halRfWriteReg(IOCFG2, IOCFG2_TX_FIFO_THR);
 
+  // Restore the 2.4 kbps data rate for this transmit phase. receive_radian_frame()
+  // reprograms MDMCFG4 to MDMCFG4_RX_BW_58KHZ_9_6KBPS (0xF8) for its 4x-oversampled
+  // RX stage, which raises the data-rate exponent to 9.6 kbps. cc1101_init() leaves
+  // MDMCFG4 at the 2.4 kbps value, so the FIRST read after boot transmits correctly,
+  // but every subsequent read would otherwise inherit the stale 9.6 kbps rate and
+  // clock the wake-up burst out 4x too fast - draining the pre-filled TX FIFO in
+  // ~47ms and triggering TXFIFO_UNDERFLOW after ~60ms instead of the full ~2s burst.
+  // Rewriting MDMCFG4/MDMCFG3 here makes every attempt transmit at 2.4 kbps.
+  // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127
+  halRfWriteReg(MDMCFG4, MDMCFG4_RX_BW_270KHZ);  // TX data rate exponent: 2.4 kbps
+  halRfWriteReg(MDMCFG3, MDMCFG3_DRATE_2_4KBPS); // TX data rate mantissa: 2.4 kbps
+
   halRfWriteReg(MDMCFG2, MDMCFG2_NO_PREAMBLE_SYNC);  // No preamble/sync for WUP
   halRfWriteReg(PKTCTRL0, PKTCTRL0_INFINITE_LENGTH); // Infinite packet length
 

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1670,9 +1670,13 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
   // but every subsequent read would otherwise inherit the stale 9.6 kbps rate and
   // clock the wake-up burst out 4x too fast - draining the pre-filled TX FIFO in
   // ~47ms and triggering TXFIFO_UNDERFLOW after ~60ms instead of the full ~2s burst.
-  // Rewriting MDMCFG4/MDMCFG3 here makes every attempt transmit at 2.4 kbps.
+  // Only the DRATE_E (low) nibble of MDMCFG4 sets the data rate; the upper CHANBW
+  // nibble is RX-only, so preserve it via read-modify-write and rewrite just the
+  // low nibble to the 2.4 kbps exponent. This makes every attempt transmit at 2.4 kbps.
   // See: https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127
-  halRfWriteReg(MDMCFG4, MDMCFG4_RX_BW_270KHZ);  // TX data rate exponent: 2.4 kbps
+  uint8_t mdmcfg4 = halRfReadReg(MDMCFG4);
+  mdmcfg4 = (mdmcfg4 & 0xF0) | (MDMCFG4_RX_BW_270KHZ & 0x0F); // DRATE_E -> 2.4 kbps
+  halRfWriteReg(MDMCFG4, mdmcfg4);               // TX data rate exponent: 2.4 kbps
   halRfWriteReg(MDMCFG3, MDMCFG3_DRATE_2_4KBPS); // TX data rate mantissa: 2.4 kbps
 
   halRfWriteReg(MDMCFG2, MDMCFG2_NO_PREAMBLE_SYNC);  // No preamble/sync for WUP

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -6,5 +6,5 @@
  */
 
 #ifndef EVERBLU_FW_VERSION
-#define EVERBLU_FW_VERSION "3.1.0"
+#define EVERBLU_FW_VERSION "3.1.1"
 #endif


### PR DESCRIPTION
## Summary

Prepares the **v3.1.1** patch release. This rolls up the wake-up burst TX data-rate fix (PR #128) and bumps the firmware version.

## Changes

- **CHANGELOG.md**: new `## [v3.1.1] - 2026-07-08` section with AI Metadata (`includes_prs: [128]`) documenting the fix for the truncated wake-up burst on repeat reads.
- **src/core/version.h**: firmware version bumped `3.1.0` → `3.1.1`.
- **ESPHOME-release/**: regenerated by the pre-commit hook to reflect the version bump.

## Fix included

**Wake-up burst truncated to ~60ms on the second and later reads** ([#127](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127)): `receive_radian_frame()` switched `MDMCFG4` to the 4x-oversampled 9.6 kbps RX rate, but `get_meter_data_for_meter()` never restored the 2.4 kbps TX rate before transmitting. Every read after the first clocked the wake-up burst out 4x too fast, draining the TX FIFO and hitting `TXFIFO_UNDERFLOW` after ~60ms instead of the full ~2s burst. The TX phase now rewrites `MDMCFG4`/`MDMCFG3` to 2.4 kbps on every read (preserving the CHANBW nibble).

Fixes #127.