### PR TITLE
Auto-generate README TOCs and add sensor-history migration tool

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -1,0 +1,28 @@
+name: TOC Generator
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - README.md
+      - ESPHOME/README.md
+      - .github/workflows/toc.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  generate-toc:
+    name: Generate TOC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/toc-generator@v4
+        with:
+          TARGET_PATHS: 'README.md,ESPHOME/README.md'
+          MAX_HEADER_LEVEL: 3
+          COMMIT_MESSAGE: 'docs: update table of contents'

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -2,59 +2,64 @@
 
 Complete ESPHome custom component for reading EverBlu Cyble Enhanced water and gas meters. This integration connects to Home Assistant without requiring an MQTT broker.
 
-## Table of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
-- [ESPHome Integration for EverBlu Cyble Enhanced Meters](#esphome-integration-for-everblu-cyble-enhanced-meters)
-  - [Table of Contents](#table-of-contents)
-  - [Troubleshooting](#troubleshooting)
-    - [Corrupted or Invalid Volume Readings](#corrupted-or-invalid-volume-readings)
-    - [No Meter Response](#no-meter-response)
-    - [Signal Quality Issues](#signal-quality-issues)
-  - [Documentation](#documentation)
-    - [For End Users](#for-end-users)
-    - [For Developers](#for-developers)
-  - [Quick Start](#quick-start)
-  - [Breaking Change: SPI Configuration Required](#breaking-change-spi-configuration-required)
-    - [1. Use as External Component](#1-use-as-external-component)
-    - [2. Build and Upload](#2-build-and-upload)
-  - [ESPHome Device Builder (Visual Dashboard)](#esphome-device-builder-visual-dashboard)
-  - [Board-Specific Configuration](#board-specific-configuration)
-    - [Arduino Nano ESP32 (ESP32S3)](#arduino-nano-esp32-esp32s3)
-    - [Other ESP32 Boards](#other-esp32-boards)
-  - [Configuration Reference](#configuration-reference)
-    - [Key Parameters](#key-parameters)
-    - [Schedule Options](#schedule-options)
-    - [Custom Schedule Example](#custom-schedule-example)
-    - [Logging](#logging)
-    - [Timezone Adjustment](#timezone-adjustment)
-  - [Features](#features)
-  - [Example Configurations](#example-configurations)
-  - [Hardware Requirements](#hardware-requirements)
-    - [Wiring (ESP8266 D1 Mini)](#wiring-esp8266-d1-mini)
-    - [Wiring (ESP32)](#wiring-esp32)
-  - [Benefits](#benefits)
-    - [vs. Standalone MQTT Mode](#vs-standalone-mqtt-mode)
-    - [ESPHome Mode Advantages](#esphome-mode-advantages)
-  - [Home Assistant Best Practice: Utility Meter Helper](#home-assistant-best-practice-utility-meter-helper)
-    - [Historical Data from Meter](#historical-data-from-meter)
-  - [Architecture](#architecture)
-  - [Available Sensors](#available-sensors)
-    - [Numeric Sensors](#numeric-sensors)
-    - [Text Sensors](#text-sensors)
-    - [Binary Sensors](#binary-sensors)
-    - [Control Buttons](#control-buttons)
-  - [Common Configuration Patterns](#common-configuration-patterns)
-    - [Water Meter - Basic](#water-meter---basic)
-    - [Gas Meter - Basic](#gas-meter---basic)
-    - [With Full Monitoring](#with-full-monitoring)
-  - [Quick Troubleshooting](#quick-troubleshooting)
-    - [Quick Fixes](#quick-fixes)
-  - [License](#license)
-  - [Credits](#credits)
-  - [Links](#links)
-  - [Development: Code Style \& Formatting](#development-code-style--formatting)
-    - [Running the formatter](#running-the-formatter)
-    - [Linting \& pre-commit](#linting--pre-commit)
+- [Troubleshooting](#troubleshooting)
+  - [Corrupted or Invalid Volume Readings](#corrupted-or-invalid-volume-readings)
+  - [No Meter Response](#no-meter-response)
+  - [Signal Quality Issues](#signal-quality-issues)
+- [Documentation](#documentation)
+  - [For End Users](#for-end-users)
+  - [For Developers](#for-developers)
+- [Quick Start](#quick-start)
+- [Breaking Change: SPI Configuration Required](#breaking-change-spi-configuration-required)
+  - [1. Use as External Component](#1-use-as-external-component)
+  - [2. Build and Upload](#2-build-and-upload)
+- [ESPHome Device Builder (Visual Dashboard)](#esphome-device-builder-visual-dashboard)
+- [Board-Specific Configuration](#board-specific-configuration)
+  - [Arduino Nano ESP32 (ESP32S3)](#arduino-nano-esp32-esp32s3)
+  - [Other ESP32 Boards](#other-esp32-boards)
+- [Configuration Reference](#configuration-reference)
+  - [Key Parameters](#key-parameters)
+  - [Schedule Options](#schedule-options)
+  - [Custom Schedule Example](#custom-schedule-example)
+  - [Logging](#logging)
+  - [Timezone Adjustment](#timezone-adjustment)
+- [Features](#features)
+- [Example Configurations](#example-configurations)
+- [Hardware Requirements](#hardware-requirements)
+  - [Wiring (ESP8266 D1 Mini)](#wiring-esp8266-d1-mini)
+  - [Wiring (ESP32)](#wiring-esp32)
+- [Benefits](#benefits)
+  - [vs. Standalone MQTT Mode](#vs-standalone-mqtt-mode)
+  - [ESPHome Mode Advantages](#esphome-mode-advantages)
+- [Home Assistant Best Practice: Utility Meter Helper](#home-assistant-best-practice-utility-meter-helper)
+  - [Migrating Sensor History Between Platforms](#migrating-sensor-history-between-platforms)
+  - [Historical Data from Meter](#historical-data-from-meter)
+- [Architecture](#architecture)
+- [Available Sensors](#available-sensors)
+  - [Numeric Sensors](#numeric-sensors)
+  - [Text Sensors](#text-sensors)
+  - [Binary Sensors](#binary-sensors)
+  - [Control Buttons](#control-buttons)
+- [Common Configuration Patterns](#common-configuration-patterns)
+  - [Water Meter - Basic](#water-meter---basic)
+  - [Gas Meter - Basic](#gas-meter---basic)
+  - [With Full Monitoring](#with-full-monitoring)
+- [Quick Troubleshooting](#quick-troubleshooting)
+  - [Quick Fixes](#quick-fixes)
+- [License](#license)
+- [Credits](#credits)
+- [Links](#links)
+- [Development: Code Style & Formatting](#development-code-style--formatting)
+  - [Running the formatter](#running-the-formatter)
+  - [Linting & pre-commit](#linting--pre-commit)
+
+<!-- END doctoc -->
+
+
 
 ## Troubleshooting
 
@@ -495,6 +500,8 @@ utility_meter:
 ```
 
 When changing platforms or meters, update only the `source` - your history stays intact!
+
+### Migrating Sensor History Between Platforms
 
 **Migrating from MQTT to ESPHome (or replacing hardware)?** A utility meter helper protects future data, but it does not move the history that already accumulated on your *old* sensor onto the *new* one. To merge the past readings from the old entity into the new entity (both raw states and long-term statistics for the Energy dashboard), use the [HA Merge Sensor History](https://github.com/mayerwin/HA-Merge-Sensor-History) custom component. It imports the older history in front of the new sensor in a single atomic, idempotent transaction, so your consumption graphs and lifetime totals stay continuous across the switch. Back up your recorder database first.
 

--- a/README.md
+++ b/README.md
@@ -29,20 +29,56 @@ Integrated with Home Assistant via MQTT AutoDiscovery and ESPHome external compo
 
 ---
 
-## Table of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
+  - [**ESPHome** - Release V3.0.0](#esphome---release-v300)
 - [Features](#features)
+  - [Full feature list](#full-feature-list)
+  - [Advanced Frame Validation](#advanced-frame-validation)
 - [Integration Options](#integration-options)
+  - [Option 1: ESPHome Component (Recommended)](#option-1-esphome-component-recommended)
+  - [Option 2: Standalone with MQTT](#option-2-standalone-with-mqtt)
 - [Quick Start: First Successful Reading](#quick-start-first-successful-reading)
+  - [1. Hardware you need](#1-hardware-you-need)
+  - [2. Files you must edit](#2-files-you-must-edit)
+  - [Meter Type Configuration](#meter-type-configuration)
+  - [3. Build and upload the firmware](#3-build-and-upload-the-firmware)
 - [Hardware](#hardware)
+  - [Connections (ESP32/ESP8266 to CC1101)](#connections-esp32esp8266-to-cc1101)
+  - [CC1101](#cc1101)
 - [MQTT Integration](#mqtt-integration)
 - [Multiple Devices](#multiple-devices)
 - [Home Assistant Best Practice: Utility Meter Helper](#home-assistant-best-practice-utility-meter-helper)
+  - [Migrating Sensor History Between Platforms](#migrating-sensor-history-between-platforms)
+  - [Historical Data from Meter](#historical-data-from-meter)
 - [Configuration](#configuration)
+  - [Local Development Setup](#local-development-setup)
+  - [Reading Schedule](#reading-schedule)
+  - [Time zone offset and wake-up window (simple)](#time-zone-offset-and-wake-up-window-simple)
+  - [Home Assistant Discovery Toggle (MQTT mode)](#home-assistant-discovery-toggle-mqtt-mode)
+  - [Radio and frequency (advanced)](#radio-and-frequency-advanced)
+  - [Frequency Configuration](#frequency-configuration)
+  - [Adaptive Frequency Management](#adaptive-frequency-management)
 - [Troubleshooting](#troubleshooting)
-- [Utility Read Counter Compatibility](#important-utility-read-counter-compatibility)
+  - [Meter reads fail — near-field RF saturation (device too close to meter)](#meter-reads-fail--near-field-rf-saturation-device-too-close-to-meter)
+  - [Corrupted or Invalid Volume Readings](#corrupted-or-invalid-volume-readings)
+  - [ESP32 build: ModuleNotFoundError: No module named 'intelhex'](#esp32-build-modulenotfounderror-no-module-named-intelhex)
+  - [ESP32 compile errors about ESP8266 headers](#esp32-compile-errors-about-esp8266-headers)
+  - [Frequency Adjustment](#frequency-adjustment)
+  - [Business Hours](#business-hours)
+  - [Serial Number Starting with 0](#serial-number-starting-with-0)
+  - [Distance Between Device and Meter](#distance-between-device-and-meter)
+- [Important: Utility Read Counter Compatibility](#important-utility-read-counter-compatibility)
+  - [Recommended Actions](#recommended-actions)
 - [Credits](#credits)
 - [Legal Notice](#legal-notice)
+  - [Community Resources](#community-resources)
+
+<!-- END doctoc -->
+
+
 
 ---
 
@@ -531,6 +567,8 @@ utility_meter:
 ```
 
 When you change platforms or meters, simply update the `source` to point to the new sensor - your history remains unbroken.
+
+### Migrating Sensor History Between Platforms
 
 **Migrating from MQTT to ESPHome (or replacing hardware)?** A utility meter helper protects future data, but it does not move the history that already accumulated on your *old* sensor onto the *new* one. To merge the past readings from the old entity into the new entity (both raw states and long-term statistics for the Energy dashboard), use the [HA Merge Sensor History](https://github.com/mayerwin/HA-Merge-Sensor-History) custom component. It imports the older history in front of the new sensor in a single atomic, idempotent transaction, so your consumption graphs and lifetime totals stay continuous across the switch. Back up your recorder database first.
 


### PR DESCRIPTION
## Summary

Automates the Table of Contents in both README files and documents a tool for migrating sensor history when switching platforms.

### Changes

- **New workflow** `.github/workflows/toc.yml` using [`technote-space/toc-generator`](https://github.com/marketplace/actions/toc-generator). It regenerates the TOC in `README.md` and `ESPHOME/README.md` (up to heading level 3) on push to `main`/`develop` and commits any changes back.
- **Converted both READMEs** from hand-maintained TOCs to DocToc marker blocks (`<!-- START doctoc -->` … `<!-- END doctoc -->`), pre-populated locally with the same settings the action uses so they render immediately.
- **Added a "Migrating Sensor History Between Platforms" section** (now a `###` heading, so it appears in the TOC) pointing to [HA Merge Sensor History](https://github.com/mayerwin/HA-Merge-Sensor-History) for merging old-sensor history into a new entity when moving MQTT ↔ ESPHome or replacing hardware. Credits [@rommess](https://github.com/rommess) via discussion #129.

### Reviewer notes

- The auto-generated TOC now lists all `##`/`###` headings, so it is longer than the previous curated `##`-only list in the main README. Lowering `MAX_HEADER_LEVEL` to `2` would shorten it (but drop the new migration subsection).
- The action commits directly to the branch. If `main`/`develop` is protected, it may need bypass permissions, a PAT, or switching to `CREATE_PR: true`.