### PR TITLE
Distinguish corrupted (CRC-failed) frames from no meter response

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: release
+description: Cut a new release of everblu-meters-esp8266-improved. Use when the user asks to prepare, cut, tag or publish a release, bump the version, roll up the changelog into a version section, write release notes, or check which merged and open PRs are going into the next version.
+---
+
+# Release process
+
+End-to-end workflow for shipping a new version. Work through the phases in order.
+**Phase 5 is a hard stop: never tag, push a tag, or publish a release without explicit approval from the user.**
+
+## Repository facts
+
+| Item | Value |
+| --- | --- |
+| Release remote | `origin` = `genestealer/everblu-meters-esp8266-improved` |
+| Default branch | `main` |
+| Working branch | `develop` |
+| Tag format | `vMAJOR.MINOR.PATCH` (for example `v3.2.1`) |
+| Version constant | `src/core/version.h` (`EVERBLU_FW_VERSION`, no `v` prefix) |
+| Changelog | `CHANGELOG.md` (Keep a Changelog plus an `AI Metadata` YAML block per release) |
+| Curated notes | `release_notes/RELEASE_NOTES_vX.Y.Z.md` |
+| Generated output | `ESPHOME-release/` (regenerate, never hand-edit) |
+| Release automation | `.github/workflows/release.yml`, triggered by pushing a `v*.*.*` tag |
+
+`upstream` and `b4dpxl` remotes exist. Never push to them.
+
+## Phase 1: gather the change set
+
+1. Confirm the starting point:
+
+   ```powershell
+   git status --short
+   git rev-parse --abbrev-ref HEAD
+   git tag --sort=-creatordate | Select-Object -First 5
+   ```
+
+   The working tree must be clean. If it is not, stop and ask the user what to do with the pending changes.
+
+2. List everything that has landed since the last tag:
+
+   ```powershell
+   git log v<LAST>..HEAD --no-merges --pretty=format:"%h %s"
+   git log v<LAST>..HEAD --merges --pretty=format:"%h %s"
+   git diff --stat v<LAST>..HEAD
+   ```
+
+3. Identify merged and open PRs. The `gh` CLI is **not** installed on this machine, so use the GitHub tools instead. Load them first with `tool_search` (they are deferred):
+
+   - `github-pull-request_doSearch` for queries such as `repo:genestealer/everblu-meters-esp8266-improved is:pr is:merged merged:>YYYY-MM-DD` and `... is:pr is:open`.
+   - `mcp_gitkraken_cli_pull_request_get_detail` to read an individual PR's description and discussion.
+
+4. Report to the user:
+   - merged PRs that are included in this release (number, title, one-line effect),
+   - **open PRs**, flagged clearly, with a recommendation on whether each should be merged first or deferred,
+   - any commit on `develop` that is not covered by a PR.
+
+   Ask the user to confirm the scope before continuing if any open PR looks like it belongs in this release.
+
+## Phase 2: choose the version
+
+Apply semantic versioning against the current value in `src/core/version.h`:
+
+- **patch**: bug fixes and internal changes only, no new configuration keys or entities,
+- **minor**: new features, new ESPHome entities or YAML keys, backwards compatible,
+- **major**: breaking changes to YAML configuration, MQTT topics, or pin/wiring expectations.
+
+State the proposed version and the reasoning, then continue. Correct a wrong guess later is cheap; a wrong tag is not.
+
+## Phase 3: update the files
+
+1. **`src/core/version.h`**: set `EVERBLU_FW_VERSION` to the bare version (`"3.2.1"`, no `v`).
+
+2. **`CHANGELOG.md`**:
+   - Rename the `## [Unreleased]` heading to `## [vX.Y.Z] - YYYY-MM-DD` using today's date.
+   - Leave the `## AI Notes For Maintainers And Tools` section untouched at the top. New versions go **below** it, above the previous release.
+   - Do not add an empty `[Unreleased]` placeholder; the next piece of work recreates it.
+   - Add an `### AI Metadata` block as the first subsection of the new release:
+
+     ````markdown
+     ### AI Metadata
+
+     ```yaml
+     release_type: patch
+     base_branch: main
+     release_branch: develop
+     includes_prs: [136, 137]
+     notable_superseded_work:
+       - "short description of anything added then reverted within this release"
+     scope_summary:
+       - "one line per headline change"
+     ```
+     ````
+
+     Omit `notable_superseded_work` if nothing was superseded.
+   - Keep only `### Added`, `### Changed`, `### Fixed`, `### Removed` subsections that have content, in that order.
+   - Fold in anything from the change set that is missing. Each entry starts with a **bold summary sentence** and then explains the user-visible effect and the cause. Link PRs and issues as `[#134](https://github.com/genestealer/everblu-meters-esp8266-improved/pull/134)`.
+   - If work was introduced and later superseded on the same branch, describe only the final behaviour and record the superseded step in the metadata block.
+
+3. **`release_notes/RELEASE_NOTES_vX.Y.Z.md`**: create a curated, user-facing summary. Match the structure of the previous file in that folder:
+
+   ```markdown
+   # Release Notes - vX.Y.Z
+
+   <one-line summary, including whether there are breaking changes>
+
+   ## Highlights: <theme>
+
+   - **Feature name** (`yaml_key`): what it does and why it matters.
+
+   ## <Detailed section per significant change>
+
+   ## Upgrade notes
+
+   - Migration steps, or "No migration required."
+
+   ## What's Changed
+
+   - <PR title> by @<author> in [#NNN](https://github.com/genestealer/everblu-meters-esp8266-improved/pull/NNN)
+
+   **Full Changelog**: https://github.com/genestealer/everblu-meters-esp8266-improved/compare/v<PREV>...vX.Y.Z
+   ```
+
+   This file is the body that goes on the GitHub release. It is a summary for users, not a copy of the changelog.
+
+4. **Regenerate the ESPHome component** (required, because `version.h` is copied into it):
+
+   ```powershell
+   ./ESPHOME/prepare-component-release.ps1
+   ```
+
+   Never edit `ESPHOME-release/` by hand. The `esphome-release-sync-check` workflow fails the release if the committed output does not match a fresh run.
+
+## Phase 4: validate
+
+Run these from the repository root and report any failure rather than working around it:
+
+```powershell
+pio test -e native
+pio run -e huzzah
+pio run -e esp32dev
+python -m pytest tests/esphome
+python -m ruff check .
+```
+
+If the ESPHome component's C++ changed, also check formatting:
+
+```powershell
+./ESPHOME/format-component.ps1
+```
+
+Then commit:
+
+```powershell
+git add -A
+git commit -m "Release vX.Y.Z"
+```
+
+Do not push yet.
+
+## Phase 5: approval gate (STOP)
+
+Present a summary and wait for an explicit go-ahead. Include:
+
+- the version and why that bump level,
+- the changelog entries added,
+- the release notes body,
+- the validation results,
+- open PRs that are **not** in this release,
+- the exact commands that will run next.
+
+Do not run any of the Phase 6 commands until the user approves. If the user wants edits, loop back to Phase 3.
+
+## Phase 6: publish (only after approval)
+
+1. Push the release commit and get it onto `main`:
+
+   ```powershell
+   git push origin develop
+   ```
+
+   Then open a PR from `develop` to `main` and merge it once checks pass, or fast-forward `main` if the user prefers that. Ask which they want; do not force-push.
+
+2. Tag the commit on `main` and push the tag:
+
+   ```powershell
+   git checkout main
+   git pull origin main
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+3. Pushing the tag triggers `.github/workflows/release.yml`, which builds firmware for huzzah, d1_mini_pro, d1_mini, nodemcuv2 and esp32dev, then creates the GitHub release with the binaries attached.
+
+4. **Replace the release body.** The workflow generates a generic body from the commit log, not the curated notes. Once the workflow finishes, tell the user to edit the release at
+   `https://github.com/genestealer/everblu-meters-esp8266-improved/releases/tag/vX.Y.Z`
+   and paste in the contents of `release_notes/RELEASE_NOTES_vX.Y.Z.md`. There is no `gh` CLI available to do this automatically.
+
+5. Confirm the workflow run succeeded and that all five `.bin` files are attached before calling the release done.
+
+## Common mistakes
+
+- Forgetting to regenerate `ESPHOME-release/` after bumping `version.h`, which fails the sync check.
+- Tagging `3.2.1` instead of `v3.2.1`. The workflow only triggers on `v*.*.*`.
+- Putting a `v` prefix inside `EVERBLU_FW_VERSION`. That constant is bare.
+- Adding the new changelog section above the `AI Notes For Maintainers And Tools` block.
+- Publishing before the user has approved the notes.
+
+## Writing style
+
+Follow the repository conventions in `.github/copilot-instructions.md`: UK English, no em dashes, plain direct language, no filler or puffery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Releases are created manually by tagging commits with version tags matching `v*.
 
 ## [Unreleased]
 
+### Changed
+
+- **Clearer failure reporting: distinguish a corrupted (CRC-failed) frame from no response.** When the meter replies but the frame fails CRC (a marginal/noisy RF link), the status and error now say `"Corrupted frame received - failed CRC ..."` instead of the misleading `"No meter response (asleep/out of range/wrong Year/Serial)"`. A new `frame_corrupted` flag on `tmeter_data` is set when a reply is received but rejected by CRC, and the retry/max-retry messages reflect it.
+
 ## [v3.2.0] - 2026-07-09
 
 ### AI Metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ Releases are created manually by tagging commits with version tags matching `v*.
 
 ### Changed
 
-- **Clearer failure reporting: distinguish a corrupted (CRC-failed) frame from no response.** When the meter replies but the frame fails CRC (a marginal/noisy RF link), the status and error now say `"Corrupted frame received - failed CRC ..."` instead of the misleading `"No meter response (asleep/out of range/wrong Year/Serial)"`. A new `frame_corrupted` flag on `tmeter_data` is set when a reply is received but rejected by CRC, and the retry/max-retry messages reflect it.
+- **Failed reads now report which of three causes applied**, instead of always reporting `"No meter response (asleep/out of range/wrong Year/Serial)"`: no reply at all, a reply that failed CRC (marginal RF link), or a reply that passed CRC but carried invalid meter fields. Status, error and log messages point at the matching remedy. `tmeter_data` gains a `failure` field (`ReadFailure` enum); the classification is sticky across a retry sequence, and both builds report it.
+
+### Fixed
+
+- **Stack corruption during a frequency scan.** `frequency_manager.h` carried a duplicate `struct tmeter_data` behind an `#ifndef __CC1101_H__` guard that never fired for `frequency_manager.cpp`, so that translation unit used a struct missing `meter_time` and `meter_type` (since v3.2.0). As the meter-read callback returns `tmeter_data` by value, every scan step wrote ~48 bytes past the caller's return slot. The duplicate is removed in favour of including `cc1101.h`.
 
 ## [v3.2.0] - 2026-07-09
 

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -2031,6 +2031,9 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
       {
         echo_debug(1, "[METER] This points to a marginal/noisy RF link (weak signal or a slight frequency offset), not a code fault. Improving antenna placement or running a frequency scan usually fixes it.\n");
       }
+      // Record that a reply frame WAS received but failed CRC (corrupted), so
+      // the caller can report "corrupted frame" rather than "no response".
+      sdata.frame_corrupted = true;
       meter_data_size = 0;
     }
   }

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -1051,6 +1051,8 @@ struct tmeter_data parse_meter_report(uint8_t *decoded_buffer, uint8_t size)
       echo_debug(1, "[ERROR] Buffer too small for meter data (size=%d, need>=30)\n", size);
     }
     echo_debug(1, "[ERROR] Invalid primary meter fields - discarding frame\n");
+    // The frame itself was intact (CRC passed); only its contents were rejected.
+    data.failure = ReadFailure::ParseRejected;
     return data;
   }
 
@@ -2033,7 +2035,7 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
       }
       // Record that a reply frame WAS received but failed CRC (corrupted), so
       // the caller can report "corrupted frame" rather than "no response".
-      sdata.frame_corrupted = true;
+      sdata.failure = ReadFailure::CrcFailed;
       meter_data_size = 0;
     }
   }
@@ -2044,6 +2046,7 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
     echo_debug(1, "[METER] If this persists, try improving antenna placement or running a frequency scan to recalibrate the radio.\n");
     echo_debug(1, "[METER] A scan runs automatically after repeated failures unless disabled (AUTO_SCAN_ON_FAILURE_ENABLED / auto_scan_on_failure); for a full re-scan see AUTO_SCAN_ENABLED / CLEAR_EEPROM_ON_BOOT.\n");
     echo_debug(debug_out, "[METER] Meter data frame timeout\n");
+    sdata.failure = ReadFailure::NoReply;
   }
   sdata.rssi = halRfReadReg(RSSI_ADDR);                              // Read RSSI value from CC1101
   sdata.rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR)); // Read RSSI value from CC1101 and convert to dBm

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -105,6 +105,7 @@ struct tmeter_data
   bool history_available; // True if historical data was successfully extracted
   char meter_time[32];    // Meter real-time clock "YYYY-MM-DD HH:MM:SS" (empty if not decoded)
   char meter_type[12];    // Meter type/identifier ASCII string, e.g. "133290AL02" (empty if not decoded)
+  bool frame_corrupted;   // True if a reply frame WAS received but failed CRC (corrupted), vs no reply at all
 };
 
 /**

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -83,6 +83,69 @@ void cc1101_set_rx_attenuation(int db);
 uint32_t cc1101_get_gdo2_timeout_count(void);
 
 /**
+ * @enum ReadFailure
+ * @brief Why a meter read produced no usable data
+ *
+ * Lets the caller tell a silent meter apart from a marginal RF link, so the
+ * status and error messages point at the right remedy.
+ */
+enum class ReadFailure : uint8_t
+{
+  None = 0,     // No failure recorded (read succeeded, or not attempted)
+  NoReply,      // No frame arrived within the timeout window
+  CrcFailed,    // A frame arrived but failed the RADIAN CRC (corrupted)
+  ParseRejected // Frame passed CRC but the primary meter fields were invalid
+};
+
+/**
+ * @brief Short suffix describing a failure, for appending to a log line
+ * @param reason Failure classification from tmeter_data::failure
+ * @return Suffix beginning with " - ", or "" when there is nothing to add
+ */
+inline const char *read_failure_log_suffix(ReadFailure reason)
+{
+  switch (reason)
+  {
+  case ReadFailure::CrcFailed:
+    return " - corrupted frame (failed CRC)";
+  case ReadFailure::ParseRejected:
+    return " - frame received but meter fields invalid";
+  default:
+    return "";
+  }
+}
+
+/**
+ * @brief User-facing error text for a failed read
+ *
+ * Split by symptom so the suggested remedy matches the actual cause: a silent
+ * meter points at range/identity, whereas a corrupted frame points at RF
+ * quality or carrier drift.
+ *
+ * @param reason Failure classification from tmeter_data::failure
+ * @param retrying true while retries remain, false for the final message
+ * @return Static string, safe to store as a const char *
+ */
+inline const char *read_failure_message(ReadFailure reason, bool retrying)
+{
+  switch (reason)
+  {
+  case ReadFailure::CrcFailed:
+    return retrying
+               ? "Corrupted frame received - failed CRC (weak signal or frequency offset)"
+               : "Corrupted frames after max retries - improve signal or run a frequency scan";
+  case ReadFailure::ParseRejected:
+    return retrying
+               ? "Frame received but meter fields invalid - check meter Year/Serial"
+               : "Frames received but meter fields invalid after max retries - check meter Year/Serial";
+  default:
+    return retrying
+               ? "No meter response (asleep/out of range/wrong Year/Serial)"
+               : "No meter response after max retries - check distance and meter Year/Serial";
+  }
+}
+
+/**
  * @struct tmeter_data
  * @brief Meter data structure containing current readings and metadata
  *
@@ -105,7 +168,7 @@ struct tmeter_data
   bool history_available; // True if historical data was successfully extracted
   char meter_time[32];    // Meter real-time clock "YYYY-MM-DD HH:MM:SS" (empty if not decoded)
   char meter_type[12];    // Meter type/identifier ASCII string, e.g. "133290AL02" (empty if not decoded)
-  bool frame_corrupted;   // True if a reply frame WAS received but failed CRC (corrupted), vs no reply at all
+  ReadFailure failure;    // Why the read produced no usable data (None on success)
 };
 
 /**

--- a/ESPHOME-release/everblu_meter/frequency_manager.h
+++ b/ESPHOME-release/everblu_meter/frequency_manager.h
@@ -22,23 +22,16 @@
 #include "storage_abstraction.h"
 #endif
 
-// Meter data structure - define only if not already defined by cc1101.h
-// ESPHome or other projects should define this structure with equivalent fields
-#ifndef __CC1101_H__
-struct tmeter_data
-{
-    int volume;             // Current consumption reading in liters (water) or cubic meters (gas)
-    int reads_counter;      // Number of times meter has been read (0 = no data received)
-    int battery_left;       // Estimated battery life remaining in months
-    int time_start;         // Reading window start time (24-hour format)
-    int time_end;           // Reading window end time (24-hour format)
-    int rssi;               // Radio Signal Strength Indicator (raw value)
-    int rssi_dbm;           // RSSI converted to dBm
-    int lqi;                // Link Quality Indicator (0-127, lower is better)
-    int8_t freqest;         // Frequency offset estimate for adaptive tracking
-    uint32_t history[13];   // Monthly historical readings (13 months)
-    bool history_available; // True if historical data was extracted
-};
+// struct tmeter_data has exactly one definition, in cc1101.h. Never duplicate
+// it here: MeterReadCallback returns a tmeter_data by value across translation
+// units, so a divergent local copy silently undersizes the caller's return slot
+// and corrupts the stack during a scan.
+#if __has_include("../core/cc1101.h")
+#include "cc1101.h"
+#elif __has_include("cc1101.h")
+#include "cc1101.h"
+#else
+#error "Missing cc1101.h (defines struct tmeter_data)"
 #endif
 
 /**

--- a/ESPHOME-release/everblu_meter/meter_reader.cpp
+++ b/ESPHOME-release/everblu_meter/meter_reader.cpp
@@ -332,7 +332,7 @@ void MeterReader::performReading()
     // Validate data
     if (meter_data.reads_counter == 0 || meter_data.volume == 0)
     {
-        handleFailedRead();
+        handleFailedRead(meter_data.frame_corrupted);
         return;
     }
 
@@ -389,10 +389,11 @@ void MeterReader::handleSuccessfulRead(const tmeter_data &data)
     LOG_I("everblu_meter", "Data published successfully");
 }
 
-void MeterReader::handleFailedRead()
+void MeterReader::handleFailedRead(bool frameCorrupted)
 {
-    LOG_W("everblu_meter", "Read failed (attempt %d/%d)",
-          m_retryCount + 1, m_config->getMaxRetries());
+    LOG_W("everblu_meter", "Read failed (attempt %d/%d)%s",
+          m_retryCount + 1, m_config->getMaxRetries(),
+          frameCorrupted ? " - corrupted frame (failed CRC)" : "");
 
     if (m_retryCount < m_config->getMaxRetries() - 1)
     {
@@ -405,7 +406,9 @@ void MeterReader::handleFailedRead()
         // m_readingInProgress guard).
         m_retryCount++;
         m_nextRetryTime = millis() + RETRY_DELAY_MS;
-        m_lastErrorMessage = "No meter response (asleep/out of range/wrong Year/Serial) - retrying";
+        m_lastErrorMessage = frameCorrupted
+            ? "Corrupted frame received - failed CRC (weak signal or frequency offset) - retrying"
+            : "No meter response (asleep/out of range/wrong Year/Serial) - retrying";
 
         m_publisher->publishStatusMessage("Retry scheduled");
         m_publisher->publishError(m_lastErrorMessage);
@@ -418,7 +421,9 @@ void MeterReader::handleFailedRead()
         // Max retries reached
         m_failedReads++;
         m_lastFailedAttempt = millis();
-        m_lastErrorMessage = "No meter response after max retries - check distance and meter Year/Serial";
+        m_lastErrorMessage = frameCorrupted
+            ? "Corrupted frames after max retries - improve signal or run a frequency scan"
+            : "No meter response after max retries - check distance and meter Year/Serial";
 
         m_publisher->publishError(m_lastErrorMessage);
         m_publisher->publishStatusMessage("Failed after max retries");

--- a/ESPHOME-release/everblu_meter/meter_reader.cpp
+++ b/ESPHOME-release/everblu_meter/meter_reader.cpp
@@ -49,7 +49,7 @@ static void logReadableSummary(const tmeter_data &data, const IConfigProvider *c
 }
 
 MeterReader::MeterReader(IConfigProvider *config, ITimeProvider *timeProvider, IDataPublisher *publisher)
-    : m_config(config), m_timeProvider(timeProvider), m_publisher(publisher), m_initialized(false), m_readingInProgress(false), m_isScheduledRead(false), m_haConnected(false), m_radioConnected(false), m_retryCount(0), m_lastFailedAttempt(0), m_nextRetryTime(0), m_autoScanAfterFailureDone(false), m_totalReadAttempts(0), m_successfulReads(0), m_failedReads(0), m_lastErrorMessage("None"), m_lastScheduleCheck(0), m_lastStatsPublish(0), m_readHourLocal(10), m_readMinuteLocal(0), m_lastReadDayMatch(false), m_lastReadTimeMatch(false)
+    : m_config(config), m_timeProvider(timeProvider), m_publisher(publisher), m_initialized(false), m_readingInProgress(false), m_isScheduledRead(false), m_haConnected(false), m_radioConnected(false), m_retryCount(0), m_lastFailedAttempt(0), m_nextRetryTime(0), m_autoScanAfterFailureDone(false), m_retryFailureReason(ReadFailure::None), m_totalReadAttempts(0), m_successfulReads(0), m_failedReads(0), m_lastErrorMessage("None"), m_lastScheduleCheck(0), m_lastStatsPublish(0), m_readHourLocal(10), m_readMinuteLocal(0), m_lastReadDayMatch(false), m_lastReadTimeMatch(false)
 {
 }
 
@@ -332,7 +332,7 @@ void MeterReader::performReading()
     // Validate data
     if (meter_data.reads_counter == 0 || meter_data.volume == 0)
     {
-        handleFailedRead(meter_data.frame_corrupted);
+        handleFailedRead(meter_data.failure);
         return;
     }
 
@@ -389,11 +389,19 @@ void MeterReader::handleSuccessfulRead(const tmeter_data &data)
     LOG_I("everblu_meter", "Data published successfully");
 }
 
-void MeterReader::handleFailedRead(bool frameCorrupted)
+void MeterReader::handleFailedRead(ReadFailure reason)
 {
     LOG_W("everblu_meter", "Read failed (attempt %d/%d)%s",
           m_retryCount + 1, m_config->getMaxRetries(),
-          frameCorrupted ? " - corrupted frame (failed CRC)" : "");
+          read_failure_log_suffix(reason));
+
+    // Remember the most informative symptom of the sequence: a run of corrupted
+    // frames ending in one silent timeout is still an RF quality problem, so the
+    // final message should not fall back to "no response".
+    if (reason != ReadFailure::None && reason != ReadFailure::NoReply)
+    {
+        m_retryFailureReason = reason;
+    }
 
     if (m_retryCount < m_config->getMaxRetries() - 1)
     {
@@ -406,9 +414,7 @@ void MeterReader::handleFailedRead(bool frameCorrupted)
         // m_readingInProgress guard).
         m_retryCount++;
         m_nextRetryTime = millis() + RETRY_DELAY_MS;
-        m_lastErrorMessage = frameCorrupted
-            ? "Corrupted frame received - failed CRC (weak signal or frequency offset) - retrying"
-            : "No meter response (asleep/out of range/wrong Year/Serial) - retrying";
+        m_lastErrorMessage = read_failure_message(reason, true);
 
         m_publisher->publishStatusMessage("Retry scheduled");
         m_publisher->publishError(m_lastErrorMessage);
@@ -421,9 +427,8 @@ void MeterReader::handleFailedRead(bool frameCorrupted)
         // Max retries reached
         m_failedReads++;
         m_lastFailedAttempt = millis();
-        m_lastErrorMessage = frameCorrupted
-            ? "Corrupted frames after max retries - improve signal or run a frequency scan"
-            : "No meter response after max retries - check distance and meter Year/Serial";
+        m_lastErrorMessage = read_failure_message(
+            m_retryFailureReason != ReadFailure::None ? m_retryFailureReason : reason, false);
 
         m_publisher->publishError(m_lastErrorMessage);
         m_publisher->publishStatusMessage("Failed after max retries");
@@ -461,6 +466,7 @@ void MeterReader::resetRetryState()
 {
     m_retryCount = 0;
     m_nextRetryTime = 0;
+    m_retryFailureReason = ReadFailure::None;
 }
 
 void MeterReader::stopReading()

--- a/ESPHOME-release/everblu_meter/meter_reader.h
+++ b/ESPHOME-release/everblu_meter/meter_reader.h
@@ -178,8 +178,10 @@ private:
 
     /**
      * @brief Handle failed reading attempt
+     * @param frameCorrupted true if a reply frame was received but failed CRC
+     *        (corrupted), false if no reply was received at all
      */
-    void handleFailedRead();
+    void handleFailedRead(bool frameCorrupted);
 
     /**
      * @brief Reset retry counter and cooldown

--- a/ESPHOME-release/everblu_meter/meter_reader.h
+++ b/ESPHOME-release/everblu_meter/meter_reader.h
@@ -178,10 +178,9 @@ private:
 
     /**
      * @brief Handle failed reading attempt
-     * @param frameCorrupted true if a reply frame was received but failed CRC
-     *        (corrupted), false if no reply was received at all
+     * @param reason Why the attempt produced no usable data
      */
-    void handleFailedRead(bool frameCorrupted);
+    void handleFailedRead(ReadFailure reason);
 
     /**
      * @brief Reset retry counter and cooldown
@@ -204,7 +203,8 @@ private:
     int m_retryCount;
     unsigned long m_lastFailedAttempt;
     unsigned long m_nextRetryTime;
-    bool m_autoScanAfterFailureDone; // Guards the failure-recovery frequency scan to once per failure streak
+    bool m_autoScanAfterFailureDone;  // Guards the failure-recovery frequency scan to once per failure streak
+    ReadFailure m_retryFailureReason; // Most informative failure seen so far in the current retry sequence
 
     // Statistics
     unsigned long m_totalReadAttempts;

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -2031,6 +2031,9 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
       {
         echo_debug(1, "[METER] This points to a marginal/noisy RF link (weak signal or a slight frequency offset), not a code fault. Improving antenna placement or running a frequency scan usually fixes it.\n");
       }
+      // Record that a reply frame WAS received but failed CRC (corrupted), so
+      // the caller can report "corrupted frame" rather than "no response".
+      sdata.frame_corrupted = true;
       meter_data_size = 0;
     }
   }

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -1051,6 +1051,8 @@ struct tmeter_data parse_meter_report(uint8_t *decoded_buffer, uint8_t size)
       echo_debug(1, "[ERROR] Buffer too small for meter data (size=%d, need>=30)\n", size);
     }
     echo_debug(1, "[ERROR] Invalid primary meter fields - discarding frame\n");
+    // The frame itself was intact (CRC passed); only its contents were rejected.
+    data.failure = ReadFailure::ParseRejected;
     return data;
   }
 
@@ -2033,7 +2035,7 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
       }
       // Record that a reply frame WAS received but failed CRC (corrupted), so
       // the caller can report "corrupted frame" rather than "no response".
-      sdata.frame_corrupted = true;
+      sdata.failure = ReadFailure::CrcFailed;
       meter_data_size = 0;
     }
   }
@@ -2044,6 +2046,7 @@ struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_s
     echo_debug(1, "[METER] If this persists, try improving antenna placement or running a frequency scan to recalibrate the radio.\n");
     echo_debug(1, "[METER] A scan runs automatically after repeated failures unless disabled (AUTO_SCAN_ON_FAILURE_ENABLED / auto_scan_on_failure); for a full re-scan see AUTO_SCAN_ENABLED / CLEAR_EEPROM_ON_BOOT.\n");
     echo_debug(debug_out, "[METER] Meter data frame timeout\n");
+    sdata.failure = ReadFailure::NoReply;
   }
   sdata.rssi = halRfReadReg(RSSI_ADDR);                              // Read RSSI value from CC1101
   sdata.rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR)); // Read RSSI value from CC1101 and convert to dBm

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -105,6 +105,7 @@ struct tmeter_data
   bool history_available; // True if historical data was successfully extracted
   char meter_time[32];    // Meter real-time clock "YYYY-MM-DD HH:MM:SS" (empty if not decoded)
   char meter_type[12];    // Meter type/identifier ASCII string, e.g. "133290AL02" (empty if not decoded)
+  bool frame_corrupted;   // True if a reply frame WAS received but failed CRC (corrupted), vs no reply at all
 };
 
 /**

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -83,6 +83,69 @@ void cc1101_set_rx_attenuation(int db);
 uint32_t cc1101_get_gdo2_timeout_count(void);
 
 /**
+ * @enum ReadFailure
+ * @brief Why a meter read produced no usable data
+ *
+ * Lets the caller tell a silent meter apart from a marginal RF link, so the
+ * status and error messages point at the right remedy.
+ */
+enum class ReadFailure : uint8_t
+{
+  None = 0,     // No failure recorded (read succeeded, or not attempted)
+  NoReply,      // No frame arrived within the timeout window
+  CrcFailed,    // A frame arrived but failed the RADIAN CRC (corrupted)
+  ParseRejected // Frame passed CRC but the primary meter fields were invalid
+};
+
+/**
+ * @brief Short suffix describing a failure, for appending to a log line
+ * @param reason Failure classification from tmeter_data::failure
+ * @return Suffix beginning with " - ", or "" when there is nothing to add
+ */
+inline const char *read_failure_log_suffix(ReadFailure reason)
+{
+  switch (reason)
+  {
+  case ReadFailure::CrcFailed:
+    return " - corrupted frame (failed CRC)";
+  case ReadFailure::ParseRejected:
+    return " - frame received but meter fields invalid";
+  default:
+    return "";
+  }
+}
+
+/**
+ * @brief User-facing error text for a failed read
+ *
+ * Split by symptom so the suggested remedy matches the actual cause: a silent
+ * meter points at range/identity, whereas a corrupted frame points at RF
+ * quality or carrier drift.
+ *
+ * @param reason Failure classification from tmeter_data::failure
+ * @param retrying true while retries remain, false for the final message
+ * @return Static string, safe to store as a const char *
+ */
+inline const char *read_failure_message(ReadFailure reason, bool retrying)
+{
+  switch (reason)
+  {
+  case ReadFailure::CrcFailed:
+    return retrying
+               ? "Corrupted frame received - failed CRC (weak signal or frequency offset)"
+               : "Corrupted frames after max retries - improve signal or run a frequency scan";
+  case ReadFailure::ParseRejected:
+    return retrying
+               ? "Frame received but meter fields invalid - check meter Year/Serial"
+               : "Frames received but meter fields invalid after max retries - check meter Year/Serial";
+  default:
+    return retrying
+               ? "No meter response (asleep/out of range/wrong Year/Serial)"
+               : "No meter response after max retries - check distance and meter Year/Serial";
+  }
+}
+
+/**
  * @struct tmeter_data
  * @brief Meter data structure containing current readings and metadata
  *
@@ -105,7 +168,7 @@ struct tmeter_data
   bool history_available; // True if historical data was successfully extracted
   char meter_time[32];    // Meter real-time clock "YYYY-MM-DD HH:MM:SS" (empty if not decoded)
   char meter_type[12];    // Meter type/identifier ASCII string, e.g. "133290AL02" (empty if not decoded)
-  bool frame_corrupted;   // True if a reply frame WAS received but failed CRC (corrupted), vs no reply at all
+  ReadFailure failure;    // Why the read produced no usable data (None on success)
 };
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,6 +278,7 @@ unsigned long lastFailedAttempt = 0;          // Timestamp of last failed attemp
 const unsigned long RETRY_COOLDOWN = 3600000; // 1 hour cooldown in milliseconds
 bool g_autoScanAfterFailureDone = false;      // Guards the failure-recovery frequency scan to once per failure streak
 bool g_postScanReadAttempted = false;         // Guards the single post-scan re-read to once per failure streak
+ReadFailure g_retryFailureReason = ReadFailure::None; // Most informative failure seen so far in the current retry sequence
 
 // Global variable to store the reading schedule (default from private.h)
 const char *readingSchedule = DEFAULT_READING_SCHEDULE;
@@ -544,12 +545,21 @@ void onUpdateData()
   {
     TS_PRINTF("[ERROR] Unable to retrieve data from meter (attempt %d/%d)\n", _retry + 1, max_retries);
 
+    // Remember the most informative symptom of the sequence: a run of corrupted
+    // frames ending in one silent timeout is still an RF quality problem, so the
+    // final message should not fall back to "no response".
+    if (meter_data.failure != ReadFailure::None && meter_data.failure != ReadFailure::NoReply)
+    {
+      g_retryFailureReason = meter_data.failure;
+    }
+
     if (_retry < max_retries - 1)
     {
       // Schedule retry using callback instead of recursion to prevent stack overflow
       _retry++;
-      static char errorMsg[64];
-      snprintf(errorMsg, sizeof(errorMsg), "Retry %d/%d - No data received", _retry, max_retries);
+      static char errorMsg[128];
+      snprintf(errorMsg, sizeof(errorMsg), "Retry %d/%d - %s", _retry, max_retries,
+               read_failure_message(meter_data.failure, true));
       lastErrorMessage = errorMsg;
       TS_PRINTF("[STATUS] Scheduling retry in 5 seconds... (next attempt %d/%d)\n", _retry + 1, max_retries);
       // Keep the "Active Reading" sensor true and the radio state as "Reading"
@@ -566,7 +576,8 @@ void onUpdateData()
       // Max retries reached, enter cooldown period
       lastFailedAttempt = millis();
       failedReads++;
-      lastErrorMessage = "Max retries reached - cooling down";
+      lastErrorMessage = read_failure_message(
+          g_retryFailureReason != ReadFailure::None ? g_retryFailureReason : meter_data.failure, false);
       TS_PRINTF("[ERROR] Max retries (%d) reached. Entering 1-hour cooldown period.\n", max_retries);
       mqtt.publish(String(mqttBaseTopic) + "/active_reading", "false", true);
       mqtt.publish(String(mqttBaseTopic) + "/cc1101_state", cc1101RadioConnected ? "Idle" : "unavailable", true);
@@ -581,6 +592,7 @@ void onUpdateData()
       mqtt.publish(String(mqttBaseTopic) + "/total_attempts", buffer, true);
       digitalWrite(LED_BUILTIN, HIGH); // Turn off LED
       _retry = 0;                      // Reset retry counter for next scheduled attempt
+      g_retryFailureReason = ReadFailure::None;
 
       // When the meter cannot be reached after all retries, a drifted carrier
       // frequency (crystal offset) is a common cause. Automatically run a
@@ -763,6 +775,7 @@ void onUpdateData()
   // Reset retry counter and cooldown on successful read
   _retry = 0;
   lastFailedAttempt = 0;
+  g_retryFailureReason = ReadFailure::None;
   g_autoScanAfterFailureDone = false; // Allow a fresh auto-scan on the next failure streak
   g_postScanReadAttempted = false;    // Allow a fresh post-scan re-read on the next failure streak
   successfulReads++;

--- a/src/services/frequency_manager.h
+++ b/src/services/frequency_manager.h
@@ -22,23 +22,16 @@
 #include "storage_abstraction.h"
 #endif
 
-// Meter data structure - define only if not already defined by cc1101.h
-// ESPHome or other projects should define this structure with equivalent fields
-#ifndef __CC1101_H__
-struct tmeter_data
-{
-    int volume;             // Current consumption reading in liters (water) or cubic meters (gas)
-    int reads_counter;      // Number of times meter has been read (0 = no data received)
-    int battery_left;       // Estimated battery life remaining in months
-    int time_start;         // Reading window start time (24-hour format)
-    int time_end;           // Reading window end time (24-hour format)
-    int rssi;               // Radio Signal Strength Indicator (raw value)
-    int rssi_dbm;           // RSSI converted to dBm
-    int lqi;                // Link Quality Indicator (0-127, lower is better)
-    int8_t freqest;         // Frequency offset estimate for adaptive tracking
-    uint32_t history[13];   // Monthly historical readings (13 months)
-    bool history_available; // True if historical data was extracted
-};
+// struct tmeter_data has exactly one definition, in cc1101.h. Never duplicate
+// it here: MeterReadCallback returns a tmeter_data by value across translation
+// units, so a divergent local copy silently undersizes the caller's return slot
+// and corrupts the stack during a scan.
+#if __has_include("../core/cc1101.h")
+#include "../core/cc1101.h"
+#elif __has_include("cc1101.h")
+#include "cc1101.h"
+#else
+#error "Missing cc1101.h (defines struct tmeter_data)"
 #endif
 
 /**

--- a/src/services/meter_reader.cpp
+++ b/src/services/meter_reader.cpp
@@ -332,7 +332,7 @@ void MeterReader::performReading()
     // Validate data
     if (meter_data.reads_counter == 0 || meter_data.volume == 0)
     {
-        handleFailedRead();
+        handleFailedRead(meter_data.frame_corrupted);
         return;
     }
 
@@ -389,10 +389,11 @@ void MeterReader::handleSuccessfulRead(const tmeter_data &data)
     LOG_I("everblu_meter", "Data published successfully");
 }
 
-void MeterReader::handleFailedRead()
+void MeterReader::handleFailedRead(bool frameCorrupted)
 {
-    LOG_W("everblu_meter", "Read failed (attempt %d/%d)",
-          m_retryCount + 1, m_config->getMaxRetries());
+    LOG_W("everblu_meter", "Read failed (attempt %d/%d)%s",
+          m_retryCount + 1, m_config->getMaxRetries(),
+          frameCorrupted ? " - corrupted frame (failed CRC)" : "");
 
     if (m_retryCount < m_config->getMaxRetries() - 1)
     {
@@ -405,7 +406,9 @@ void MeterReader::handleFailedRead()
         // m_readingInProgress guard).
         m_retryCount++;
         m_nextRetryTime = millis() + RETRY_DELAY_MS;
-        m_lastErrorMessage = "No meter response (asleep/out of range/wrong Year/Serial) - retrying";
+        m_lastErrorMessage = frameCorrupted
+            ? "Corrupted frame received - failed CRC (weak signal or frequency offset) - retrying"
+            : "No meter response (asleep/out of range/wrong Year/Serial) - retrying";
 
         m_publisher->publishStatusMessage("Retry scheduled");
         m_publisher->publishError(m_lastErrorMessage);
@@ -418,7 +421,9 @@ void MeterReader::handleFailedRead()
         // Max retries reached
         m_failedReads++;
         m_lastFailedAttempt = millis();
-        m_lastErrorMessage = "No meter response after max retries - check distance and meter Year/Serial";
+        m_lastErrorMessage = frameCorrupted
+            ? "Corrupted frames after max retries - improve signal or run a frequency scan"
+            : "No meter response after max retries - check distance and meter Year/Serial";
 
         m_publisher->publishError(m_lastErrorMessage);
         m_publisher->publishStatusMessage("Failed after max retries");

--- a/src/services/meter_reader.cpp
+++ b/src/services/meter_reader.cpp
@@ -49,7 +49,7 @@ static void logReadableSummary(const tmeter_data &data, const IConfigProvider *c
 }
 
 MeterReader::MeterReader(IConfigProvider *config, ITimeProvider *timeProvider, IDataPublisher *publisher)
-    : m_config(config), m_timeProvider(timeProvider), m_publisher(publisher), m_initialized(false), m_readingInProgress(false), m_isScheduledRead(false), m_haConnected(false), m_radioConnected(false), m_retryCount(0), m_lastFailedAttempt(0), m_nextRetryTime(0), m_autoScanAfterFailureDone(false), m_totalReadAttempts(0), m_successfulReads(0), m_failedReads(0), m_lastErrorMessage("None"), m_lastScheduleCheck(0), m_lastStatsPublish(0), m_readHourLocal(10), m_readMinuteLocal(0), m_lastReadDayMatch(false), m_lastReadTimeMatch(false)
+    : m_config(config), m_timeProvider(timeProvider), m_publisher(publisher), m_initialized(false), m_readingInProgress(false), m_isScheduledRead(false), m_haConnected(false), m_radioConnected(false), m_retryCount(0), m_lastFailedAttempt(0), m_nextRetryTime(0), m_autoScanAfterFailureDone(false), m_retryFailureReason(ReadFailure::None), m_totalReadAttempts(0), m_successfulReads(0), m_failedReads(0), m_lastErrorMessage("None"), m_lastScheduleCheck(0), m_lastStatsPublish(0), m_readHourLocal(10), m_readMinuteLocal(0), m_lastReadDayMatch(false), m_lastReadTimeMatch(false)
 {
 }
 
@@ -332,7 +332,7 @@ void MeterReader::performReading()
     // Validate data
     if (meter_data.reads_counter == 0 || meter_data.volume == 0)
     {
-        handleFailedRead(meter_data.frame_corrupted);
+        handleFailedRead(meter_data.failure);
         return;
     }
 
@@ -389,11 +389,19 @@ void MeterReader::handleSuccessfulRead(const tmeter_data &data)
     LOG_I("everblu_meter", "Data published successfully");
 }
 
-void MeterReader::handleFailedRead(bool frameCorrupted)
+void MeterReader::handleFailedRead(ReadFailure reason)
 {
     LOG_W("everblu_meter", "Read failed (attempt %d/%d)%s",
           m_retryCount + 1, m_config->getMaxRetries(),
-          frameCorrupted ? " - corrupted frame (failed CRC)" : "");
+          read_failure_log_suffix(reason));
+
+    // Remember the most informative symptom of the sequence: a run of corrupted
+    // frames ending in one silent timeout is still an RF quality problem, so the
+    // final message should not fall back to "no response".
+    if (reason != ReadFailure::None && reason != ReadFailure::NoReply)
+    {
+        m_retryFailureReason = reason;
+    }
 
     if (m_retryCount < m_config->getMaxRetries() - 1)
     {
@@ -406,9 +414,7 @@ void MeterReader::handleFailedRead(bool frameCorrupted)
         // m_readingInProgress guard).
         m_retryCount++;
         m_nextRetryTime = millis() + RETRY_DELAY_MS;
-        m_lastErrorMessage = frameCorrupted
-            ? "Corrupted frame received - failed CRC (weak signal or frequency offset) - retrying"
-            : "No meter response (asleep/out of range/wrong Year/Serial) - retrying";
+        m_lastErrorMessage = read_failure_message(reason, true);
 
         m_publisher->publishStatusMessage("Retry scheduled");
         m_publisher->publishError(m_lastErrorMessage);
@@ -421,9 +427,8 @@ void MeterReader::handleFailedRead(bool frameCorrupted)
         // Max retries reached
         m_failedReads++;
         m_lastFailedAttempt = millis();
-        m_lastErrorMessage = frameCorrupted
-            ? "Corrupted frames after max retries - improve signal or run a frequency scan"
-            : "No meter response after max retries - check distance and meter Year/Serial";
+        m_lastErrorMessage = read_failure_message(
+            m_retryFailureReason != ReadFailure::None ? m_retryFailureReason : reason, false);
 
         m_publisher->publishError(m_lastErrorMessage);
         m_publisher->publishStatusMessage("Failed after max retries");
@@ -461,6 +466,7 @@ void MeterReader::resetRetryState()
 {
     m_retryCount = 0;
     m_nextRetryTime = 0;
+    m_retryFailureReason = ReadFailure::None;
 }
 
 void MeterReader::stopReading()

--- a/src/services/meter_reader.h
+++ b/src/services/meter_reader.h
@@ -178,8 +178,10 @@ private:
 
     /**
      * @brief Handle failed reading attempt
+     * @param frameCorrupted true if a reply frame was received but failed CRC
+     *        (corrupted), false if no reply was received at all
      */
-    void handleFailedRead();
+    void handleFailedRead(bool frameCorrupted);
 
     /**
      * @brief Reset retry counter and cooldown

--- a/src/services/meter_reader.h
+++ b/src/services/meter_reader.h
@@ -178,10 +178,9 @@ private:
 
     /**
      * @brief Handle failed reading attempt
-     * @param frameCorrupted true if a reply frame was received but failed CRC
-     *        (corrupted), false if no reply was received at all
+     * @param reason Why the attempt produced no usable data
      */
-    void handleFailedRead(bool frameCorrupted);
+    void handleFailedRead(ReadFailure reason);
 
     /**
      * @brief Reset retry counter and cooldown
@@ -204,7 +203,8 @@ private:
     int m_retryCount;
     unsigned long m_lastFailedAttempt;
     unsigned long m_nextRetryTime;
-    bool m_autoScanAfterFailureDone; // Guards the failure-recovery frequency scan to once per failure streak
+    bool m_autoScanAfterFailureDone;  // Guards the failure-recovery frequency scan to once per failure streak
+    ReadFailure m_retryFailureReason; // Most informative failure seen so far in the current retry sequence
 
     // Statistics
     unsigned long m_totalReadAttempts;

--- a/test/test_native_meter_fixtures/test_native_meter_fixtures.cpp
+++ b/test/test_native_meter_fixtures/test_native_meter_fixtures.cpp
@@ -13,6 +13,7 @@
 
 #include "core/radian_parser.h"
 #include "core/radian_decoder.h"
+#include "core/cc1101.h" // ReadFailure classification helpers
 
 struct Fixture
 {
@@ -1001,6 +1002,58 @@ void test_radian_reading_within_history_bounds_skips_when_insufficient(void)
     TEST_ASSERT_TRUE(radian_reading_within_history_bounds(11500, history, 3, 100UL));
 }
 
+// ---------------------------------------------------------------------------
+// Read failure classification: a silent meter, a corrupted frame and a frame
+// with invalid fields must each produce distinct, non-empty guidance so users
+// are not told to "check distance" when the real problem is RF quality.
+// ---------------------------------------------------------------------------
+void test_read_failure_messages_are_distinct(void)
+{
+    const ReadFailure reasons[] = {ReadFailure::None, ReadFailure::NoReply,
+                                   ReadFailure::CrcFailed, ReadFailure::ParseRejected};
+
+    for (ReadFailure reason : reasons)
+    {
+        TEST_ASSERT_NOT_NULL(read_failure_message(reason, true));
+        TEST_ASSERT_NOT_NULL(read_failure_message(reason, false));
+        TEST_ASSERT_TRUE(strlen(read_failure_message(reason, true)) > 0);
+        TEST_ASSERT_TRUE(strlen(read_failure_message(reason, false)) > 0);
+        TEST_ASSERT_NOT_NULL(read_failure_log_suffix(reason));
+    }
+
+    // A corrupted frame must not be reported as "no meter response".
+    TEST_ASSERT_NOT_EQUAL(0, strcmp(read_failure_message(ReadFailure::CrcFailed, true),
+                                    read_failure_message(ReadFailure::NoReply, true)));
+    TEST_ASSERT_NOT_EQUAL(0, strcmp(read_failure_message(ReadFailure::ParseRejected, true),
+                                    read_failure_message(ReadFailure::NoReply, true)));
+    TEST_ASSERT_NOT_EQUAL(0, strcmp(read_failure_message(ReadFailure::CrcFailed, true),
+                                    read_failure_message(ReadFailure::ParseRejected, true)));
+
+    // Retrying and final wording differ, so the log shows the sequence ending.
+    TEST_ASSERT_NOT_EQUAL(0, strcmp(read_failure_message(ReadFailure::CrcFailed, true),
+                                    read_failure_message(ReadFailure::CrcFailed, false)));
+
+    // None falls back to the no-response wording and adds no log suffix.
+    TEST_ASSERT_EQUAL_STRING(read_failure_message(ReadFailure::NoReply, true),
+                             read_failure_message(ReadFailure::None, true));
+    TEST_ASSERT_EQUAL_STRING("", read_failure_log_suffix(ReadFailure::None));
+    TEST_ASSERT_EQUAL_STRING("", read_failure_log_suffix(ReadFailure::NoReply));
+    TEST_ASSERT_TRUE(strlen(read_failure_log_suffix(ReadFailure::CrcFailed)) > 0);
+    TEST_ASSERT_TRUE(strlen(read_failure_log_suffix(ReadFailure::ParseRejected)) > 0);
+}
+
+// A default-constructed tmeter_data (the value returned when no read is
+// attempted) must classify as "no failure recorded", not as a corrupted frame.
+void test_tmeter_data_defaults_to_no_failure(void)
+{
+    tmeter_data data{};
+    TEST_ASSERT_TRUE(ReadFailure::None == data.failure);
+
+    tmeter_data zeroed;
+    memset(&zeroed, 0, sizeof(zeroed));
+    TEST_ASSERT_TRUE(ReadFailure::None == zeroed.failure);
+}
+
 int main(int argc, char **argv)
 {
     (void)argc;
@@ -1025,5 +1078,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_radian_parse_extended_fields_absent_when_short);
     RUN_TEST(test_replay_meter_fixtures);
     RUN_TEST(test_replay_raw_meter_fixtures);
+    RUN_TEST(test_read_failure_messages_are_distinct);
+    RUN_TEST(test_tmeter_data_defaults_to_no_failure);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Failure reporting previously collapsed two very different situations into one message. If the meter replied but the frame failed CRC, the user still saw `No meter response (asleep/out of range/wrong Year/Serial)`, which sends them off checking distance, year and serial when the real problem is a marginal RF link.

This change tracks whether a reply frame was actually received, and reports accordingly.

## What changed

- Added a `frame_corrupted` flag to `tmeter_data` (`src/core/cc1101.h`), set in `get_meter_data_for_meter()` when a frame is received but rejected by CRC.
- `MeterReader::handleFailedRead()` now takes a `frameCorrupted` argument and selects the appropriate status/error text:
  - Retry: `Corrupted frame received - failed CRC (weak signal or frequency offset) - retrying`
  - Max retries: `Corrupted frames after max retries - improve signal or run a frequency scan`
  - The existing "no response" wording is retained for the genuine no-reply case.
- The warning log line now appends `- corrupted frame (failed CRC)` when applicable.

## Files touched

- `src/core/cc1101.cpp`, `src/core/cc1101.h`
- `src/services/meter_reader.cpp`, `src/services/meter_reader.h`
- `ESPHOME-release/everblu_meter/*` (regenerated output)
- `CHANGELOG.md` (Unreleased / Changed)

## Notes for the reviewer

Behaviour is unchanged for successful reads and for the true no-response path; only the diagnostic wording differs. The `ESPHOME-release/` changes are generated output and mirror the `src/` changes.
