### PR TITLE
Add host test coverage and fix four defects it uncovered

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,8 +8,10 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_fakes.*
       - test/native_shims/**
       - test/test_native_meter_fixtures/**
+      - test/test_native_meter_reader/**
       - test/test_embedded_unit/**
       - .github/workflows/coverage.yml
   pull_request:
@@ -19,8 +21,10 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_fakes.*
       - test/native_shims/**
       - test/test_native_meter_fixtures/**
+      - test/test_native_meter_reader/**
       - test/test_embedded_unit/**
       - .github/workflows/coverage.yml
   workflow_dispatch:
@@ -78,6 +82,10 @@ jobs:
             --filter src/core/crc_kermit.cpp \
             --filter src/core/radian_parser.cpp \
             --filter src/core/radian_decoder.cpp \
+            --filter src/core/utils.cpp \
+            --filter src/services/frequency_manager.cpp \
+            --filter src/services/meter_history.cpp \
+            --filter src/services/meter_reader.cpp \
             --filter src/services/schedule_manager.cpp \
             --object-directory .pio/build/native/ \
             --xml coverage.xml \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,9 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_shims/**
       - test/test_native_meter_fixtures/**
+      - test/test_embedded_unit/**
       - .github/workflows/coverage.yml
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -17,7 +19,9 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_shims/**
       - test/test_native_meter_fixtures/**
+      - test/test_embedded_unit/**
       - .github/workflows/coverage.yml
   workflow_dispatch:
 
@@ -74,6 +78,7 @@ jobs:
             --filter src/core/crc_kermit.cpp \
             --filter src/core/radian_parser.cpp \
             --filter src/core/radian_decoder.cpp \
+            --filter src/services/schedule_manager.cpp \
             --object-directory .pio/build/native/ \
             --xml coverage.xml \
             --print-summary

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,8 +8,10 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_esphome/**
       - test/native_fakes.*
       - test/native_shims/**
+      - test/test_native_esphome_publisher/**
       - test/test_native_meter_fixtures/**
       - test/test_native_meter_reader/**
       - test/test_embedded_unit/**
@@ -21,8 +23,10 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_esphome/**
       - test/native_fakes.*
       - test/native_shims/**
+      - test/test_native_esphome_publisher/**
       - test/test_native_meter_fixtures/**
       - test/test_native_meter_reader/**
       - test/test_embedded_unit/**
@@ -74,6 +78,7 @@ jobs:
       - name: Run native tests with coverage instrumentation
         run: |
           pio test -e native -v
+          pio test -e native_esphome -v
 
       - name: Collect coverage
         run: |
@@ -83,11 +88,12 @@ jobs:
             --filter src/core/radian_parser.cpp \
             --filter src/core/radian_decoder.cpp \
             --filter src/core/utils.cpp \
+            --filter src/adapters/implementations/esphome_data_publisher.cpp \
             --filter src/services/frequency_manager.cpp \
             --filter src/services/meter_history.cpp \
             --filter src/services/meter_reader.cpp \
             --filter src/services/schedule_manager.cpp \
-            --object-directory .pio/build/native/ \
+            --object-directory .pio/build/ \
             --xml coverage.xml \
             --print-summary
 

--- a/.github/workflows/meter-fixture-tests.yml
+++ b/.github/workflows/meter-fixture-tests.yml
@@ -8,8 +8,10 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_fakes.*
       - test/native_shims/**
       - test/test_native_meter_fixtures/**
+      - test/test_native_meter_reader/**
       - test/test_embedded_unit/**
       - .github/workflows/meter-fixture-tests.yml
   pull_request:
@@ -19,8 +21,10 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_fakes.*
       - test/native_shims/**
       - test/test_native_meter_fixtures/**
+      - test/test_native_meter_reader/**
       - test/test_embedded_unit/**
       - .github/workflows/meter-fixture-tests.yml
   workflow_dispatch:

--- a/.github/workflows/meter-fixture-tests.yml
+++ b/.github/workflows/meter-fixture-tests.yml
@@ -8,7 +8,9 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_shims/**
       - test/test_native_meter_fixtures/**
+      - test/test_embedded_unit/**
       - .github/workflows/meter-fixture-tests.yml
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -17,7 +19,9 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_shims/**
       - test/test_native_meter_fixtures/**
+      - test/test_embedded_unit/**
       - .github/workflows/meter-fixture-tests.yml
   workflow_dispatch:
 

--- a/.github/workflows/meter-fixture-tests.yml
+++ b/.github/workflows/meter-fixture-tests.yml
@@ -8,8 +8,10 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_esphome/**
       - test/native_fakes.*
       - test/native_shims/**
+      - test/test_native_esphome_publisher/**
       - test/test_native_meter_fixtures/**
       - test/test_native_meter_reader/**
       - test/test_embedded_unit/**
@@ -21,8 +23,10 @@ on:
       - include/**
       - platformio.ini
       - test/fixtures/**
+      - test/native_esphome/**
       - test/native_fakes.*
       - test/native_shims/**
+      - test/test_native_esphome_publisher/**
       - test/test_native_meter_fixtures/**
       - test/test_native_meter_reader/**
       - test/test_embedded_unit/**
@@ -74,3 +78,7 @@ jobs:
       - name: Run native fixture tests
         run: |
           pio test -e native -v
+
+      - name: Run native ESPHome publisher tests
+        run: |
+          pio test -e native_esphome -v

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,10 @@
 {
-	// This repository is a fork. The `upstream` remote points at the original
-	// project (psykokwak-com/everblu-meters-esp8266), so by default the GitHub
-	// Pull Requests extension treats that as the repository: it lists upstream's
-	// pull requests and defaults new ones to upstream's owner and base branch.
-	// Day-to-day work happens entirely within this fork, so restrict it to
-	// `origin`.
-	//
-	// To contribute a change back to the original project, temporarily add
-	// "upstream" to this list.
+	// This repository began as a fork but is no longer linked to the original
+	// project on GitHub, and it has its own default branch and release history.
+	// Other remotes may be present for pulling in work from sibling forks, so
+	// pin the GitHub Pull Requests extension to `origin`: otherwise it can treat
+	// one of those as the repository and default new pull requests to the wrong
+	// owner and base branch.
 	"githubPullRequests.remotes": [
 		"origin"
 	],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,17 @@
 {
+	// This repository is a fork. The `upstream` remote points at the original
+	// project (psykokwak-com/everblu-meters-esp8266), so by default the GitHub
+	// Pull Requests extension treats that as the repository: it lists upstream's
+	// pull requests and defaults new ones to upstream's owner and base branch.
+	// Day-to-day work happens entirely within this fork, so restrict it to
+	// `origin`.
+	//
+	// To contribute a change back to the original project, temporarily add
+	// "upstream" to this list.
+	"githubPullRequests.remotes": [
+		"origin"
+	],
+
 	// // Keep the release folder out of search/watch
 	// "files.exclude": {
 	// 	"**/ESPHOME-release/**": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,14 @@ Releases are created manually by tagging commits with version tags matching `v*.
 ### Changed
 
 - **Failed reads now report which of three causes applied**, instead of always reporting `"No meter response (asleep/out of range/wrong Year/Serial)"`: no reply at all, a reply that failed CRC (marginal RF link), or a reply that passed CRC but carried invalid meter fields. Status, error and log messages point at the matching remedy. `tmeter_data` gains a `failure` field (`ReadFailure` enum); the classification is sticky across a retry sequence, and both builds report it.
+- **ESPHome RSSI percentage values will change on upgrade.** The ESPHome publisher carried its own copy of the dBm-to-percentage conversion, mapping -120..-50 dBm onto 0-100%, while the shared helper in `utils.cpp` maps -120..-40 dBm. The same reading was therefore logged as one figure and published to Home Assistant as another: -70 dBm appeared as 62% in the device log and 71% in the `rssi_percentage` sensor. Both now use the shared helper, so ESPHome values drop slightly (-70 dBm now reports 62%, -50 dBm now reports 87% instead of 100%). Expect a one-off step down in Home Assistant history, and retune any automation thresholds set against that entity. MQTT values and the LQI percentage are unchanged.
 
 ### Fixed
 
 - **Stack corruption during a frequency scan.** `frequency_manager.h` carried a duplicate `struct tmeter_data` behind an `#ifndef __CC1101_H__` guard that never fired for `frequency_manager.cpp`, so that translation unit used a struct missing `meter_time` and `meter_type` (since v3.2.0). As the meter-read callback returns `tmeter_data` by value, every scan step wrote ~48 bytes past the caller's return slot. The duplicate is removed in favour of including `cc1101.h`.
+- **Crash when publishing a null radio state (ESPHome).** `ESPHomeDataPublisher::publishRadioState()` guarded the null before updating the text sensor, but then dereferenced it in the `strcmp` that derives the CC1101 Connected binary sensor.
+- **Post-failure cooldown was skipped when a read failed at `millis() == 0`.** The cooldown used a non-zero timestamp as its "running" flag, so a failure in the first millisecond after boot left the scheduler free to retry immediately. It is now tracked with an explicit flag.
+- **`MeterHistory::generateHistoryJson()` could return a length greater than the supplied buffer** and emit a truncated, unparseable JSON document that callers would then publish. It now refuses to truncate and returns 0.
 
 ## [v3.2.0] - 2026-07-09
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,14 @@ bash ./ESPHOME/prepare-component-release.sh
 Before opening a PR, run the same checks CI runs:
 
 ```powershell
+pip install -r scripts/requirements-dev.txt   # first time only
 ./scripts/run-tests.ps1 -Build
 ```
 
 That runs the host test suites (`pio test -e native` and `-e native_esphome`), the ESPHome
 config tests, and compiles both firmware targets. None of it needs a board, a radio or a
-meter. See [test/README.md](test/README.md) for the individual commands and for how to add
-a test.
+meter. Steps whose tooling is missing are reported as skipped rather than failing. See
+[test/README.md](test/README.md) for the individual commands and for how to add a test.
 
 If your PR changes files under `src/` or `ESPHOME/components/everblu_meter/`, you should also run the release preparation script and commit updated files in `ESPHOME-release/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,17 @@ bash ./ESPHOME/prepare-component-release.sh
 
 ## Pull request expectations
 
+Before opening a PR, run the same checks CI runs:
+
+```powershell
+./scripts/run-tests.ps1 -Build
+```
+
+That runs the host test suites (`pio test -e native` and `-e native_esphome`), the ESPHome
+config tests, and compiles both firmware targets. None of it needs a board, a radio or a
+meter. See [test/README.md](test/README.md) for the individual commands and for how to add
+a test.
+
 If your PR changes files under `src/` or `ESPHOME/components/everblu_meter/`, you should also run the release preparation script and commit updated files in `ESPHOME-release/`.
 
 A CI workflow validates that `ESPHOME-release/` matches generated output.

--- a/ESPHOME-release/everblu_meter/esphome_data_publisher.cpp
+++ b/ESPHOME-release/everblu_meter/esphome_data_publisher.cpp
@@ -7,6 +7,7 @@
 #include "meter_history.h"
 
 #ifdef USE_ESPHOME
+#include "utils.h" // Shared RSSI/LQI percentage conversions
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
@@ -220,7 +221,13 @@ void ESPHomeDataPublisher::publishRadioState(const char *state)
 {
 #ifdef USE_ESPHOME
     ESP_LOGD(TAG_PUB, "Radio state: %s", state ? state : "(null)");
-    if (radio_state_sensor_ && state)
+    if (!state)
+    {
+        // Nothing to report, and the connectivity check below would dereference it.
+        return;
+    }
+
+    if (radio_state_sensor_)
     {
         radio_state_sensor_->publish_state(state);
     }
@@ -365,20 +372,28 @@ bool ESPHomeDataPublisher::isReady() const
 }
 
 // Helper methods
+//
+// Both conversions delegate to the shared implementations in utils.cpp so that
+// the ESPHome and MQTT builds report the same percentage for the same reading.
+// They previously carried their own copies, and the RSSI one used a different
+// input range (-120..-50 rather than -120..-40), which made the same signal
+// read several percent higher under ESPHome.
 int ESPHomeDataPublisher::calculateRssiPercentage(int rssi_dbm) const
 {
-    // RSSI to percentage conversion
-    // -50 dBm = 100%, -120 dBm = 0%
-    int clamped = (rssi_dbm < -120) ? -120 : (rssi_dbm > -50 ? -50 : rssi_dbm);
-    return (int)((clamped + 120) * 100.0 / 70.0);
+#ifdef USE_ESPHOME
+    return calculateMeterdBmToPercentage(rssi_dbm);
+#else
+    (void)rssi_dbm;
+    return 0;
+#endif
 }
 
 int ESPHomeDataPublisher::calculateLqiPercentage(int lqi) const
 {
-    // CC1101 LQI is a 7-bit demodulation-error metric (bit 7 = CRC_OK, masked upstream)
-    // where a LOWER value means a better link. Invert so a higher percentage means a
-    // better link. Uses the same integer arithmetic as Arduino map(error, 0, 127, 100, 0)
-    // in calculateLQIToPercentage() so both builds report identical values.
-    int error = lqi & 0x7F;
-    return (error * -100) / 127 + 100;
+#ifdef USE_ESPHOME
+    return calculateLQIToPercentage(lqi);
+#else
+    (void)lqi;
+    return 0;
+#endif
 }

--- a/ESPHOME-release/everblu_meter/meter_history.cpp
+++ b/ESPHOME-release/everblu_meter/meter_history.cpp
@@ -5,7 +5,40 @@
 
 #include "meter_history.h"
 #include "logging.h"
+#include <cstdarg>
+#include <cstdio>
 #include <cstring>
+
+namespace
+{
+    /**
+     * @brief Append printf-style text at @p pos, refusing to truncate
+     *
+     * Returns false if the formatted text does not fit in the remaining space,
+     * leaving @p pos unchanged. A half-written JSON document is never useful to
+     * a caller, so truncation is treated as an error rather than best-effort.
+     */
+    bool appendFormatted(char *buffer, int bufferSize, int &pos, const char *fmt, ...)
+    {
+        if (pos < 0 || pos >= bufferSize)
+        {
+            return false;
+        }
+
+        va_list args;
+        va_start(args, fmt);
+        const int written = vsnprintf(buffer + pos, (size_t)(bufferSize - pos), fmt, args);
+        va_end(args);
+
+        if (written < 0 || written >= bufferSize - pos)
+        {
+            return false;
+        }
+
+        pos += written;
+        return true;
+    }
+}
 
 HistoryStats MeterHistory::calculateStats(const uint32_t history[13], uint32_t currentVolume)
 {
@@ -64,81 +97,52 @@ int MeterHistory::generateHistoryJson(const uint32_t history[13], uint32_t curre
         return 0;
     }
 
-    int monthCount = countValidMonths(history);
+    outputBuffer[0] = '\0';
+
+    const int monthCount = countValidMonths(history);
     if (monthCount == 0)
     {
         return 0; // No valid history
     }
 
     int pos = 0;
-    int remaining = bufferSize;
-
-    // Start JSON object
-    pos += snprintf(outputBuffer + pos, remaining, "{\"history\":[");
-    remaining = bufferSize - pos;
-
-    if (remaining <= 1)
-    {
-        return 0;
-    }
+    bool ok = appendFormatted(outputBuffer, bufferSize, pos, "{\"history\":[");
 
     // Add historical volumes
-    for (int i = 0; i < monthCount; i++)
+    for (int i = 0; ok && i < monthCount; i++)
     {
-        remaining = bufferSize - pos;
-        if (remaining <= 1)
-        {
-            break;
-        }
-        pos += snprintf(outputBuffer + pos, remaining, "%s%u",
-                        (i > 0 ? "," : ""), history[i]);
+        ok = appendFormatted(outputBuffer, bufferSize, pos, "%s%u", (i > 0 ? "," : ""), history[i]);
     }
 
-    // Add monthly usage calculations
-    remaining = bufferSize - pos;
-    if (remaining <= 1)
+    if (ok)
     {
-        // Buffer full before monthly_usage - close and return best-effort
-        outputBuffer[bufferSize - 1] = '\0';
-        return pos;
+        ok = appendFormatted(outputBuffer, bufferSize, pos, "],\"monthly_usage\":[");
     }
-
-    pos += snprintf(outputBuffer + pos, remaining, "],\"monthly_usage\":[");
 
     // Start at the second month: the oldest month has no earlier baseline, so we
     // omit it entirely rather than publishing a misleading value. monthly_usage
     // holds (monthCount - 1) real month-over-month deltas, aligned so
     // monthly_usage[k] pairs with history[k+1].
-    for (int i = 1; i < monthCount; i++)
+    for (int i = 1; ok && i < monthCount; i++)
     {
-        uint32_t usage = calculateUsage(history[i], history[i - 1]);
-
-        remaining = bufferSize - pos;
-        if (remaining <= 1)
-        {
-            break;
-        }
-        pos += snprintf(outputBuffer + pos, remaining, "%s%u",
-                        (i > 1 ? "," : ""), usage);
+        const uint32_t usage = calculateUsage(history[i], history[i - 1]);
+        ok = appendFormatted(outputBuffer, bufferSize, pos, "%s%u", (i > 1 ? "," : ""), usage);
     }
 
-    // Calculate current month usage
-    uint32_t currentMonthUsage = calculateUsage(currentVolume, (monthCount > 0) ? history[monthCount - 1] : 0);
-
-    remaining = bufferSize - pos;
-    if (remaining <= 1)
+    if (ok)
     {
-        // Buffer full - close and return best-effort
-        outputBuffer[bufferSize - 1] = '\0';
-        return pos;
+        const uint32_t currentMonthUsage = calculateUsage(currentVolume, history[monthCount - 1]);
+        ok = appendFormatted(outputBuffer, bufferSize, pos,
+                             "],\"current_month_usage\":%u,\"months_available\":%d}",
+                             currentMonthUsage, monthCount);
     }
 
-    pos += snprintf(outputBuffer + pos, remaining,
-                    "],\"current_month_usage\":%u,\"months_available\":%d}",
-                    currentMonthUsage, monthCount);
-
-    // Ensure null termination
-    outputBuffer[bufferSize - 1] = '\0';
+    if (!ok)
+    {
+        // Report failure rather than publishing a truncated, unparseable payload.
+        outputBuffer[0] = '\0';
+        return 0;
+    }
 
     return pos;
 }

--- a/ESPHOME-release/everblu_meter/meter_history.h
+++ b/ESPHOME-release/everblu_meter/meter_history.h
@@ -67,7 +67,9 @@ public:
      * @param currentVolume Current meter reading
      * @param outputBuffer Buffer to write JSON to
      * @param bufferSize Size of output buffer
-     * @return Number of bytes written (including null terminator), or 0 if buffer too small
+     * @return Number of characters written, excluding the null terminator, or 0
+     *         if there is no history or the payload does not fit. A truncated,
+     *         unparseable payload is never returned.
      */
     static int generateHistoryJson(const uint32_t history[13], uint32_t currentVolume,
                                    char *outputBuffer, int bufferSize);

--- a/ESPHOME-release/everblu_meter/meter_reader.cpp
+++ b/ESPHOME-release/everblu_meter/meter_reader.cpp
@@ -49,7 +49,7 @@ static void logReadableSummary(const tmeter_data &data, const IConfigProvider *c
 }
 
 MeterReader::MeterReader(IConfigProvider *config, ITimeProvider *timeProvider, IDataPublisher *publisher)
-    : m_config(config), m_timeProvider(timeProvider), m_publisher(publisher), m_initialized(false), m_readingInProgress(false), m_isScheduledRead(false), m_haConnected(false), m_radioConnected(false), m_retryCount(0), m_lastFailedAttempt(0), m_nextRetryTime(0), m_autoScanAfterFailureDone(false), m_retryFailureReason(ReadFailure::None), m_totalReadAttempts(0), m_successfulReads(0), m_failedReads(0), m_lastErrorMessage("None"), m_lastScheduleCheck(0), m_lastStatsPublish(0), m_readHourLocal(10), m_readMinuteLocal(0), m_lastReadDayMatch(false), m_lastReadTimeMatch(false)
+    : m_config(config), m_timeProvider(timeProvider), m_publisher(publisher), m_initialized(false), m_readingInProgress(false), m_isScheduledRead(false), m_haConnected(false), m_radioConnected(false), m_retryCount(0), m_inCooldown(false), m_lastFailedAttempt(0), m_nextRetryTime(0), m_autoScanAfterFailureDone(false), m_retryFailureReason(ReadFailure::None), m_totalReadAttempts(0), m_successfulReads(0), m_failedReads(0), m_lastErrorMessage("None"), m_lastScheduleCheck(0), m_lastStatsPublish(0), m_readHourLocal(10), m_readMinuteLocal(0), m_lastReadDayMatch(false), m_lastReadTimeMatch(false)
 {
 }
 
@@ -249,8 +249,11 @@ bool MeterReader::shouldPerformScheduledRead()
         return false;
     }
 
-    // Check if in cooldown period after failures
-    if (m_lastFailedAttempt > 0)
+    // Check if in cooldown period after failures.
+    // The flag, rather than a non-zero timestamp, is what marks the cooldown as
+    // running: millis() legitimately returns 0 for the first millisecond after
+    // boot, and a failure landing there must not skip the cooldown entirely.
+    if (m_inCooldown)
     {
         unsigned long cooldown = m_config->getRetryCooldownMs();
         if (millis() - m_lastFailedAttempt < cooldown)
@@ -258,6 +261,7 @@ bool MeterReader::shouldPerformScheduledRead()
             return false;
         }
         // Cooldown expired, reset
+        m_inCooldown = false;
         m_lastFailedAttempt = 0;
     }
 
@@ -406,9 +410,10 @@ void MeterReader::handleFailedRead(ReadFailure reason)
     if (m_retryCount < m_config->getMaxRetries() - 1)
     {
         // Schedule retry after delay.
-        // Keep the "Active Reading" sensor true and the radio state as "Reading"
-        // for the whole retry sequence so they don't flicker running/idle between
-        // attempts. They are cleared only on final success or after max retries.
+        // The "Active Reading" sensor and the radio state are re-asserted on
+        // every attempt but never cleared between them, so they don't drop to
+        // idle mid-sequence and make the read look finished. They are cleared
+        // only on final success or after max retries.
         // m_readingInProgress also stays true to keep the sequence atomic (the
         // retry timer in loop() calls performReading() directly, bypassing the
         // m_readingInProgress guard).
@@ -426,6 +431,7 @@ void MeterReader::handleFailedRead(ReadFailure reason)
     {
         // Max retries reached
         m_failedReads++;
+        m_inCooldown = true;
         m_lastFailedAttempt = millis();
         m_lastErrorMessage = read_failure_message(
             m_retryFailureReason != ReadFailure::None ? m_retryFailureReason : reason, false);

--- a/ESPHOME-release/everblu_meter/meter_reader.h
+++ b/ESPHOME-release/everblu_meter/meter_reader.h
@@ -201,6 +201,7 @@ private:
 
     // Retry management
     int m_retryCount;
+    bool m_inCooldown;                // True while the post-failure cooldown is running
     unsigned long m_lastFailedAttempt;
     unsigned long m_nextRetryTime;
     bool m_autoScanAfterFailureDone;  // Guards the failure-recovery frequency scan to once per failure streak

--- a/ESPHOME-release/everblu_meter/schedule_manager.cpp
+++ b/ESPHOME-release/everblu_meter/schedule_manager.cpp
@@ -26,6 +26,11 @@ void ScheduleManager::begin(const char *schedule, int readHourUtc, int readMinut
 
 bool ScheduleManager::isValidSchedule(const char *schedule)
 {
+    if (schedule == nullptr)
+    {
+        return false;
+    }
+
     return (strcmp(schedule, "Monday-Friday") == 0 ||
             strcmp(schedule, "Monday-Saturday") == 0 ||
             strcmp(schedule, "Monday-Sunday") == 0 ||
@@ -47,7 +52,8 @@ void ScheduleManager::setSchedule(const char *schedule)
     }
     else
     {
-        LOG_W("everblu_meter", "Invalid schedule '%s' - falling back to 'Monday-Friday'", schedule);
+        LOG_W("everblu_meter", "Invalid schedule '%s' - falling back to 'Monday-Friday'",
+              schedule ? schedule : "(null)");
         s_schedule = "Monday-Friday";
     }
 }

--- a/ESPHOME-release/everblu_meter/utils.cpp
+++ b/ESPHOME-release/everblu_meter/utils.cpp
@@ -135,6 +135,16 @@ void show_in_bin(const uint8_t *buffer, size_t len)
 
 int calculateMeterdBmToPercentage(int rssi_dbm)
 {
+	// NOTE: the -120..-40 dBm scale is an arbitrary display convenience, not a
+	// calibrated measurement. It exists so Home Assistant can show a signal bar;
+	// the percentage has no physical meaning and the endpoints were picked to
+	// span roughly "unusable" to "right next to the meter". Judge link quality
+	// from the dBm and LQI values instead. Any change to these endpoints shifts
+	// every historical value in Home Assistant, so treat it as user-visible.
+	//
+	// This is the single implementation for both builds: the ESPHome publisher
+	// delegates here so its sensor cannot drift away from the device log.
+
 	// Clamp RSSI to a reasonable range (e.g., -120 dBm to -40 dBm)
 	int clamped_rssi = constrain(rssi_dbm, -120, -40);
 

--- a/ESPHOME-release/everblu_meter/utils.cpp
+++ b/ESPHOME-release/everblu_meter/utils.cpp
@@ -28,61 +28,76 @@
 // When true, echo_debug() output is suppressed (see utils.h).
 bool g_echo_debug_quiet = false;
 
-// Consolidated hex display function with optional formatting
-// mode: 0=16 per line with newlines, 1=array format, 2=single line, 3=single line with 'S' separator
-void show_in_hex_formatted(const uint8_t *buffer, size_t len, int mode)
+// Emit the accumulated line and start a new one.
+static void flush_hex_line(char *line_buf, int &line_pos)
 {
-	size_t i = 0;
-	char line_buf[256];
-	int line_pos = 0;
-
-	for (i = 0; i < len; i++)
-	{
-		if (mode == 0)
-		{
-			// Original show_in_hex: 16 bytes per line
-			if (!(i % 16))
-			{
-				if (line_pos > 0)
-				{
-					line_buf[line_pos] = '\0';
-					LOG_D("everblu_meter", "%s", line_buf);
-					line_pos = 0;
-				}
-			}
-			line_pos += snprintf(line_buf + line_pos, sizeof(line_buf) - line_pos, "%02X ", buffer[i]);
-		}
-		else if (mode == 1)
-		{
-			// Array format with 16 per line
-			if (!(i % 16) && i > 0)
-			{
-				if (line_pos > 0)
-				{
-					line_buf[line_pos] = '\0';
-					LOG_D("everblu_meter", "%s", line_buf);
-					line_pos = 0;
-				}
-			}
-			line_pos += snprintf(line_buf + line_pos, sizeof(line_buf) - line_pos, "0x%02X, ", buffer[i]);
-		}
-		else if (mode == 2)
-		{
-			// Single line format
-			line_pos += snprintf(line_buf + line_pos, sizeof(line_buf) - line_pos, "%02X ", buffer[i]);
-		}
-		else if (mode == 3)
-		{
-			// Single line with 'S' separator (for GET requests)
-			line_pos += snprintf(line_buf + line_pos, sizeof(line_buf) - line_pos, "%02XS", buffer[i]);
-		}
-	}
-
 	if (line_pos > 0)
 	{
 		line_buf[line_pos] = '\0';
 		LOG_D("everblu_meter", "%s", line_buf);
+		line_pos = 0;
 	}
+}
+
+// Consolidated hex display function with optional formatting
+// mode: 0=16 per line with newlines, 1=array format, 2=single line, 3=single line with 'S' separator
+//
+// Modes 2 and 3 describe a single logical line whose length grows with the
+// buffer, so the output is wrapped once it fills line_buf. Without that wrap a
+// buffer longer than about 85 bytes walked off the end of the stack array: a
+// full 124-byte RADIAN frame needs 372 characters. snprintf() returns the
+// length it *would* have written, so line_pos ran past the buffer size and the
+// remaining-space argument, computed as an unsigned difference, underflowed to
+// a huge value instead of clamping.
+void show_in_hex_formatted(const uint8_t *buffer, size_t len, int mode)
+{
+	if (buffer == nullptr)
+	{
+		return;
+	}
+
+	char line_buf[256];
+	int line_pos = 0;
+
+	// Longest chunk any mode appends ("0x%02X, ") plus its terminator.
+	const int MAX_CHUNK = 7;
+
+	for (size_t i = 0; i < len; i++)
+	{
+		if ((mode == 0 || mode == 1) && i > 0 && (i % 16) == 0)
+		{
+			// Fixed 16 bytes per line.
+			flush_hex_line(line_buf, line_pos);
+		}
+		else if (line_pos + MAX_CHUNK > (int)sizeof(line_buf))
+		{
+			// Would not fit: wrap before writing rather than overrun.
+			flush_hex_line(line_buf, line_pos);
+		}
+
+		const int space = (int)sizeof(line_buf) - line_pos;
+		int written = 0;
+
+		if (mode == 0 || mode == 2)
+		{
+			written = snprintf(line_buf + line_pos, (size_t)space, "%02X ", buffer[i]);
+		}
+		else if (mode == 1)
+		{
+			written = snprintf(line_buf + line_pos, (size_t)space, "0x%02X, ", buffer[i]);
+		}
+		else if (mode == 3)
+		{
+			written = snprintf(line_buf + line_pos, (size_t)space, "%02XS", buffer[i]);
+		}
+
+		if (written > 0 && written < space)
+		{
+			line_pos += written;
+		}
+	}
+
+	flush_hex_line(line_buf, line_pos);
 }
 
 // Legacy function wrappers for backwards compatibility
@@ -108,6 +123,11 @@ void show_in_hex_one_line_GET(const uint8_t *buffer, size_t len)
 
 void show_in_bin(const uint8_t *buffer, size_t len)
 {
+	if (buffer == nullptr)
+	{
+		return;
+	}
+
 	const uint8_t *ptr;
 	uint8_t mask;
 	char bin_buf[512];

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -552,7 +552,7 @@ EverbluMeterComponent (ESPHome)
 - **volume** - Current meter reading (L or m³)
 - **battery** - Estimated battery life (years)
 - **counter** - Alternative volume counter
-- **rssi** / **rssi_percentage** - Radio signal strength
+- **rssi** / **rssi_percentage** - Radio signal strength. `rssi_percentage` maps -120 to -40 dBm onto 0-100%; the scale is an arbitrary display convenience so Home Assistant can show a signal bar, not a calibrated measurement. Judge link quality from the dBm and LQI values instead.
 - **lqi** / **lqi_percentage** - Link quality indicator (raw `lqi` is 0-127 where *lower is better*; `lqi_percentage` inverts this so higher % = better link)
 - **time_start** / **time_end** - Reading timing
 - **frequency_offset** - Current frequency offset (kHz)

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ The following MQTT topics are used to integrate the device with Home Assistant v
 | `Counter`          | `everblu/cyble/counter`                | Number of times the meter has been read (wraps around 255→1). |
 | `RSSI`             | `everblu/cyble/rssi`                   | Raw RSSI value of the meter's signal.                         |
 | `RSSI (dBm)`       | `everblu/cyble/rssi_dbm`               | RSSI value converted to dBm.                                  |
-| `RSSI (%)`         | `everblu/cyble/rssi_percentage`        | RSSI value converted to a percentage.                         |
+| `RSSI (%)`         | `everblu/cyble/rssi_percentage`        | RSSI value converted to a percentage. See the note below.     |
 | `Time Start`       | `everblu/cyble/time_start`             | Time when the meter wakes up, formatted as `HH:MM`.           |
 | `Time End`         | `everblu/cyble/time_end`               | Time when the meter goes to sleep, formatted as `HH:MM`.      |
 | `Timestamp`        | `everblu/cyble/timestamp`              | ISO 8601 timestamp of the last reading.                       |
@@ -522,6 +522,8 @@ The following MQTT topics are used to integrate the device with Home Assistant v
 | `SSID`             | `everblu/cyble/ssid`                   | Wi-Fi SSID the device is connected to.                        |
 | `BSSID`            | `everblu/cyble/bssid`                  | Wi-Fi BSSID the device is connected to.                       |
 | `Uptime`           | `everblu/cyble/uptime`                 | Device uptime in ISO 8601 format.                             |
+
+> **Note on `RSSI (%)`.** The percentage is a display convenience, not a calibrated measurement. It maps the -120 to -40 dBm range onto 0-100% so Home Assistant can show a signal bar; the endpoints were chosen to span roughly "unusable" to "right next to the meter" and have no physical meaning. Judge link quality from the dBm and LQI values instead. The same scale is used by the ESPHome `rssi_percentage` sensor and by the device log.
 
 </details>
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,9 @@ upload_speed = 460800
 ; terminal. The default filter rewrites control characters into printable
 ; Unicode glyphs (e.g. ESC -> the "␛" symbol), which prevents colour rendering.
 monitor_filters = direct
-test_ignore = test_native_meter_fixtures
+; Unit tests are pure logic and run on the host via `pio test -e native`.
+; Nothing in test/ needs real hardware, so exclude every suite here.
+test_ignore = test_native_meter_fixtures, test_embedded_unit
 
 ; ============================================================================
 ; ESP8266 Environments
@@ -155,13 +157,19 @@ custom_monitor_connect_delay = 30
 platform = native
 test_framework = unity
 test_build_src = yes
-test_filter = test_native_meter_fixtures
+test_filter =
+    test_native_meter_fixtures
+    test_embedded_unit
 build_src_filter =
     +<core/crc_kermit.cpp>
     +<core/radian_parser.cpp>
     +<core/radian_decoder.cpp>
+    +<services/schedule_manager.cpp>
 build_flags =
     -Isrc
+    ; test/native_shims provides a minimal Arduino.h so platform-neutral
+    ; service code can be compiled and tested on the host.
+    -Itest/native_shims
     -std=gnu++17
     --coverage
     -lgcov

--- a/platformio.ini
+++ b/platformio.ini
@@ -164,6 +164,7 @@ build_src_filter =
     +<core/crc_kermit.cpp>
     +<core/radian_parser.cpp>
     +<core/radian_decoder.cpp>
+    +<services/meter_history.cpp>
     +<services/schedule_manager.cpp>
 build_flags =
     -Isrc

--- a/platformio.ini
+++ b/platformio.ini
@@ -179,6 +179,10 @@ build_flags =
     ; link seams that every host suite needs.
     -Itest
     -std=gnu++17
+    ; Abort on a stack buffer overrun instead of corrupting memory silently.
+    ; Several formatting helpers build strings in fixed stack buffers, and on
+    ; the device that damage is invisible until something unrelated crashes.
+    -fstack-protector-all
     --coverage
     -lgcov
 build_unflags =

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,7 +40,7 @@ upload_speed = 460800
 monitor_filters = direct
 ; Unit tests are pure logic and run on the host via `pio test -e native`.
 ; Nothing in test/ needs real hardware, so exclude every suite here.
-test_ignore = test_native_meter_fixtures, test_embedded_unit
+test_ignore = test_native_meter_fixtures, test_embedded_unit, test_native_meter_reader
 
 ; ============================================================================
 ; ESP8266 Environments
@@ -160,17 +160,24 @@ test_build_src = yes
 test_filter =
     test_native_meter_fixtures
     test_embedded_unit
+    test_native_meter_reader
 build_src_filter =
     +<core/crc_kermit.cpp>
     +<core/radian_parser.cpp>
     +<core/radian_decoder.cpp>
+    +<core/utils.cpp>
+    +<services/frequency_manager.cpp>
     +<services/meter_history.cpp>
+    +<services/meter_reader.cpp>
     +<services/schedule_manager.cpp>
 build_flags =
     -Isrc
     ; test/native_shims provides a minimal Arduino.h so platform-neutral
     ; service code can be compiled and tested on the host.
     -Itest/native_shims
+    ; test/native_fakes.{h,cpp} supplies the CC1101, storage and WiFi-serial
+    ; link seams that every host suite needs.
+    -Itest
     -std=gnu++17
     --coverage
     -lgcov

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,7 +40,7 @@ upload_speed = 460800
 monitor_filters = direct
 ; Unit tests are pure logic and run on the host via `pio test -e native`.
 ; Nothing in test/ needs real hardware, so exclude every suite here.
-test_ignore = test_native_meter_fixtures, test_embedded_unit, test_native_meter_reader
+test_ignore = test_native_meter_fixtures, test_embedded_unit, test_native_meter_reader, test_native_esphome_publisher
 
 ; ============================================================================
 ; ESP8266 Environments
@@ -185,8 +185,47 @@ build_unflags =
     -O2
 
 ; ============================================================================
-; Hex Frame Decoder -- Native Development Tool
+; Native ESPHome Test Environment (host/CI, no hardware)
 ; ============================================================================
+; Compiles the shared sources the way the ESPHome external component does -
+; USE_ESPHOME defined and the source folders flattened onto the include path -
+; against the recording sensor stubs in test/native_esphome/. That covers
+; ESPHomeDataPublisher, which is entirely #ifdef'd out of the MQTT build and so
+; is invisible to [env:native].
+; ============================================================================
+[env:native_esphome]
+platform = native
+test_framework = unity
+test_build_src = yes
+test_filter =
+    test_native_esphome_publisher
+build_src_filter =
+    +<core/crc_kermit.cpp>
+    +<core/radian_parser.cpp>
+    +<core/radian_decoder.cpp>
+    +<core/utils.cpp>
+    +<adapters/implementations/esphome_data_publisher.cpp>
+    +<services/frequency_manager.cpp>
+    +<services/meter_history.cpp>
+    +<services/meter_reader.cpp>
+    +<services/schedule_manager.cpp>
+build_flags =
+    -DUSE_ESPHOME
+    ; The ESPHome component ships a flattened source tree, so the unqualified
+    ; includes guarded by USE_ESPHOME resolve from these folders.
+    -Isrc
+    -Isrc/core
+    -Isrc/services
+    -Isrc/adapters
+    -Isrc/adapters/implementations
+    -Itest
+    -Itest/native_shims
+    -Itest/native_esphome
+    -std=gnu++17
+    --coverage
+    -lgcov
+build_unflags =
+    -O2
 ; Interactive host program for decoding RADIAN hex frame dumps from the serial
 ; log.  Run with:  pio run -e hex_decoder && .pio/build/hex_decoder/program
 ;

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,7 +40,7 @@ upload_speed = 460800
 monitor_filters = direct
 ; Unit tests are pure logic and run on the host via `pio test -e native`.
 ; Nothing in test/ needs real hardware, so exclude every suite here.
-test_ignore = test_native_meter_fixtures, test_embedded_unit, test_native_meter_reader, test_native_esphome_publisher
+test_ignore = test_native_meter_fixtures, test_embedded_unit, test_native_meter_reader, test_native_esphome_publisher, test_native_esphome_reader
 
 ; ============================================================================
 ; ESP8266 Environments
@@ -203,6 +203,7 @@ test_framework = unity
 test_build_src = yes
 test_filter =
     test_native_esphome_publisher
+    test_native_esphome_reader
 build_src_filter =
     +<core/crc_kermit.cpp>
     +<core/radian_parser.cpp>
@@ -226,6 +227,8 @@ build_flags =
     -Itest/native_shims
     -Itest/native_esphome
     -std=gnu++17
+    ; Abort on a stack buffer overrun instead of corrupting memory silently.
+    -fstack-protector-all
     --coverage
     -lgcov
 build_unflags =

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -1,0 +1,17 @@
+# Development and test dependencies.
+#
+#   pip install -r scripts/requirements-dev.txt
+#
+# Everything needed to run ./scripts/run-tests.ps1, which mirrors CI. None of
+# it is required to build or flash the firmware from the PlatformIO IDE.
+
+# Firmware builds and the host unit test suites (pio run / pio test).
+platformio
+
+# tests/esphome validates the external component's YAML schema against the real
+# ESPHome config validators, so ESPHome itself has to be importable.
+esphome>=2025.0
+pytest
+
+# Coverage reporting over the host-tested sources (./scripts/run-tests.ps1 -Coverage).
+gcovr

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -8,6 +8,10 @@
 #   ./scripts/run-tests.ps1 -Serial      # mirror firmware log output to stdout
 #
 # Nothing here needs a board, a radio or a meter.
+#
+# First time: pip install -r scripts/requirements-dev.txt
+# Steps whose tooling is missing are reported as SKIPPED rather than failing,
+# so a partial environment still gets useful results.
 
 [CmdletBinding()]
 param(
@@ -44,8 +48,27 @@ function Invoke-Step {
     Write-Host ""
     Write-Host "==> $Name" -ForegroundColor Cyan
 
-    & $Action
-    $code = $LASTEXITCODE
+    $code = 0
+    $previous = $ErrorActionPreference
+
+    # Several of these tools write progress to stderr even on success (gcovr
+    # logs "(INFO) Reading coverage data..." there). Under a Stop preference
+    # PowerShell turns that into a terminating NativeCommandError, so the step
+    # would be reported as failed despite a zero exit code. Judge success by the
+    # exit code alone.
+    $ErrorActionPreference = "Continue"
+    try {
+        $global:LASTEXITCODE = 0
+        & $Action
+        $code = $LASTEXITCODE
+    }
+    catch {
+        Write-Host "    $($_.Exception.Message)" -ForegroundColor Red
+        $code = 1
+    }
+    finally {
+        $ErrorActionPreference = $previous
+    }
 
     if ($code -eq 0) {
         $script:results[$Name] = "PASS"
@@ -58,6 +81,41 @@ function Invoke-Step {
     }
 }
 
+function Skip-Step {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Reason
+    )
+
+    Write-Host ""
+    Write-Host "==> $Name" -ForegroundColor Cyan
+    $script:results[$Name] = "SKIP"
+    Write-Host "    $Name : SKIPPED - $Reason" -ForegroundColor Yellow
+}
+
+function Test-PythonModule {
+    param([Parameter(Mandatory)][string]$Module)
+
+    # Probe the interpreter the script will actually invoke, which is not
+    # necessarily the one that installed the package. All streams are discarded:
+    # a failed import writes a traceback to stderr, which PowerShell would
+    # otherwise turn into a terminating NativeCommandError.
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        & python -c "import $Module" *> $null
+        return ($LASTEXITCODE -eq 0)
+    }
+    catch {
+        return $false
+    }
+    finally {
+        $ErrorActionPreference = $previous
+    }
+}
+
+$installHint = "install the dev dependencies: pip install -r scripts/requirements-dev.txt"
+
 # Run from the repository root regardless of where the script was invoked.
 Push-Location (Join-Path $PSScriptRoot "..")
 
@@ -67,14 +125,28 @@ if ($Serial) {
 }
 
 try {
+    if (-not (Get-Command pio -ErrorAction SilentlyContinue)) {
+        Write-Host "PlatformIO ('pio') is not on PATH. Please $installHint" -ForegroundColor Red
+        exit 1
+    }
+
     # Host test suites. -e native covers the MQTT-mode code; -e native_esphome
     # rebuilds the shared sources with USE_ESPHOME so the ESPHome publisher,
     # which is otherwise compiled out entirely, is exercised too.
     Invoke-Step "Host tests (native)" { pio test -e native }
     Invoke-Step "Host tests (native_esphome)" { pio test -e native_esphome }
 
-    # ESPHome YAML schema validation.
-    Invoke-Step "ESPHome config tests" { python -m pytest tests/esphome -q }
+    # ESPHome YAML schema validation. These import the real ESPHome validators,
+    # so they need both esphome and pytest.
+    if (-not (Test-PythonModule "pytest")) {
+        Skip-Step "ESPHome config tests" "pytest is not available to '$((Get-Command python).Source)'. Please $installHint"
+    }
+    elseif (-not (Test-PythonModule "esphome")) {
+        Skip-Step "ESPHome config tests" "esphome is not available to '$((Get-Command python).Source)'. Please $installHint"
+    }
+    else {
+        Invoke-Step "ESPHome config tests" { python -m pytest tests/esphome -q }
+    }
 
     if ($Build) {
         Invoke-Step "Firmware build (huzzah)" { pio run -e huzzah }
@@ -82,24 +154,43 @@ try {
     }
 
     if ($Coverage) {
-        Invoke-Step "Coverage" {
-            gcovr --root . --object-directory .pio/build/ --print-summary `
-                --filter src/core/crc_kermit.cpp `
-                --filter src/core/radian_parser.cpp `
-                --filter src/core/radian_decoder.cpp `
-                --filter src/core/utils.cpp `
-                --filter src/adapters/implementations/esphome_data_publisher.cpp `
-                --filter src/services/frequency_manager.cpp `
-                --filter src/services/meter_history.cpp `
-                --filter src/services/meter_reader.cpp `
-                --filter src/services/schedule_manager.cpp
+        $gcovrArgs = @(
+            "--root", ".",
+            "--object-directory", ".pio/build/",
+            "--print-summary",
+            "--filter", "src/core/crc_kermit.cpp",
+            "--filter", "src/core/radian_parser.cpp",
+            "--filter", "src/core/radian_decoder.cpp",
+            "--filter", "src/core/utils.cpp",
+            "--filter", "src/adapters/implementations/esphome_data_publisher.cpp",
+            "--filter", "src/services/frequency_manager.cpp",
+            "--filter", "src/services/meter_history.cpp",
+            "--filter", "src/services/meter_reader.cpp",
+            "--filter", "src/services/schedule_manager.cpp"
+        )
+
+        # Prefer the console script, but fall back to the module: a virtual
+        # environment's Scripts directory is not always on PATH in the shell
+        # that installed into it.
+        if (Get-Command gcovr -ErrorAction SilentlyContinue) {
+            Invoke-Step "Coverage" { gcovr @gcovrArgs }
+        }
+        elseif (Test-PythonModule "gcovr") {
+            Invoke-Step "Coverage" { python -m gcovr @gcovrArgs }
+        }
+        else {
+            Skip-Step "Coverage" "gcovr is not available. Please $installHint"
         }
     }
 
     Write-Host ""
     Write-Host "================ SUMMARY ================" -ForegroundColor Cyan
     foreach ($entry in $results.GetEnumerator()) {
-        $colour = if ($entry.Value -eq "PASS") { "Green" } else { "Red" }
+        $colour = switch ($entry.Value) {
+            "PASS" { "Green" }
+            "SKIP" { "Yellow" }
+            default { "Red" }
+        }
         Write-Host ("  {0,-32} {1}" -f $entry.Key, $entry.Value) -ForegroundColor $colour
     }
     Write-Host "=========================================" -ForegroundColor Cyan
@@ -110,8 +201,13 @@ try {
         exit 1
     }
 
+    $skipped = @($results.GetEnumerator() | Where-Object { $_.Value -eq "SKIP" })
+
     Write-Host ""
     Write-Host "All checks passed." -ForegroundColor Green
+    if ($skipped.Count -gt 0) {
+        Write-Host "$($skipped.Count) step(s) skipped for missing tools. To $installHint" -ForegroundColor Yellow
+    }
     if (-not $Build) {
         Write-Host "Firmware was not compiled. Run with -Build before pushing." -ForegroundColor Yellow
     }

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -1,0 +1,125 @@
+# run-tests.ps1
+# Runs the same checks CI runs, in the same order, without any hardware.
+#
+#   ./scripts/run-tests.ps1              # host test suites only (fast)
+#   ./scripts/run-tests.ps1 -Build       # also compile both firmware targets
+#   ./scripts/run-tests.ps1 -Coverage    # also produce a gcovr summary
+#   ./scripts/run-tests.ps1 -All         # everything
+#   ./scripts/run-tests.ps1 -Serial      # mirror firmware log output to stdout
+#
+# Nothing here needs a board, a radio or a meter.
+
+[CmdletBinding()]
+param(
+    # Compile the ESP8266 and ESP32 firmware. Host tests cannot catch a
+    # board-only compile break, so run this before pushing.
+    [switch]$Build,
+
+    # Collect coverage over the host-tested sources.
+    [switch]$Coverage,
+
+    # Equivalent to -Build -Coverage.
+    [switch]$All,
+
+    # Show the firmware's own log output, which the suites suppress by default.
+    [switch]$Serial
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($All) {
+    $Build = $true
+    $Coverage = $true
+}
+
+$results = [ordered]@{}
+$failed = @()
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][scriptblock]$Action
+    )
+
+    Write-Host ""
+    Write-Host "==> $Name" -ForegroundColor Cyan
+
+    & $Action
+    $code = $LASTEXITCODE
+
+    if ($code -eq 0) {
+        $script:results[$Name] = "PASS"
+        Write-Host "    $Name : PASS" -ForegroundColor Green
+    }
+    else {
+        $script:results[$Name] = "FAIL"
+        $script:failed += $Name
+        Write-Host "    $Name : FAIL (exit $code)" -ForegroundColor Red
+    }
+}
+
+# Run from the repository root regardless of where the script was invoked.
+Push-Location (Join-Path $PSScriptRoot "..")
+
+$hadSerial = Test-Path Env:\EVERBLU_NATIVE_SERIAL
+if ($Serial) {
+    $env:EVERBLU_NATIVE_SERIAL = "1"
+}
+
+try {
+    # Host test suites. -e native covers the MQTT-mode code; -e native_esphome
+    # rebuilds the shared sources with USE_ESPHOME so the ESPHome publisher,
+    # which is otherwise compiled out entirely, is exercised too.
+    Invoke-Step "Host tests (native)" { pio test -e native }
+    Invoke-Step "Host tests (native_esphome)" { pio test -e native_esphome }
+
+    # ESPHome YAML schema validation.
+    Invoke-Step "ESPHome config tests" { python -m pytest tests/esphome -q }
+
+    if ($Build) {
+        Invoke-Step "Firmware build (huzzah)" { pio run -e huzzah }
+        Invoke-Step "Firmware build (esp32dev)" { pio run -e esp32dev }
+    }
+
+    if ($Coverage) {
+        Invoke-Step "Coverage" {
+            gcovr --root . --object-directory .pio/build/ --print-summary `
+                --filter src/core/crc_kermit.cpp `
+                --filter src/core/radian_parser.cpp `
+                --filter src/core/radian_decoder.cpp `
+                --filter src/core/utils.cpp `
+                --filter src/adapters/implementations/esphome_data_publisher.cpp `
+                --filter src/services/frequency_manager.cpp `
+                --filter src/services/meter_history.cpp `
+                --filter src/services/meter_reader.cpp `
+                --filter src/services/schedule_manager.cpp
+        }
+    }
+
+    Write-Host ""
+    Write-Host "================ SUMMARY ================" -ForegroundColor Cyan
+    foreach ($entry in $results.GetEnumerator()) {
+        $colour = if ($entry.Value -eq "PASS") { "Green" } else { "Red" }
+        Write-Host ("  {0,-32} {1}" -f $entry.Key, $entry.Value) -ForegroundColor $colour
+    }
+    Write-Host "=========================================" -ForegroundColor Cyan
+
+    if ($failed.Count -gt 0) {
+        Write-Host ""
+        Write-Host "$($failed.Count) step(s) failed: $($failed -join ', ')" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host ""
+    Write-Host "All checks passed." -ForegroundColor Green
+    if (-not $Build) {
+        Write-Host "Firmware was not compiled. Run with -Build before pushing." -ForegroundColor Yellow
+    }
+    exit 0
+}
+finally {
+    if ($Serial -and -not $hadSerial) {
+        Remove-Item Env:\EVERBLU_NATIVE_SERIAL -ErrorAction SilentlyContinue
+    }
+    Pop-Location
+}

--- a/src/adapters/implementations/esphome_data_publisher.cpp
+++ b/src/adapters/implementations/esphome_data_publisher.cpp
@@ -7,6 +7,7 @@
 #include "../../services/meter_history.h"
 
 #ifdef USE_ESPHOME
+#include "utils.h" // Shared RSSI/LQI percentage conversions
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
@@ -220,7 +221,13 @@ void ESPHomeDataPublisher::publishRadioState(const char *state)
 {
 #ifdef USE_ESPHOME
     ESP_LOGD(TAG_PUB, "Radio state: %s", state ? state : "(null)");
-    if (radio_state_sensor_ && state)
+    if (!state)
+    {
+        // Nothing to report, and the connectivity check below would dereference it.
+        return;
+    }
+
+    if (radio_state_sensor_)
     {
         radio_state_sensor_->publish_state(state);
     }
@@ -365,20 +372,28 @@ bool ESPHomeDataPublisher::isReady() const
 }
 
 // Helper methods
+//
+// Both conversions delegate to the shared implementations in utils.cpp so that
+// the ESPHome and MQTT builds report the same percentage for the same reading.
+// They previously carried their own copies, and the RSSI one used a different
+// input range (-120..-50 rather than -120..-40), which made the same signal
+// read several percent higher under ESPHome.
 int ESPHomeDataPublisher::calculateRssiPercentage(int rssi_dbm) const
 {
-    // RSSI to percentage conversion
-    // -50 dBm = 100%, -120 dBm = 0%
-    int clamped = (rssi_dbm < -120) ? -120 : (rssi_dbm > -50 ? -50 : rssi_dbm);
-    return (int)((clamped + 120) * 100.0 / 70.0);
+#ifdef USE_ESPHOME
+    return calculateMeterdBmToPercentage(rssi_dbm);
+#else
+    (void)rssi_dbm;
+    return 0;
+#endif
 }
 
 int ESPHomeDataPublisher::calculateLqiPercentage(int lqi) const
 {
-    // CC1101 LQI is a 7-bit demodulation-error metric (bit 7 = CRC_OK, masked upstream)
-    // where a LOWER value means a better link. Invert so a higher percentage means a
-    // better link. Uses the same integer arithmetic as Arduino map(error, 0, 127, 100, 0)
-    // in calculateLQIToPercentage() so both builds report identical values.
-    int error = lqi & 0x7F;
-    return (error * -100) / 127 + 100;
+#ifdef USE_ESPHOME
+    return calculateLQIToPercentage(lqi);
+#else
+    (void)lqi;
+    return 0;
+#endif
 }

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -135,6 +135,16 @@ void show_in_bin(const uint8_t *buffer, size_t len)
 
 int calculateMeterdBmToPercentage(int rssi_dbm)
 {
+	// NOTE: the -120..-40 dBm scale is an arbitrary display convenience, not a
+	// calibrated measurement. It exists so Home Assistant can show a signal bar;
+	// the percentage has no physical meaning and the endpoints were picked to
+	// span roughly "unusable" to "right next to the meter". Judge link quality
+	// from the dBm and LQI values instead. Any change to these endpoints shifts
+	// every historical value in Home Assistant, so treat it as user-visible.
+	//
+	// This is the single implementation for both builds: the ESPHome publisher
+	// delegates here so its sensor cannot drift away from the device log.
+
 	// Clamp RSSI to a reasonable range (e.g., -120 dBm to -40 dBm)
 	int clamped_rssi = constrain(rssi_dbm, -120, -40);
 

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -28,61 +28,76 @@
 // When true, echo_debug() output is suppressed (see utils.h).
 bool g_echo_debug_quiet = false;
 
-// Consolidated hex display function with optional formatting
-// mode: 0=16 per line with newlines, 1=array format, 2=single line, 3=single line with 'S' separator
-void show_in_hex_formatted(const uint8_t *buffer, size_t len, int mode)
+// Emit the accumulated line and start a new one.
+static void flush_hex_line(char *line_buf, int &line_pos)
 {
-	size_t i = 0;
-	char line_buf[256];
-	int line_pos = 0;
-
-	for (i = 0; i < len; i++)
-	{
-		if (mode == 0)
-		{
-			// Original show_in_hex: 16 bytes per line
-			if (!(i % 16))
-			{
-				if (line_pos > 0)
-				{
-					line_buf[line_pos] = '\0';
-					LOG_D("everblu_meter", "%s", line_buf);
-					line_pos = 0;
-				}
-			}
-			line_pos += snprintf(line_buf + line_pos, sizeof(line_buf) - line_pos, "%02X ", buffer[i]);
-		}
-		else if (mode == 1)
-		{
-			// Array format with 16 per line
-			if (!(i % 16) && i > 0)
-			{
-				if (line_pos > 0)
-				{
-					line_buf[line_pos] = '\0';
-					LOG_D("everblu_meter", "%s", line_buf);
-					line_pos = 0;
-				}
-			}
-			line_pos += snprintf(line_buf + line_pos, sizeof(line_buf) - line_pos, "0x%02X, ", buffer[i]);
-		}
-		else if (mode == 2)
-		{
-			// Single line format
-			line_pos += snprintf(line_buf + line_pos, sizeof(line_buf) - line_pos, "%02X ", buffer[i]);
-		}
-		else if (mode == 3)
-		{
-			// Single line with 'S' separator (for GET requests)
-			line_pos += snprintf(line_buf + line_pos, sizeof(line_buf) - line_pos, "%02XS", buffer[i]);
-		}
-	}
-
 	if (line_pos > 0)
 	{
 		line_buf[line_pos] = '\0';
 		LOG_D("everblu_meter", "%s", line_buf);
+		line_pos = 0;
 	}
+}
+
+// Consolidated hex display function with optional formatting
+// mode: 0=16 per line with newlines, 1=array format, 2=single line, 3=single line with 'S' separator
+//
+// Modes 2 and 3 describe a single logical line whose length grows with the
+// buffer, so the output is wrapped once it fills line_buf. Without that wrap a
+// buffer longer than about 85 bytes walked off the end of the stack array: a
+// full 124-byte RADIAN frame needs 372 characters. snprintf() returns the
+// length it *would* have written, so line_pos ran past the buffer size and the
+// remaining-space argument, computed as an unsigned difference, underflowed to
+// a huge value instead of clamping.
+void show_in_hex_formatted(const uint8_t *buffer, size_t len, int mode)
+{
+	if (buffer == nullptr)
+	{
+		return;
+	}
+
+	char line_buf[256];
+	int line_pos = 0;
+
+	// Longest chunk any mode appends ("0x%02X, ") plus its terminator.
+	const int MAX_CHUNK = 7;
+
+	for (size_t i = 0; i < len; i++)
+	{
+		if ((mode == 0 || mode == 1) && i > 0 && (i % 16) == 0)
+		{
+			// Fixed 16 bytes per line.
+			flush_hex_line(line_buf, line_pos);
+		}
+		else if (line_pos + MAX_CHUNK > (int)sizeof(line_buf))
+		{
+			// Would not fit: wrap before writing rather than overrun.
+			flush_hex_line(line_buf, line_pos);
+		}
+
+		const int space = (int)sizeof(line_buf) - line_pos;
+		int written = 0;
+
+		if (mode == 0 || mode == 2)
+		{
+			written = snprintf(line_buf + line_pos, (size_t)space, "%02X ", buffer[i]);
+		}
+		else if (mode == 1)
+		{
+			written = snprintf(line_buf + line_pos, (size_t)space, "0x%02X, ", buffer[i]);
+		}
+		else if (mode == 3)
+		{
+			written = snprintf(line_buf + line_pos, (size_t)space, "%02XS", buffer[i]);
+		}
+
+		if (written > 0 && written < space)
+		{
+			line_pos += written;
+		}
+	}
+
+	flush_hex_line(line_buf, line_pos);
 }
 
 // Legacy function wrappers for backwards compatibility
@@ -108,6 +123,11 @@ void show_in_hex_one_line_GET(const uint8_t *buffer, size_t len)
 
 void show_in_bin(const uint8_t *buffer, size_t len)
 {
+	if (buffer == nullptr)
+	{
+		return;
+	}
+
 	const uint8_t *ptr;
 	uint8_t mask;
 	char bin_buf[512];

--- a/src/services/meter_history.cpp
+++ b/src/services/meter_history.cpp
@@ -5,7 +5,40 @@
 
 #include "meter_history.h"
 #include "../core/logging.h"
+#include <cstdarg>
+#include <cstdio>
 #include <cstring>
+
+namespace
+{
+    /**
+     * @brief Append printf-style text at @p pos, refusing to truncate
+     *
+     * Returns false if the formatted text does not fit in the remaining space,
+     * leaving @p pos unchanged. A half-written JSON document is never useful to
+     * a caller, so truncation is treated as an error rather than best-effort.
+     */
+    bool appendFormatted(char *buffer, int bufferSize, int &pos, const char *fmt, ...)
+    {
+        if (pos < 0 || pos >= bufferSize)
+        {
+            return false;
+        }
+
+        va_list args;
+        va_start(args, fmt);
+        const int written = vsnprintf(buffer + pos, (size_t)(bufferSize - pos), fmt, args);
+        va_end(args);
+
+        if (written < 0 || written >= bufferSize - pos)
+        {
+            return false;
+        }
+
+        pos += written;
+        return true;
+    }
+}
 
 HistoryStats MeterHistory::calculateStats(const uint32_t history[13], uint32_t currentVolume)
 {
@@ -64,81 +97,52 @@ int MeterHistory::generateHistoryJson(const uint32_t history[13], uint32_t curre
         return 0;
     }
 
-    int monthCount = countValidMonths(history);
+    outputBuffer[0] = '\0';
+
+    const int monthCount = countValidMonths(history);
     if (monthCount == 0)
     {
         return 0; // No valid history
     }
 
     int pos = 0;
-    int remaining = bufferSize;
-
-    // Start JSON object
-    pos += snprintf(outputBuffer + pos, remaining, "{\"history\":[");
-    remaining = bufferSize - pos;
-
-    if (remaining <= 1)
-    {
-        return 0;
-    }
+    bool ok = appendFormatted(outputBuffer, bufferSize, pos, "{\"history\":[");
 
     // Add historical volumes
-    for (int i = 0; i < monthCount; i++)
+    for (int i = 0; ok && i < monthCount; i++)
     {
-        remaining = bufferSize - pos;
-        if (remaining <= 1)
-        {
-            break;
-        }
-        pos += snprintf(outputBuffer + pos, remaining, "%s%u",
-                        (i > 0 ? "," : ""), history[i]);
+        ok = appendFormatted(outputBuffer, bufferSize, pos, "%s%u", (i > 0 ? "," : ""), history[i]);
     }
 
-    // Add monthly usage calculations
-    remaining = bufferSize - pos;
-    if (remaining <= 1)
+    if (ok)
     {
-        // Buffer full before monthly_usage - close and return best-effort
-        outputBuffer[bufferSize - 1] = '\0';
-        return pos;
+        ok = appendFormatted(outputBuffer, bufferSize, pos, "],\"monthly_usage\":[");
     }
-
-    pos += snprintf(outputBuffer + pos, remaining, "],\"monthly_usage\":[");
 
     // Start at the second month: the oldest month has no earlier baseline, so we
     // omit it entirely rather than publishing a misleading value. monthly_usage
     // holds (monthCount - 1) real month-over-month deltas, aligned so
     // monthly_usage[k] pairs with history[k+1].
-    for (int i = 1; i < monthCount; i++)
+    for (int i = 1; ok && i < monthCount; i++)
     {
-        uint32_t usage = calculateUsage(history[i], history[i - 1]);
-
-        remaining = bufferSize - pos;
-        if (remaining <= 1)
-        {
-            break;
-        }
-        pos += snprintf(outputBuffer + pos, remaining, "%s%u",
-                        (i > 1 ? "," : ""), usage);
+        const uint32_t usage = calculateUsage(history[i], history[i - 1]);
+        ok = appendFormatted(outputBuffer, bufferSize, pos, "%s%u", (i > 1 ? "," : ""), usage);
     }
 
-    // Calculate current month usage
-    uint32_t currentMonthUsage = calculateUsage(currentVolume, (monthCount > 0) ? history[monthCount - 1] : 0);
-
-    remaining = bufferSize - pos;
-    if (remaining <= 1)
+    if (ok)
     {
-        // Buffer full - close and return best-effort
-        outputBuffer[bufferSize - 1] = '\0';
-        return pos;
+        const uint32_t currentMonthUsage = calculateUsage(currentVolume, history[monthCount - 1]);
+        ok = appendFormatted(outputBuffer, bufferSize, pos,
+                             "],\"current_month_usage\":%u,\"months_available\":%d}",
+                             currentMonthUsage, monthCount);
     }
 
-    pos += snprintf(outputBuffer + pos, remaining,
-                    "],\"current_month_usage\":%u,\"months_available\":%d}",
-                    currentMonthUsage, monthCount);
-
-    // Ensure null termination
-    outputBuffer[bufferSize - 1] = '\0';
+    if (!ok)
+    {
+        // Report failure rather than publishing a truncated, unparseable payload.
+        outputBuffer[0] = '\0';
+        return 0;
+    }
 
     return pos;
 }

--- a/src/services/meter_history.h
+++ b/src/services/meter_history.h
@@ -67,7 +67,9 @@ public:
      * @param currentVolume Current meter reading
      * @param outputBuffer Buffer to write JSON to
      * @param bufferSize Size of output buffer
-     * @return Number of bytes written (including null terminator), or 0 if buffer too small
+     * @return Number of characters written, excluding the null terminator, or 0
+     *         if there is no history or the payload does not fit. A truncated,
+     *         unparseable payload is never returned.
      */
     static int generateHistoryJson(const uint32_t history[13], uint32_t currentVolume,
                                    char *outputBuffer, int bufferSize);

--- a/src/services/meter_reader.cpp
+++ b/src/services/meter_reader.cpp
@@ -49,7 +49,7 @@ static void logReadableSummary(const tmeter_data &data, const IConfigProvider *c
 }
 
 MeterReader::MeterReader(IConfigProvider *config, ITimeProvider *timeProvider, IDataPublisher *publisher)
-    : m_config(config), m_timeProvider(timeProvider), m_publisher(publisher), m_initialized(false), m_readingInProgress(false), m_isScheduledRead(false), m_haConnected(false), m_radioConnected(false), m_retryCount(0), m_lastFailedAttempt(0), m_nextRetryTime(0), m_autoScanAfterFailureDone(false), m_retryFailureReason(ReadFailure::None), m_totalReadAttempts(0), m_successfulReads(0), m_failedReads(0), m_lastErrorMessage("None"), m_lastScheduleCheck(0), m_lastStatsPublish(0), m_readHourLocal(10), m_readMinuteLocal(0), m_lastReadDayMatch(false), m_lastReadTimeMatch(false)
+    : m_config(config), m_timeProvider(timeProvider), m_publisher(publisher), m_initialized(false), m_readingInProgress(false), m_isScheduledRead(false), m_haConnected(false), m_radioConnected(false), m_retryCount(0), m_inCooldown(false), m_lastFailedAttempt(0), m_nextRetryTime(0), m_autoScanAfterFailureDone(false), m_retryFailureReason(ReadFailure::None), m_totalReadAttempts(0), m_successfulReads(0), m_failedReads(0), m_lastErrorMessage("None"), m_lastScheduleCheck(0), m_lastStatsPublish(0), m_readHourLocal(10), m_readMinuteLocal(0), m_lastReadDayMatch(false), m_lastReadTimeMatch(false)
 {
 }
 
@@ -249,8 +249,11 @@ bool MeterReader::shouldPerformScheduledRead()
         return false;
     }
 
-    // Check if in cooldown period after failures
-    if (m_lastFailedAttempt > 0)
+    // Check if in cooldown period after failures.
+    // The flag, rather than a non-zero timestamp, is what marks the cooldown as
+    // running: millis() legitimately returns 0 for the first millisecond after
+    // boot, and a failure landing there must not skip the cooldown entirely.
+    if (m_inCooldown)
     {
         unsigned long cooldown = m_config->getRetryCooldownMs();
         if (millis() - m_lastFailedAttempt < cooldown)
@@ -258,6 +261,7 @@ bool MeterReader::shouldPerformScheduledRead()
             return false;
         }
         // Cooldown expired, reset
+        m_inCooldown = false;
         m_lastFailedAttempt = 0;
     }
 
@@ -406,9 +410,10 @@ void MeterReader::handleFailedRead(ReadFailure reason)
     if (m_retryCount < m_config->getMaxRetries() - 1)
     {
         // Schedule retry after delay.
-        // Keep the "Active Reading" sensor true and the radio state as "Reading"
-        // for the whole retry sequence so they don't flicker running/idle between
-        // attempts. They are cleared only on final success or after max retries.
+        // The "Active Reading" sensor and the radio state are re-asserted on
+        // every attempt but never cleared between them, so they don't drop to
+        // idle mid-sequence and make the read look finished. They are cleared
+        // only on final success or after max retries.
         // m_readingInProgress also stays true to keep the sequence atomic (the
         // retry timer in loop() calls performReading() directly, bypassing the
         // m_readingInProgress guard).
@@ -426,6 +431,7 @@ void MeterReader::handleFailedRead(ReadFailure reason)
     {
         // Max retries reached
         m_failedReads++;
+        m_inCooldown = true;
         m_lastFailedAttempt = millis();
         m_lastErrorMessage = read_failure_message(
             m_retryFailureReason != ReadFailure::None ? m_retryFailureReason : reason, false);

--- a/src/services/meter_reader.h
+++ b/src/services/meter_reader.h
@@ -201,6 +201,7 @@ private:
 
     // Retry management
     int m_retryCount;
+    bool m_inCooldown;                // True while the post-failure cooldown is running
     unsigned long m_lastFailedAttempt;
     unsigned long m_nextRetryTime;
     bool m_autoScanAfterFailureDone;  // Guards the failure-recovery frequency scan to once per failure streak

--- a/src/services/schedule_manager.cpp
+++ b/src/services/schedule_manager.cpp
@@ -26,6 +26,11 @@ void ScheduleManager::begin(const char *schedule, int readHourUtc, int readMinut
 
 bool ScheduleManager::isValidSchedule(const char *schedule)
 {
+    if (schedule == nullptr)
+    {
+        return false;
+    }
+
     return (strcmp(schedule, "Monday-Friday") == 0 ||
             strcmp(schedule, "Monday-Saturday") == 0 ||
             strcmp(schedule, "Monday-Sunday") == 0 ||
@@ -47,7 +52,8 @@ void ScheduleManager::setSchedule(const char *schedule)
     }
     else
     {
-        LOG_W("everblu_meter", "Invalid schedule '%s' - falling back to 'Monday-Friday'", schedule);
+        LOG_W("everblu_meter", "Invalid schedule '%s' - falling back to 'Monday-Friday'",
+              schedule ? schedule : "(null)");
         s_schedule = "Monday-Friday";
     }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -89,6 +89,16 @@ cooldowns are exercised instantly and deterministically. Nothing ever sleeps.
 
 ## Running
 
+```powershell
+# Everything CI runs, in the same order
+./scripts/run-tests.ps1            # host suites only (a few seconds)
+./scripts/run-tests.ps1 -Build     # also compile both firmware targets
+./scripts/run-tests.ps1 -All       # also collect coverage
+./scripts/run-tests.ps1 -Serial    # show the firmware log output
+```
+
+Or drive PlatformIO directly:
+
 ```bash
 # All MQTT-mode host suites
 pio test -e native

--- a/test/README.md
+++ b/test/README.md
@@ -30,7 +30,44 @@ Pure logic tests for the platform-neutral parts of the firmware.
 - `test_config_validation.cpp` - meter code parsing, schedule string validation
 - `test_schedule_manager.cpp` - reading days, UTC/local conversion, clamping, auto-alignment to the meter wake window
 - `test_utils.cpp` - CRC-16/KERMIT correctness, determinism and bit-flip detection
+- `test_meter_history.cpp` - monthly usage maths, meter-reset handling, the history JSON payload
 - `test_runner.cpp` - the single Unity entry point; every test case is registered here
+
+### `test_native_meter_reader/`
+
+Behaviour of the two stateful services, driven against fake hardware.
+
+- `test_meter_reader.cpp` - retry sequence and backoff, post-failure cooldown,
+  schedule gating and edge detection, failure classification, publish ordering,
+  the manual stop path and the automatic scan after a failure streak
+- `test_frequency_manager.cpp` - deep scan lock and abort paths, the calibration
+  quality guard, persistence round-trips and adaptive FREQEST tracking
+
+## Fakes and the virtual clock
+
+`test/native_fakes.{h,cpp}` provides the test doubles. It sits in the test root
+rather than in a suite folder because PlatformIO compiles everything listed in
+`build_src_filter` into *every* host test binary, so all suites have to be able
+to resolve the same symbols.
+
+It replaces three things at link time:
+
+| Replaced | Why |
+| --- | --- |
+| CC1101 free functions (`cc1101_init`, `get_meter_data_for_meter`, ...) | No radio on the host |
+| `StorageAbstraction` | No EEPROM or NVS on the host |
+| `WifiSerialStream` / `WiFiSerial` | No network stack; log output goes to stdout |
+
+The fake radio answers in one of two modes. Scripted mode consumes a queue of
+`tmeter_data` outcomes, repeating the last entry once the script runs out.
+Frequency-selective mode places a simulated carrier at a chosen offset and only
+answers while the radio is tuned inside the response window, reporting a FREQEST
+proportional to the tuning error. That is what makes the deep frequency scan
+testable in milliseconds instead of the minutes a real sweep takes.
+
+The shim clock is virtual and starts at a fixed value. Tests move time with
+`nativeClockAdvance(ms)`, and `delay()` advances it too, so retry delays and
+cooldowns are exercised instantly and deterministically. Nothing ever sleeps.
 
 ## Running
 
@@ -46,15 +83,16 @@ pio test -e native -v
 ```
 
 `pio test -e huzzah` (or any board environment) deliberately runs nothing:
-`test_ignore` in `platformio.ini` excludes both suites, because neither needs
-hardware and both are already covered on the host in CI.
+`test_ignore` in `platformio.ini` excludes every suite, because none of them
+needs hardware and all are already covered on the host in CI.
 
 ## Native Arduino shim
 
 `test/native_shims/Arduino.h` is a small stand-in for the Arduino core, added to
 the include path only by `[env:native]`. It supplies `millis()`, `delay()`,
-`constrain()`, `map()` and a `Serial` object so that shared service code such as
-`src/services/schedule_manager.cpp` compiles on a desktop host.
+`constrain()`, `map()`, the `Print`/`Stream` base classes and a `Serial` object,
+so that shared service code such as `src/services/schedule_manager.cpp` compiles
+on a desktop host.
 
 Serial output from the firmware under test is discarded by default. Set
 `EVERBLU_NATIVE_SERIAL=1` to mirror it to stdout when debugging a failure.
@@ -67,8 +105,8 @@ rather than trying to emulate the whole Arduino API.
 1. Add the test function to the relevant `test_*.cpp` file, or create a new one
    in the same suite directory.
 2. Declare it and register it with `RUN_TEST(...)` in that suite's runner
-   (`test_runner.cpp` for `test_embedded_unit`, `main()` for
-   `test_native_meter_fixtures`).
+   (`test_runner.cpp` for `test_embedded_unit` and `test_native_meter_reader`,
+   `main()` for `test_native_meter_fixtures`).
 3. Do not define `setUp`, `tearDown` or `main` in the individual test files:
    Unity allows only one of each per suite binary.
 4. If the code under test is not already compiled for the host, add its `.cpp`
@@ -100,5 +138,9 @@ gcovr --root . --object-directory .pio/build/native/ --print-summary \
   --filter src/core/crc_kermit.cpp \
   --filter src/core/radian_parser.cpp \
   --filter src/core/radian_decoder.cpp \
+  --filter src/core/utils.cpp \
+  --filter src/services/frequency_manager.cpp \
+  --filter src/services/meter_history.cpp \
+  --filter src/services/meter_reader.cpp \
   --filter src/services/schedule_manager.cpp
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -16,6 +16,9 @@ End-to-end replay of real radio captures.
   are parsed and checked field by field.
 - Also covers CRC validation, framing errors, glitch tolerance, buffer
   truncation, history bounds and read-failure classification.
+- `test_transmit_frame.cpp` covers the other direction: the interrogation frame
+  built by `Make_Radian_Master_req()` is pushed back through the receiver and
+  checked to recover the original payload, identity and CRC.
 
 To add a fixture from a firmware log:
 
@@ -42,6 +45,21 @@ Behaviour of the two stateful services, driven against fake hardware.
   the manual stop path and the automatic scan after a failure streak
 - `test_frequency_manager.cpp` - deep scan lock and abort paths, the calibration
   quality guard, persistence round-trips and adaptive FREQEST tracking
+
+### `test_native_esphome_publisher/`
+
+ESPHomeDataPublisher, built the way the shipped external component builds it.
+
+Runs under `[env:native_esphome]` rather than `[env:native]`, because the whole
+publisher is wrapped in `#ifdef USE_ESPHOME` and the ESPHome build needs a
+flattened include path. The recording sensor stubs live in
+`test/native_esphome/esphome/`, on that environment's include path only, so
+`__has_include("esphome/core/log.h")` stays false for the MQTT-mode suites.
+
+Covers sensor population and formatting, the history payload and its
+"unavailable" fallbacks, null-argument handling, unit conversions, and the
+"first non-null registration wins" rule for the sensors that describe the one
+shared radio.
 
 ## Fakes and the virtual clock
 
@@ -72,8 +90,11 @@ cooldowns are exercised instantly and deterministically. Nothing ever sleeps.
 ## Running
 
 ```bash
-# All host suites
+# All MQTT-mode host suites
 pio test -e native
+
+# The ESPHome-mode suite
+pio test -e native_esphome
 
 # One suite
 pio test -e native -f test_embedded_unit
@@ -105,8 +126,8 @@ rather than trying to emulate the whole Arduino API.
 1. Add the test function to the relevant `test_*.cpp` file, or create a new one
    in the same suite directory.
 2. Declare it and register it with `RUN_TEST(...)` in that suite's runner
-   (`test_runner.cpp` for `test_embedded_unit` and `test_native_meter_reader`,
-   `main()` for `test_native_meter_fixtures`).
+   (`test_runner.cpp` for `test_embedded_unit`, `test_native_meter_reader` and
+   `test_native_esphome_publisher`, `main()` for `test_native_meter_fixtures`).
 3. Do not define `setUp`, `tearDown` or `main` in the individual test files:
    Unity allows only one of each per suite binary.
 4. If the code under test is not already compiled for the host, add its `.cpp`
@@ -134,11 +155,13 @@ CI collects coverage over the host-tested sources with gcovr. Locally:
 
 ```bash
 pio test -e native
-gcovr --root . --object-directory .pio/build/native/ --print-summary \
+pio test -e native_esphome
+gcovr --root . --object-directory .pio/build/ --print-summary \
   --filter src/core/crc_kermit.cpp \
   --filter src/core/radian_parser.cpp \
   --filter src/core/radian_decoder.cpp \
   --filter src/core/utils.cpp \
+  --filter src/adapters/implementations/esphome_data_publisher.cpp \
   --filter src/services/frequency_manager.cpp \
   --filter src/services/meter_history.cpp \
   --filter src/services/meter_reader.cpp \

--- a/test/README.md
+++ b/test/README.md
@@ -90,6 +90,9 @@ cooldowns are exercised instantly and deterministically. Nothing ever sleeps.
 ## Running
 
 ```powershell
+# One-off: install the tooling (platformio, pytest, esphome, gcovr)
+pip install -r scripts/requirements-dev.txt
+
 # Everything CI runs, in the same order
 ./scripts/run-tests.ps1            # host suites only (a few seconds)
 ./scripts/run-tests.ps1 -Build     # also compile both firmware targets

--- a/test/README.md
+++ b/test/README.md
@@ -1,113 +1,104 @@
 # Unit Tests
 
-This directory contains unit tests for the EverBlu Meters ESP8266/ESP32 project using the Unity test framework.
+Unit tests for the EverBlu Meters ESP8266/ESP32 project, using the Unity test
+framework. Every suite runs on the host: no board, no radio, no meter needed.
 
-## Test Files
+## Suites
 
-- **test_config_validation.cpp** - Tests for configuration validation functions
-  - Valid/invalid reading schedules
-  - Meter year, serial, frequency validation
+### `test_native_meter_fixtures/`
 
-- **test_utils.cpp** - Tests for utility functions
-  - CRC calculation correctness and determinism
-  - Hex display functions
+End-to-end replay of real radio captures.
 
-- **test_state_machine.cpp** - Tests for state machine implementation
-  - State enumeration validation
-  - State transition logic
-  - State uniqueness
+- Raw oversampled CC1101 receive buffers from `test/fixtures/meter_frames/raw_frames.lst`
+  are pushed through the RADIAN decoder, then the parser, then checked against
+  the expected meter reading.
+- Fully decoded 124-byte frames from `test/fixtures/meter_frames/fixtures.lst`
+  are parsed and checked field by field.
+- Also covers CRC validation, framing errors, glitch tolerance, buffer
+  truncation, history bounds and read-failure classification.
 
-## Running Tests
-
-### With PlatformIO
-
-```bash
-# Run all tests
-pio test
-
-# Run specific test environment
-pio test -e huzzah
-
-# Run with verbose output
-pio test -v
-
-# Run native fixture replay tests (no hardware required)
-pio test -e native -v
-```
-
-### Native Fixture Replay (GitHub CI compatible)
-
-The `test_native_meter_fixtures` suite replays captured decoded meter frames from:
-
-- `test/fixtures/meter_frames/fixtures.lst`
-
-This suite runs on host (PlatformIO `native` environment), so it is suitable for GitHub Actions.
-
-To generate fixture entries from firmware logs, use:
+To add a fixture from a firmware log:
 
 ```bash
 python scripts/extract-meter-fixture.py --input meter-capture.log --append --name-prefix capture
 ```
 
-### Test Framework
+### `test_embedded_unit/`
 
-These tests use the [Unity](http://www.throwtheswitch.org/unity) test framework, which is automatically managed by PlatformIO.
+Pure logic tests for the platform-neutral parts of the firmware.
 
-## Adding New Tests
+- `test_config_validation.cpp` - meter code parsing, schedule string validation
+- `test_schedule_manager.cpp` - reading days, UTC/local conversion, clamping, auto-alignment to the meter wake window
+- `test_utils.cpp` - CRC-16/KERMIT correctness, determinism and bit-flip detection
+- `test_runner.cpp` - the single Unity entry point; every test case is registered here
 
-1. Create a new test file in this directory: `test_<feature>.cpp`
-2. Include the Unity header: `#include <unity.h>`
-3. Implement test functions with `test_` prefix
-4. Add `setUp()` and `tearDown()` functions if needed
-5. Call tests in `setup()` using `RUN_TEST(test_function_name)`
+## Running
 
-### Test Template
+```bash
+# All host suites
+pio test -e native
 
-```cpp
-#include <unity.h>
-#include <Arduino.h>
+# One suite
+pio test -e native -f test_embedded_unit
 
-void setUp(void) {
-    // Runs before each test
-}
-
-void tearDown(void) {
-    // Runs after each test
-}
-
-void test_example(void) {
-    TEST_ASSERT_EQUAL(expected, actual);
-}
-
-void setup() {
-    delay(2000);
-    UNITY_BEGIN();
-    RUN_TEST(test_example);
-    UNITY_END();
-}
-
-void loop() {
-    // Nothing
-}
+# Verbose
+pio test -e native -v
 ```
 
-## Test Assertions
+`pio test -e huzzah` (or any board environment) deliberately runs nothing:
+`test_ignore` in `platformio.ini` excludes both suites, because neither needs
+hardware and both are already covered on the host in CI.
 
-Common Unity assertions:
+## Native Arduino shim
+
+`test/native_shims/Arduino.h` is a small stand-in for the Arduino core, added to
+the include path only by `[env:native]`. It supplies `millis()`, `delay()`,
+`constrain()`, `map()` and a `Serial` object so that shared service code such as
+`src/services/schedule_manager.cpp` compiles on a desktop host.
+
+Serial output from the firmware under test is discarded by default. Set
+`EVERBLU_NATIVE_SERIAL=1` to mirror it to stdout when debugging a failure.
+
+Keep the shim minimal. Extend it when a newly host-tested source needs a symbol,
+rather than trying to emulate the whole Arduino API.
+
+## Adding a test
+
+1. Add the test function to the relevant `test_*.cpp` file, or create a new one
+   in the same suite directory.
+2. Declare it and register it with `RUN_TEST(...)` in that suite's runner
+   (`test_runner.cpp` for `test_embedded_unit`, `main()` for
+   `test_native_meter_fixtures`).
+3. Do not define `setUp`, `tearDown` or `main` in the individual test files:
+   Unity allows only one of each per suite binary.
+4. If the code under test is not already compiled for the host, add its `.cpp`
+   to `build_src_filter` under `[env:native]` in `platformio.ini`.
+
+## Assertions
+
+Commonly used Unity assertions:
 
 - `TEST_ASSERT_TRUE(condition)`
 - `TEST_ASSERT_FALSE(condition)`
-- `TEST_ASSERT_EQUAL(expected, actual)`
+- `TEST_ASSERT_EQUAL_INT(expected, actual)`
+- `TEST_ASSERT_EQUAL_UINT32(expected, actual)`
+- `TEST_ASSERT_EQUAL_HEX16(expected, actual)`
 - `TEST_ASSERT_NOT_EQUAL(expected, actual)`
 - `TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual)`
-- `TEST_ASSERT_NULL(pointer)`
-- `TEST_ASSERT_NOT_NULL(pointer)`
+- `TEST_ASSERT_NULL(pointer)` / `TEST_ASSERT_NOT_NULL(pointer)`
 
-See [Unity documentation](https://github.com/ThrowTheSwitch/Unity/blob/master/docs/UnityAssertionsReference.md) for complete list.
+See the [Unity assertion reference](https://github.com/ThrowTheSwitch/Unity/blob/master/docs/UnityAssertionsReference.md)
+for the full list.
 
-## Notes
+## Coverage
 
-- Tests run on the actual hardware (ESP8266/ESP32)
-- Serial output shows test results
-- Failed tests will stop execution and report the failure
-- Use mocks/stubs for hardware-dependent code when needed
+CI collects coverage over the host-tested sources with gcovr. Locally:
+
+```bash
+pio test -e native
+gcovr --root . --object-directory .pio/build/native/ --print-summary \
+  --filter src/core/crc_kermit.cpp \
+  --filter src/core/radian_parser.cpp \
+  --filter src/core/radian_decoder.cpp \
+  --filter src/services/schedule_manager.cpp
+```

--- a/test/native_esphome/esphome/components/binary_sensor/binary_sensor.h
+++ b/test/native_esphome/esphome/components/binary_sensor/binary_sensor.h
@@ -1,0 +1,32 @@
+/**
+ * @file binary_sensor.h
+ * @brief Minimal recording stand-in for esphome::binary_sensor::BinarySensor
+ *
+ * Host-build only, used by the PlatformIO `native_esphome` environment.
+ */
+
+#ifndef EVERBLU_NATIVE_ESPHOME_BINARY_SENSOR_H
+#define EVERBLU_NATIVE_ESPHOME_BINARY_SENSOR_H
+
+#include <vector>
+
+namespace esphome
+{
+    namespace binary_sensor
+    {
+        class BinarySensor
+        {
+        public:
+            std::vector<bool> states;
+
+            void publish_state(bool state) { states.push_back(state); }
+
+            bool published() const { return !states.empty(); }
+            bool last() const { return states.empty() ? false : states.back(); }
+            int count() const { return (int)states.size(); }
+            void clear() { states.clear(); }
+        };
+    }
+}
+
+#endif // EVERBLU_NATIVE_ESPHOME_BINARY_SENSOR_H

--- a/test/native_esphome/esphome/components/sensor/sensor.h
+++ b/test/native_esphome/esphome/components/sensor/sensor.h
@@ -1,0 +1,34 @@
+/**
+ * @file sensor.h
+ * @brief Minimal recording stand-in for esphome::sensor::Sensor
+ *
+ * Host-build only, used by the PlatformIO `native_esphome` environment. Every
+ * published state is kept so tests can assert on what Home Assistant would
+ * have received.
+ */
+
+#ifndef EVERBLU_NATIVE_ESPHOME_SENSOR_H
+#define EVERBLU_NATIVE_ESPHOME_SENSOR_H
+
+#include <vector>
+
+namespace esphome
+{
+    namespace sensor
+    {
+        class Sensor
+        {
+        public:
+            std::vector<float> states;
+
+            void publish_state(float state) { states.push_back(state); }
+
+            bool published() const { return !states.empty(); }
+            float last() const { return states.empty() ? 0.0f : states.back(); }
+            int count() const { return (int)states.size(); }
+            void clear() { states.clear(); }
+        };
+    }
+}
+
+#endif // EVERBLU_NATIVE_ESPHOME_SENSOR_H

--- a/test/native_esphome/esphome/components/text_sensor/text_sensor.h
+++ b/test/native_esphome/esphome/components/text_sensor/text_sensor.h
@@ -1,0 +1,33 @@
+/**
+ * @file text_sensor.h
+ * @brief Minimal recording stand-in for esphome::text_sensor::TextSensor
+ *
+ * Host-build only, used by the PlatformIO `native_esphome` environment.
+ */
+
+#ifndef EVERBLU_NATIVE_ESPHOME_TEXT_SENSOR_H
+#define EVERBLU_NATIVE_ESPHOME_TEXT_SENSOR_H
+
+#include <string>
+#include <vector>
+
+namespace esphome
+{
+    namespace text_sensor
+    {
+        class TextSensor
+        {
+        public:
+            std::vector<std::string> states;
+
+            void publish_state(const std::string &state) { states.push_back(state); }
+
+            bool published() const { return !states.empty(); }
+            const char *last() const { return states.empty() ? "" : states.back().c_str(); }
+            int count() const { return (int)states.size(); }
+            void clear() { states.clear(); }
+        };
+    }
+}
+
+#endif // EVERBLU_NATIVE_ESPHOME_TEXT_SENSOR_H

--- a/test/native_esphome/esphome/core/log.h
+++ b/test/native_esphome/esphome/core/log.h
@@ -1,0 +1,50 @@
+/**
+ * @file log.h
+ * @brief Minimal stand-in for esphome/core/log.h for host builds
+ *
+ * Only used by the PlatformIO `native_esphome` environment. It exists so the
+ * USE_ESPHOME code paths in src/ can be compiled and tested on a desktop host
+ * without checking out the ESPHome source tree.
+ *
+ * Log output is discarded unless EVERBLU_NATIVE_SERIAL is set, matching the
+ * behaviour of the Serial shim used by the MQTT-mode host tests.
+ */
+
+#ifndef EVERBLU_NATIVE_ESPHOME_LOG_H
+#define EVERBLU_NATIVE_ESPHOME_LOG_H
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace esphome
+{
+    inline bool native_log_enabled()
+    {
+        static const bool on = (std::getenv("EVERBLU_NATIVE_SERIAL") != nullptr);
+        return on;
+    }
+
+    inline void native_log(const char *level, const char *tag, const char *fmt, ...)
+    {
+        if (!native_log_enabled())
+        {
+            return;
+        }
+        std::printf("[%s][%s]: ", level, tag ? tag : "?");
+        va_list args;
+        va_start(args, fmt);
+        std::vfprintf(stdout, fmt, args);
+        va_end(args);
+        std::printf("\n");
+    }
+}
+
+#define ESP_LOGV(tag, ...) ::esphome::native_log("V", tag, __VA_ARGS__)
+#define ESP_LOGD(tag, ...) ::esphome::native_log("D", tag, __VA_ARGS__)
+#define ESP_LOGI(tag, ...) ::esphome::native_log("I", tag, __VA_ARGS__)
+#define ESP_LOGW(tag, ...) ::esphome::native_log("W", tag, __VA_ARGS__)
+#define ESP_LOGE(tag, ...) ::esphome::native_log("E", tag, __VA_ARGS__)
+
+#endif // EVERBLU_NATIVE_ESPHOME_LOG_H

--- a/test/native_fakes.cpp
+++ b/test/native_fakes.cpp
@@ -1,0 +1,430 @@
+/**
+ * @file native_fakes.cpp
+ * @brief Definitions for the host-side test doubles declared in native_fakes.h
+ *
+ * This file also supplies link-time replacements for three sets of symbols the
+ * production code expects the platform to provide:
+ *   - the CC1101 driver free functions (core/cc1101.h),
+ *   - StorageAbstraction (services/storage_abstraction.h), and
+ *   - the WiFi serial mirror (core/wifi_serial.h), which is reduced to plain
+ *     stdout so that logging still works without a network stack.
+ */
+
+#include "native_fakes.h"
+
+#include <cmath>
+#include <cstring>
+#include <ctime>
+
+#include "services/frequency_manager.h"
+#include "services/storage_abstraction.h"
+
+// Take the real Serial object rather than the WiFiSerial remap this header
+// installs, since this translation unit is what defines WiFiSerial.
+#define WIFI_SERIAL_NO_REMAP
+#include "core/wifi_serial.h"
+
+// ---------------------------------------------------------------------------
+// FakeRadio and the cc1101 link seam
+// ---------------------------------------------------------------------------
+
+FakeRadio &fakeRadio()
+{
+    static FakeRadio instance;
+    return instance;
+}
+
+void FakeRadio::reset()
+{
+    responses.clear();
+    calls.clear();
+    initFrequencies.clear();
+    initSucceeds = true;
+    recModeCalls = 0;
+    carrierFrequency = 0.0f;
+    carrierWidthMHz = 0.010f;
+    cancelScanAfterCalls = 0;
+}
+
+tmeter_data FakeRadio::success(int volume, int8_t freqest)
+{
+    tmeter_data data{};
+    data.volume = volume;
+    data.reads_counter = 42;
+    data.battery_left = 120;
+    data.time_start = 8;
+    data.time_end = 18;
+    data.rssi_dbm = -70;
+    data.lqi = 20;
+    data.freqest = freqest;
+    data.history_available = false;
+    data.failure = ReadFailure::None;
+    return data;
+}
+
+tmeter_data FakeRadio::failure(ReadFailure reason)
+{
+    tmeter_data data{};
+    data.failure = reason;
+    return data;
+}
+
+void setMHZ(float mhz)
+{
+    fakeRadio().initFrequencies.push_back(mhz);
+}
+
+bool cc1101_init(float freq)
+{
+    FakeRadio &radio = fakeRadio();
+    radio.initFrequencies.push_back(freq);
+    return radio.initSucceeds;
+}
+
+void cc1101_rec_mode(void)
+{
+    fakeRadio().recModeCalls++;
+}
+
+uint32_t cc1101_get_gdo2_timeout_count(void)
+{
+    return 0;
+}
+
+struct tmeter_data get_meter_data_for_meter(uint8_t meter_year, uint32_t meter_serial)
+{
+    FakeRadio &radio = fakeRadio();
+    const float tuned = radio.lastInitFrequency();
+    radio.calls.push_back({meter_year, meter_serial, tuned});
+
+    if (radio.cancelScanAfterCalls > 0 &&
+        (int)radio.calls.size() >= radio.cancelScanAfterCalls)
+    {
+        FrequencyManager::requestScanCancel();
+    }
+
+    if (radio.carrierFrequency > 0.0f)
+    {
+        const float errorMHz = tuned - radio.carrierFrequency;
+        if (std::fabs(errorMHz) > radio.carrierWidthMHz)
+        {
+            return FakeRadio::failure(ReadFailure::NoReply);
+        }
+        // FREQEST reports how far the receiver is from the true carrier, with
+        // the sign the CC1101 uses: positive when tuned below the carrier.
+        const float lsb = -errorMHz / 0.001587f;
+        int quantised = (int)lroundf(lsb);
+        if (quantised > 127) quantised = 127;
+        if (quantised < -128) quantised = -128;
+        tmeter_data data = FakeRadio::success(12345, (int8_t)quantised);
+        data.rssi_dbm = -60 - (int)(std::fabs(errorMHz) * 1000.0f);
+        return data;
+    }
+
+    if (radio.responses.empty())
+    {
+        return FakeRadio::failure(ReadFailure::NoReply);
+    }
+
+    // The final scripted response repeats, so a test only has to describe the
+    // outcomes it cares about rather than pad the script to the retry count.
+    const size_t index = radio.calls.size() - 1;
+    if (index >= radio.responses.size())
+    {
+        return radio.responses.back();
+    }
+    return radio.responses[index];
+}
+
+struct tmeter_data get_meter_data(void)
+{
+    return get_meter_data_for_meter(0, 0);
+}
+
+// ---------------------------------------------------------------------------
+// FakeStorage and the StorageAbstraction link seam
+// ---------------------------------------------------------------------------
+
+FakeStorage &fakeStorage()
+{
+    static FakeStorage instance;
+    return instance;
+}
+
+void FakeStorage::clear()
+{
+    entries.clear();
+    beginCalls = 0;
+    saveCalls = 0;
+}
+
+const FakeStorage::Entry *FakeStorage::find(const char *key) const
+{
+    for (const Entry &entry : entries)
+    {
+        if (entry.key == key)
+        {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+bool StorageAbstraction::begin()
+{
+    fakeStorage().beginCalls++;
+    return true;
+}
+
+bool StorageAbstraction::saveFloat(const char *key, float value, uint16_t magic)
+{
+    FakeStorage &storage = fakeStorage();
+    storage.saveCalls++;
+    for (FakeStorage::Entry &entry : storage.entries)
+    {
+        if (entry.key == key)
+        {
+            entry.value = value;
+            entry.magic = magic;
+            return true;
+        }
+    }
+    storage.entries.push_back({key, value, magic});
+    return true;
+}
+
+float StorageAbstraction::loadFloat(const char *key, float defaultValue, uint16_t magic,
+                                    float minValue, float maxValue)
+{
+    const FakeStorage::Entry *entry = fakeStorage().find(key);
+    if (!entry || entry->magic != magic)
+    {
+        return defaultValue;
+    }
+    if (std::isnan(entry->value) || entry->value < minValue || entry->value > maxValue)
+    {
+        return defaultValue;
+    }
+    return entry->value;
+}
+
+bool StorageAbstraction::hasKey(const char *key)
+{
+    return fakeStorage().find(key) != nullptr;
+}
+
+bool StorageAbstraction::clearKey(const char *key)
+{
+    FakeStorage &storage = fakeStorage();
+    for (size_t i = 0; i < storage.entries.size(); i++)
+    {
+        if (storage.entries[i].key == key)
+        {
+            storage.entries.erase(storage.entries.begin() + (long)i);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool StorageAbstraction::clearAll()
+{
+    fakeStorage().entries.clear();
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// WiFi serial mirror: reduced to the local stdout stream
+// ---------------------------------------------------------------------------
+
+WifiSerialStream WiFiSerial(::Serial);
+
+size_t WifiSerialStream::write(uint8_t c) { return _usb.write(c); }
+size_t WifiSerialStream::write(const uint8_t *buffer, size_t size) { return _usb.write(buffer, size); }
+void WifiSerialStream::flush() { _usb.flush(); }
+int WifiSerialStream::available() { return 0; }
+int WifiSerialStream::read() { return -1; }
+int WifiSerialStream::peek() { return -1; }
+void WifiSerialStream::beginServer() {}
+void WifiSerialStream::loop() {}
+
+size_t WifiSerialStream::printf(const char *format, ...)
+{
+    char buf[512];
+    va_list args;
+    va_start(args, format);
+    const int n = vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+    if (n <= 0)
+    {
+        return 0;
+    }
+    const size_t len = (size_t)n < sizeof(buf) ? (size_t)n : sizeof(buf) - 1;
+    return write((const uint8_t *)buf, len);
+}
+
+void wifiSerialBegin() {}
+void wifiSerialLoop() {}
+void wifiSerialPrint(const char *str) { WiFiSerial.print(str); }
+void wifiSerialPrintln(const char *str) { WiFiSerial.println(str); }
+
+void wifiSerialPrintf(const char *format, ...)
+{
+    char buf[512];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+    WiFiSerial.print(buf);
+}
+
+// ---------------------------------------------------------------------------
+// FakeTime
+// ---------------------------------------------------------------------------
+
+void FakeTime::setUtc(int year, int month, int day, int hour, int minute, int second)
+{
+    struct tm parts = {};
+    parts.tm_year = year - 1900;
+    parts.tm_mon = month - 1;
+    parts.tm_mday = day;
+    parts.tm_hour = hour;
+    parts.tm_min = minute;
+    parts.tm_sec = second;
+
+    // timegm() is not portable, so convert by hand: the meter code only ever
+    // reads the result back through gmtime(), so a pure UTC epoch is enough.
+    static const int cumulativeDays[12] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
+    long days = 0;
+    for (int y = 1970; y < year; y++)
+    {
+        const bool leap = (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
+        days += leap ? 366 : 365;
+    }
+    days += cumulativeDays[parts.tm_mon];
+    const bool leapThisYear = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+    if (leapThisYear && month > 2)
+    {
+        days += 1;
+    }
+    days += day - 1;
+
+    nowUtc = (time_t)days * 86400 + hour * 3600 + minute * 60 + second;
+}
+
+// ---------------------------------------------------------------------------
+// RecordingPublisher
+// ---------------------------------------------------------------------------
+
+void RecordingPublisher::reset()
+{
+    ready = true;
+    readings.clear();
+    statuses.clear();
+    radioStates.clear();
+    errors.clear();
+    activeReadingFlags.clear();
+    frequencyOffsets.clear();
+    tunedFrequencies.clear();
+    statistics.clear();
+    historyPublishes = 0;
+    settingsPublishes = 0;
+    discoveryPublishes = 0;
+}
+
+int RecordingPublisher::countOf(const std::vector<std::string> &v, const char *value)
+{
+    int count = 0;
+    for (const std::string &entry : v)
+    {
+        if (entry == value)
+        {
+            count++;
+        }
+    }
+    return count;
+}
+
+const std::string &RecordingPublisher::last(const std::vector<std::string> &v)
+{
+    static const std::string empty;
+    return v.empty() ? empty : v.back();
+}
+
+void RecordingPublisher::publishMeterReading(const tmeter_data &data, const char *timestamp)
+{
+    readings.push_back({data, timestamp ? timestamp : ""});
+}
+
+void RecordingPublisher::publishHistory(const uint32_t *, bool) { historyPublishes++; }
+
+void RecordingPublisher::publishWiFiDetails(const char *, int, int, const char *, const char *, const char *) {}
+
+void RecordingPublisher::publishMeterSettings(int, unsigned long, const char *, const char *, float)
+{
+    settingsPublishes++;
+}
+
+void RecordingPublisher::publishStatusMessage(const char *message)
+{
+    statuses.push_back(message ? message : "");
+}
+
+void RecordingPublisher::publishRadioState(const char *state)
+{
+    radioStates.push_back(state ? state : "");
+}
+
+void RecordingPublisher::publishActiveReading(bool active)
+{
+    activeReadingFlags.push_back(active);
+}
+
+void RecordingPublisher::publishError(const char *error)
+{
+    errors.push_back(error ? error : "");
+}
+
+void RecordingPublisher::publishStatistics(unsigned long totalAttempts, unsigned long successfulReads,
+                                           unsigned long failedReads)
+{
+    statistics.push_back({totalAttempts, successfulReads, failedReads});
+}
+
+void RecordingPublisher::publishFrequencyOffset(float offsetMHz)
+{
+    frequencyOffsets.push_back(offsetMHz);
+}
+
+void RecordingPublisher::publishTunedFrequency(float frequencyMHz)
+{
+    tunedFrequencies.push_back(frequencyMHz);
+}
+
+void RecordingPublisher::publishFrequencyEstimate(int8_t) {}
+void RecordingPublisher::publishUptime(unsigned long, const char *) {}
+void RecordingPublisher::publishFirmwareVersion(const char *) {}
+void RecordingPublisher::publishDiscovery() { discoveryPublishes++; }
+
+// ---------------------------------------------------------------------------
+// Shared reset
+// ---------------------------------------------------------------------------
+
+void resetAllFakes()
+{
+    // Start at a plausible uptime rather than zero: several timers in the
+    // firmware use "0" as their "never happened" sentinel, so a test running at
+    // millis() == 0 would exercise a state the device never boots into.
+    nativeClockSet(10000);
+    fakeRadio().reset();
+    fakeStorage().clear();
+
+    // FrequencyManager keeps its calibration in static members that outlive a
+    // single test, so put it back to a clean, uncalibrated state.
+    FrequencyManager::setAdaptiveThreshold(10);
+    FrequencyManager::resetAdaptiveTracking();
+    FrequencyManager::setAutoScanEnabled(false);
+    FrequencyManager::setOffset(0.0f);
+    FrequencyManager::setRadioInitCallback(nullptr);
+    FrequencyManager::setMeterReadCallback(nullptr);
+}

--- a/test/native_fakes.h
+++ b/test/native_fakes.h
@@ -1,0 +1,279 @@
+/**
+ * @file native_fakes.h
+ * @brief Host-side test doubles shared by every PlatformIO `native` suite
+ *
+ * This file lives in the test root, not inside a suite folder, because
+ * PlatformIO compiles the whole of `build_src_filter` into every host test
+ * binary. Suites that never mention MeterReader still have to resolve the
+ * symbols its translation units reference, so the link seams below are shared.
+ *
+ * The production code reaches the outside world through four seams:
+ *   - the IConfigProvider / ITimeProvider / IDataPublisher interfaces, and
+ *   - the free functions declared in core/cc1101.h, StorageAbstraction, and the
+ *     WiFi serial mirror, which are replaced at link time by native_fakes.cpp.
+ *
+ * Nothing here is compiled into the firmware.
+ */
+
+#ifndef EVERBLU_TEST_FAKES_H
+#define EVERBLU_TEST_FAKES_H
+
+#include <string>
+#include <vector>
+
+#include "adapters/config_provider.h"
+#include "adapters/data_publisher.h"
+#include "adapters/time_provider.h"
+#include "core/cc1101.h"
+
+// ---------------------------------------------------------------------------
+// Radio fake (link seam over core/cc1101.h)
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Scriptable stand-in for the CC1101 driver.
+ *
+ * Tests push outcomes onto @ref responses; each call to get_meter_data_for_meter()
+ * consumes the next one, and the last entry repeats once the script runs out.
+ * Every call is recorded so tests can assert on attempt counts and on the
+ * frequency the radio was tuned to at the time.
+ */
+struct FakeRadio
+{
+    struct Call
+    {
+        uint8_t year;
+        uint32_t serial;
+        float frequency; // Frequency the radio was last initialised at
+    };
+
+    // Scripted outcomes, consumed in order
+    std::vector<tmeter_data> responses;
+    std::vector<Call> calls;
+
+    // Frequency-selective mode: when carrierFrequency is non-zero the scripted
+    // responses are ignored and the meter answers only while the radio is tuned
+    // within carrierWidthMHz of the carrier, with a FREQEST proportional to how
+    // far off centre it is. This models the response window that a frequency
+    // scan is trying to find.
+    float carrierFrequency = 0.0f;
+    float carrierWidthMHz = 0.010f;
+
+    // When positive, ask FrequencyManager to cancel the running scan once this
+    // many reads have been served. A scan clears the cancel flag on entry, so
+    // cancellation can only be tested from inside the sweep.
+    int cancelScanAfterCalls = 0;
+
+    // cc1101_init() behaviour and history
+    bool initSucceeds = true;
+    std::vector<float> initFrequencies;
+    int recModeCalls = 0;
+
+    void reset();
+
+    /// Build a successful reading (non-zero volume and reads_counter).
+    static tmeter_data success(int volume = 12345, int8_t freqest = 0);
+
+    /// Build a failed reading of the given kind (zeroed volume and counter).
+    static tmeter_data failure(ReadFailure reason);
+
+    float lastInitFrequency() const
+    {
+        return initFrequencies.empty() ? 0.0f : initFrequencies.back();
+    }
+};
+
+/// The single fake radio instance the cc1101 stubs in fakes.cpp operate on.
+FakeRadio &fakeRadio();
+
+// ---------------------------------------------------------------------------
+// Storage fake (link seam over services/storage_abstraction.h)
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief In-memory replacement for the EEPROM/Preferences backend.
+ *
+ * Keeps values across a simulated reboot unless clear() is called, so
+ * persistence round-trips can be tested.
+ */
+struct FakeStorage
+{
+    struct Entry
+    {
+        std::string key;
+        float value;
+        uint16_t magic;
+    };
+
+    std::vector<Entry> entries;
+    int beginCalls = 0;
+    int saveCalls = 0;
+
+    void clear();
+    const Entry *find(const char *key) const;
+};
+
+FakeStorage &fakeStorage();
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Mutable IConfigProvider whose values tests set directly as public fields.
+class FakeConfig : public IConfigProvider
+{
+public:
+    uint8_t meterYear = 21;
+    uint32_t meterSerial = 123456;
+    bool meterIsGas = false;
+    int gasVolumeDivisor = 100;
+
+    float frequency = 433.82f;
+    bool autoScan = false;
+    bool autoScanOnFailure = false;
+
+    std::string schedule = "Monday-Friday";
+    int readHourUTC = 10;
+    int readMinuteUTC = 0;
+    int timezoneOffsetMinutes = 0;
+    bool autoAlign = false;
+    bool autoAlignMidpoint = false;
+
+    int maxRetries = 3;
+    unsigned long retryCooldownMs = 60000;
+
+    uint8_t getMeterYear() const override { return meterYear; }
+    uint32_t getMeterSerial() const override { return meterSerial; }
+    bool isMeterGas() const override { return meterIsGas; }
+    int getGasVolumeDivisor() const override { return gasVolumeDivisor; }
+
+    float getFrequency() const override { return frequency; }
+    bool isAutoScanEnabled() const override { return autoScan; }
+    bool isAutoScanOnFailureEnabled() const override { return autoScanOnFailure; }
+
+    const char *getReadingSchedule() const override { return schedule.c_str(); }
+    int getReadHourUTC() const override { return readHourUTC; }
+    int getReadMinuteUTC() const override { return readMinuteUTC; }
+    int getTimezoneOffsetMinutes() const override { return timezoneOffsetMinutes; }
+    bool isAutoAlignReadingTime() const override { return autoAlign; }
+    bool useAutoAlignMidpoint() const override { return autoAlignMidpoint; }
+
+    int getMaxRetries() const override { return maxRetries; }
+    unsigned long getRetryCooldownMs() const override { return retryCooldownMs; }
+
+    const char *getWiFiSSID() const override { return "ssid"; }
+    const char *getWiFiPassword() const override { return "password"; }
+    const char *getMqttServer() const override { return "127.0.0.1"; }
+    const char *getMqttUsername() const override { return "user"; }
+    const char *getMqttPassword() const override { return "pass"; }
+    const char *getMqttClientId() const override { return "everblu-test"; }
+    const char *getNtpServer() const override { return "pool.ntp.org"; }
+};
+
+// ---------------------------------------------------------------------------
+// Time
+// ---------------------------------------------------------------------------
+
+/// ITimeProvider with a UTC timestamp the test sets explicitly.
+class FakeTime : public ITimeProvider
+{
+public:
+    bool synced = true;
+    time_t nowUtc = 1735689600; // 2025-01-01 00:00:00 UTC
+    int syncRequests = 0;
+
+    bool isTimeSynced() const override { return synced; }
+    time_t getCurrentTime() const override { return nowUtc; }
+    void requestSync() override { syncRequests++; }
+
+    /// Set the clock to a specific UTC wall-clock instant.
+    void setUtc(int year, int month, int day, int hour, int minute, int second);
+};
+
+// ---------------------------------------------------------------------------
+// Publisher
+// ---------------------------------------------------------------------------
+
+/// IDataPublisher that records every call so tests can assert on the sequence.
+class RecordingPublisher : public IDataPublisher
+{
+public:
+    struct Reading
+    {
+        tmeter_data data;
+        std::string timestamp;
+    };
+
+    bool ready = true;
+
+    std::vector<Reading> readings;
+    std::vector<std::string> statuses;
+    std::vector<std::string> radioStates;
+    std::vector<std::string> errors;
+    std::vector<bool> activeReadingFlags;
+    std::vector<float> frequencyOffsets;
+    std::vector<float> tunedFrequencies;
+
+    struct Stats
+    {
+        unsigned long attempts;
+        unsigned long successes;
+        unsigned long failures;
+    };
+    std::vector<Stats> statistics;
+
+    int historyPublishes = 0;
+    int settingsPublishes = 0;
+    int discoveryPublishes = 0;
+
+    void reset();
+
+    /// Number of recorded entries equal to @p value.
+    static int countOf(const std::vector<std::string> &v, const char *value);
+
+    bool sawStatus(const char *value) const { return countOf(statuses, value) > 0; }
+    bool sawError(const char *value) const { return countOf(errors, value) > 0; }
+
+    const std::string &lastStatus() const { return last(statuses); }
+    const std::string &lastRadioState() const { return last(radioStates); }
+    const std::string &lastError() const { return last(errors); }
+
+    void publishMeterReading(const tmeter_data &data, const char *timestamp) override;
+    void publishHistory(const uint32_t *history, bool historyAvailable) override;
+    void publishWiFiDetails(const char *ip, int rssi, int signalPercent,
+                            const char *mac, const char *ssid, const char *bssid) override;
+    void publishMeterSettings(int meterYear, unsigned long meterSerial,
+                              const char *schedule, const char *readingTime,
+                              float frequency) override;
+    void publishStatusMessage(const char *message) override;
+    void publishRadioState(const char *state) override;
+    void publishActiveReading(bool active) override;
+    void publishError(const char *error) override;
+    void publishStatistics(unsigned long totalAttempts, unsigned long successfulReads,
+                           unsigned long failedReads) override;
+    void publishFrequencyOffset(float offsetMHz) override;
+    void publishTunedFrequency(float frequencyMHz) override;
+    void publishFrequencyEstimate(int8_t freqestValue) override;
+    void publishUptime(unsigned long uptimeSeconds, const char *uptimeISO) override;
+    void publishFirmwareVersion(const char *version) override;
+    void publishDiscovery() override;
+    bool isReady() const override { return ready; }
+
+private:
+    static const std::string &last(const std::vector<std::string> &v);
+};
+
+// ---------------------------------------------------------------------------
+// Shared setup
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Return every fake and every piece of static production state to a
+ *        known baseline.
+ *
+ * FrequencyManager and MeterReader both hold static state that would otherwise
+ * leak between test cases, so this is called from setUp().
+ */
+void resetAllFakes();
+
+#endif // EVERBLU_TEST_FAKES_H

--- a/test/native_shims/Arduino.h
+++ b/test/native_shims/Arduino.h
@@ -19,7 +19,6 @@
 #ifndef EVERBLU_NATIVE_ARDUINO_SHIM_H
 #define EVERBLU_NATIVE_ARDUINO_SHIM_H
 
-#include <chrono>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdint>
@@ -27,27 +26,35 @@
 #include <cstring>
 #include <string>
 
+// The real Arduino core exposes the C maths library (NAN, isnan, roundf, fabs)
+// in the global namespace, and shared service code relies on that.
+#include <math.h>
+
 // ---------------------------------------------------------------------------
 // Timing
 // ---------------------------------------------------------------------------
+//
+// The host clock is virtual and starts at zero. Tests drive it explicitly with
+// nativeClockAdvance(), so timing-dependent code (retry delays, cooldowns,
+// scan step pacing) is exercised deterministically and instantly instead of
+// sleeping. delay() advances it, which mirrors what the firmware experiences.
 
-inline unsigned long millis()
+inline unsigned long &nativeClockMillisRef()
 {
-    using namespace std::chrono;
-    static const steady_clock::time_point start = steady_clock::now();
-    return (unsigned long)duration_cast<milliseconds>(steady_clock::now() - start).count();
+    static unsigned long ms = 0;
+    return ms;
 }
 
-inline unsigned long micros()
-{
-    using namespace std::chrono;
-    static const steady_clock::time_point start = steady_clock::now();
-    return (unsigned long)duration_cast<microseconds>(steady_clock::now() - start).count();
-}
+inline void nativeClockSet(unsigned long ms) { nativeClockMillisRef() = ms; }
+inline void nativeClockAdvance(unsigned long ms) { nativeClockMillisRef() += ms; }
+inline void nativeClockReset() { nativeClockMillisRef() = 0; }
 
-// No-ops on the host: unit tests must never actually sleep.
-inline void delay(unsigned long) {}
-inline void delayMicroseconds(unsigned int) {}
+inline unsigned long millis() { return nativeClockMillisRef(); }
+inline unsigned long micros() { return nativeClockMillisRef() * 1000UL; }
+
+// Unit tests must never actually sleep: advance the virtual clock instead.
+inline void delay(unsigned long ms) { nativeClockAdvance(ms); }
+inline void delayMicroseconds(unsigned int us) { nativeClockAdvance(us / 1000UL); }
 inline void yield() {}
 
 // ---------------------------------------------------------------------------
@@ -68,6 +75,66 @@ inline long map(long x, long in_min, long in_max, long out_min, long out_max)
 }
 
 // ---------------------------------------------------------------------------
+// Print / Stream
+// ---------------------------------------------------------------------------
+//
+// src/core/wifi_serial.h derives WifiSerialStream from Print and holds a
+// Stream reference, so both base classes have to exist for that header to
+// compile on the host.
+
+class Print
+{
+public:
+    virtual ~Print() = default;
+
+    virtual size_t write(uint8_t c) = 0;
+
+    virtual size_t write(const uint8_t *buffer, size_t size)
+    {
+        size_t written = 0;
+        for (size_t i = 0; i < size; i++)
+        {
+            written += write(buffer[i]);
+        }
+        return written;
+    }
+
+    size_t write(const char *s) { return s ? write((const uint8_t *)s, strlen(s)) : 0; }
+
+    size_t print(char c) { return write((uint8_t)c); }
+    size_t print(const char *s) { return write(s); }
+    size_t print(const std::string &s) { return write(s.c_str()); }
+
+    size_t println() { return write((uint8_t)'\n'); }
+    size_t println(const char *s) { return print(s) + println(); }
+    size_t println(const std::string &s) { return println(s.c_str()); }
+
+    size_t printf(const char *fmt, ...) __attribute__((format(printf, 2, 3)))
+    {
+        char buf[512];
+        va_list args;
+        va_start(args, fmt);
+        const int n = vsnprintf(buf, sizeof(buf), fmt, args);
+        va_end(args);
+        if (n <= 0)
+        {
+            return 0;
+        }
+        const size_t len = (size_t)n < sizeof(buf) ? (size_t)n : sizeof(buf) - 1;
+        return write((const uint8_t *)buf, len);
+    }
+};
+
+class Stream : public Print
+{
+public:
+    virtual int available() { return 0; }
+    virtual int read() { return -1; }
+    virtual int peek() { return -1; }
+    virtual void flush() {}
+};
+
+// ---------------------------------------------------------------------------
 // Serial
 // ---------------------------------------------------------------------------
 //
@@ -75,49 +142,23 @@ inline long map(long x, long in_min, long in_max, long out_min, long out_max)
 // environment variable EVERBLU_NATIVE_SERIAL=1 to mirror firmware log output to
 // stdout when debugging a failing test.
 
-class NativeSerial
+class NativeSerial : public Stream
 {
 public:
     void begin(unsigned long = 0) {}
-    void flush() {}
+    void setDebugOutput(bool) {}
+    void flush() override { fflush(stdout); }
     explicit operator bool() const { return true; }
 
-    int printf(const char *fmt, ...)
-    {
-        if (!enabled())
-        {
-            return 0;
-        }
-        va_list args;
-        va_start(args, fmt);
-        const int written = vfprintf(stdout, fmt, args);
-        va_end(args);
-        return written;
-    }
-
-    void print(const char *s)
-    {
-        if (enabled() && s)
-        {
-            fputs(s, stdout);
-        }
-    }
-
-    void print(const std::string &s) { print(s.c_str()); }
-
-    void println(const char *s)
+    size_t write(uint8_t c) override
     {
         if (enabled())
         {
-            fputs(s ? s : "", stdout);
-            fputc('\n', stdout);
+            fputc((int)c, stdout);
         }
+        return 1;
     }
 
-    void println(const std::string &s) { println(s.c_str()); }
-    void println() { println(""); }
-
-private:
     static bool enabled()
     {
         static const bool on = (std::getenv("EVERBLU_NATIVE_SERIAL") != nullptr);

--- a/test/native_shims/Arduino.h
+++ b/test/native_shims/Arduino.h
@@ -1,0 +1,143 @@
+/**
+ * @file Arduino.h
+ * @brief Minimal Arduino compatibility shim for the PlatformIO `native` (host) build
+ *
+ * This header is NOT part of the firmware. It exists so that platform-neutral
+ * service code (for example `src/services/schedule_manager.cpp` and the MQTT
+ * logging path in `src/core/logging.h`) can be compiled and unit-tested on a
+ * desktop host, where no Arduino core is available.
+ *
+ * It is pulled in only by the `[env:native]` environment, via
+ * `-I test/native_shims` in `platformio.ini`. Hardware builds keep using the
+ * real Arduino core header.
+ *
+ * Scope is deliberately narrow: only the symbols actually referenced by the
+ * host-tested sources are provided. Add to it when a newly host-tested source
+ * needs something, rather than trying to emulate the whole Arduino API.
+ */
+
+#ifndef EVERBLU_NATIVE_ARDUINO_SHIM_H
+#define EVERBLU_NATIVE_ARDUINO_SHIM_H
+
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Timing
+// ---------------------------------------------------------------------------
+
+inline unsigned long millis()
+{
+    using namespace std::chrono;
+    static const steady_clock::time_point start = steady_clock::now();
+    return (unsigned long)duration_cast<milliseconds>(steady_clock::now() - start).count();
+}
+
+inline unsigned long micros()
+{
+    using namespace std::chrono;
+    static const steady_clock::time_point start = steady_clock::now();
+    return (unsigned long)duration_cast<microseconds>(steady_clock::now() - start).count();
+}
+
+// No-ops on the host: unit tests must never actually sleep.
+inline void delay(unsigned long) {}
+inline void delayMicroseconds(unsigned int) {}
+inline void yield() {}
+
+// ---------------------------------------------------------------------------
+// Arduino maths helpers
+// ---------------------------------------------------------------------------
+
+#ifndef constrain
+#define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
+#endif
+
+inline long map(long x, long in_min, long in_max, long out_min, long out_max)
+{
+    if (in_max == in_min)
+    {
+        return out_min;
+    }
+    return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
+
+// ---------------------------------------------------------------------------
+// Serial
+// ---------------------------------------------------------------------------
+//
+// Output is discarded by default so that test runs stay readable. Set the
+// environment variable EVERBLU_NATIVE_SERIAL=1 to mirror firmware log output to
+// stdout when debugging a failing test.
+
+class NativeSerial
+{
+public:
+    void begin(unsigned long = 0) {}
+    void flush() {}
+    explicit operator bool() const { return true; }
+
+    int printf(const char *fmt, ...)
+    {
+        if (!enabled())
+        {
+            return 0;
+        }
+        va_list args;
+        va_start(args, fmt);
+        const int written = vfprintf(stdout, fmt, args);
+        va_end(args);
+        return written;
+    }
+
+    void print(const char *s)
+    {
+        if (enabled() && s)
+        {
+            fputs(s, stdout);
+        }
+    }
+
+    void print(const std::string &s) { print(s.c_str()); }
+
+    void println(const char *s)
+    {
+        if (enabled())
+        {
+            fputs(s ? s : "", stdout);
+            fputc('\n', stdout);
+        }
+    }
+
+    void println(const std::string &s) { println(s.c_str()); }
+    void println() { println(""); }
+
+private:
+    static bool enabled()
+    {
+        static const bool on = (std::getenv("EVERBLU_NATIVE_SERIAL") != nullptr);
+        return on;
+    }
+};
+
+inline NativeSerial Serial;
+
+// ---------------------------------------------------------------------------
+// Assorted Arduino spellings used by shared code
+// ---------------------------------------------------------------------------
+
+using String = std::string;
+
+#ifndef HIGH
+#define HIGH 1
+#endif
+#ifndef LOW
+#define LOW 0
+#endif
+
+#endif // EVERBLU_NATIVE_ARDUINO_SHIM_H

--- a/test/native_shims/Arduino.h
+++ b/test/native_shims/Arduino.h
@@ -27,8 +27,10 @@
 #include <string>
 
 // The real Arduino core exposes the C maths library (NAN, isnan, roundf, fabs)
-// in the global namespace, and shared service code relies on that.
+// and the C time functions in the global namespace, and shared service code
+// relies on both.
 #include <math.h>
+#include <time.h>
 
 // ---------------------------------------------------------------------------
 // Timing

--- a/test/test_embedded_unit/test_config_validation.cpp
+++ b/test/test_embedded_unit/test_config_validation.cpp
@@ -8,6 +8,7 @@
 #include <unity.h>
 #include <string.h>
 #include "core/meter_code_parser.h"
+#include "core/utils.h"
 #include "services/schedule_manager.h"
 
 #define TEST_FREQUENCY 433.82
@@ -40,6 +41,35 @@ void test_invalid_reading_schedules(void)
     TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule(nullptr));
     TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule("Monday-Thursday"));
     TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule("monday-friday")); // case sensitive
+}
+
+/**
+ * Test: the two schedule validators agree
+ *
+ * isValidReadingSchedule() in core/utils.cpp is a second copy of the same rule,
+ * used by the standalone MQTT build, while ScheduleManager::isValidSchedule()
+ * is what the reader and the ESPHome component use. A YAML value accepted by
+ * one and rejected by the other would be reported as a configuration error on
+ * only one of the two builds, so pin them together.
+ */
+void test_both_schedule_validators_agree(void)
+{
+    static const char *const candidates[] = {
+        "Monday-Friday", "Monday-Saturday", "Monday-Sunday",
+        "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+        "Daily", "Weekdays", "Weekend", "", " ", "monday", "MONDAY",
+        "Monday-Thursday", "Monday ", " Monday", "Sunday-Monday"};
+
+    for (const char *candidate : candidates)
+    {
+        TEST_ASSERT_EQUAL_MESSAGE(ScheduleManager::isValidSchedule(candidate),
+                                  isValidReadingSchedule(candidate),
+                                  candidate);
+    }
+
+    // Both must survive a null rather than reaching strcmp with it.
+    TEST_ASSERT_FALSE(isValidReadingSchedule(nullptr));
+    TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule(nullptr));
 }
 
 /**

--- a/test/test_embedded_unit/test_config_validation.cpp
+++ b/test/test_embedded_unit/test_config_validation.cpp
@@ -1,118 +1,45 @@
 /**
  * @file test_config_validation.cpp
- * @brief Unit tests for configuration validation functions
+ * @brief Unit tests for configuration validation
+ *
+ * Test registration lives in test_runner.cpp.
  */
 
 #include <unity.h>
-#include <Arduino.h>
 #include <string.h>
 #include "core/meter_code_parser.h"
+#include "services/schedule_manager.h"
 
-// Mock configuration values for testing
-#define TEST_METER_YEAR 2020
-#define TEST_METER_SERIAL 12345678
 #define TEST_FREQUENCY 433.82
 
-// Local implementations of functions under test for now.
-// These can later be moved into shared application code if needed.
-
-bool isValidReadingSchedule(const char *schedule)
-{
-    // Reject null or empty schedules
-    if (schedule == nullptr || schedule[0] == '\0')
-    {
-        return false;
-    }
-
-    // Allowed values based on unit tests
-    if (strcmp(schedule, "Monday-Friday") == 0)
-        return true;
-    if (strcmp(schedule, "Monday-Saturday") == 0)
-        return true;
-    if (strcmp(schedule, "Monday-Sunday") == 0)
-        return true;
-    if (strcmp(schedule, "Monday") == 0)
-        return true;
-    if (strcmp(schedule, "Tuesday") == 0)
-        return true;
-    if (strcmp(schedule, "Wednesday") == 0)
-        return true;
-    if (strcmp(schedule, "Thursday") == 0)
-        return true;
-    if (strcmp(schedule, "Friday") == 0)
-        return true;
-    if (strcmp(schedule, "Saturday") == 0)
-        return true;
-    if (strcmp(schedule, "Sunday") == 0)
-        return true;
-
-    // Everything else is considered invalid for now
-    return false;
-}
-
-bool validateConfiguration()
-{
-    // Placeholder; not used by current tests
-    return true;
-}
-
-void setUp(void)
-{
-    // This runs before each test
-}
-
-void tearDown(void)
-{
-    // This runs after each test
-}
-
 /**
- * Test: isValidReadingSchedule with valid inputs
+ * Test: schedule strings accepted by ScheduleManager
  */
 void test_valid_reading_schedules(void)
 {
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Monday-Friday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Monday-Saturday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Monday-Sunday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Monday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Tuesday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Wednesday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Thursday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Friday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Saturday"));
-    TEST_ASSERT_TRUE(isValidReadingSchedule("Sunday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Monday-Friday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Monday-Saturday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Monday-Sunday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Monday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Tuesday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Wednesday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Thursday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Friday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Saturday"));
+    TEST_ASSERT_TRUE(ScheduleManager::isValidSchedule("Sunday"));
 }
 
 /**
- * Test: isValidReadingSchedule with invalid inputs
+ * Test: schedule strings rejected by ScheduleManager
  */
 void test_invalid_reading_schedules(void)
 {
-    TEST_ASSERT_FALSE(isValidReadingSchedule("Daily"));
-    TEST_ASSERT_FALSE(isValidReadingSchedule("Weekdays"));
-    TEST_ASSERT_FALSE(isValidReadingSchedule(""));
-    TEST_ASSERT_FALSE(isValidReadingSchedule(NULL));
-    TEST_ASSERT_FALSE(isValidReadingSchedule("Monday-Thursday"));
-}
-
-/**
- * Test: Meter year validation
- */
-void test_meter_year_validation(void)
-{
-    // Valid years (2009 onwards when RADIAN was introduced)
-    TEST_ASSERT_TRUE(TEST_METER_YEAR >= 2009);
-    TEST_ASSERT_TRUE(TEST_METER_YEAR <= 2025);
-}
-
-/**
- * Test: Meter serial validation
- */
-void test_meter_serial_validation(void)
-{
-    // Valid serial (non-zero, max 8 digits)
-    TEST_ASSERT_TRUE(TEST_METER_SERIAL > 0);
-    TEST_ASSERT_TRUE(TEST_METER_SERIAL <= 99999999);
+    TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule("Daily"));
+    TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule("Weekdays"));
+    TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule(""));
+    TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule(nullptr));
+    TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule("Monday-Thursday"));
+    TEST_ASSERT_FALSE(ScheduleManager::isValidSchedule("monday-friday")); // case sensitive
 }
 
 /**
@@ -169,31 +96,4 @@ void test_meter_code_parse_rejects_short_serial(void)
 {
     // Fewer than 7 digits is invalid
     TEST_ASSERT_FALSE(everblu::core::parseMeterCode("20-257750-000", nullptr, nullptr));
-}
-
-void setup()
-{
-    delay(2000); // Wait for serial monitor
-
-    UNITY_BEGIN();
-
-    RUN_TEST(test_valid_reading_schedules);
-    RUN_TEST(test_invalid_reading_schedules);
-    RUN_TEST(test_meter_year_validation);
-    RUN_TEST(test_meter_serial_validation);
-    RUN_TEST(test_frequency_validation);
-    RUN_TEST(test_meter_code_parse_valid_dashed_with_suffix);
-    RUN_TEST(test_meter_code_parse_valid_dashed_without_suffix);
-    RUN_TEST(test_meter_code_parse_rejects_non_digit);
-    RUN_TEST(test_meter_code_parse_rejects_missing_dash_format);
-    RUN_TEST(test_meter_code_parse_rejects_zero_serial);
-    RUN_TEST(test_meter_code_parse_rejects_serial_over_24bit);
-    RUN_TEST(test_meter_code_parse_rejects_short_serial);
-
-    UNITY_END();
-}
-
-void loop()
-{
-    // Nothing to do here
 }

--- a/test/test_embedded_unit/test_hex_dump.cpp
+++ b/test/test_embedded_unit/test_hex_dump.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file test_hex_dump.cpp
+ * @brief Bounds tests for the hex/binary dump helpers in core/utils.cpp
+ *
+ * These functions format into a fixed stack buffer. They are only reachable
+ * with diagnostics enabled, so a defect here never shows up in normal use, but
+ * cc1101.cpp calls show_in_hex_one_line() with a whole received frame. The
+ * tests below drive every mode with buffers large enough to run past the end of
+ * that stack buffer if the wrapping is ever removed.
+ *
+ * The native build compiles with -fstack-protector-all, so an overrun aborts
+ * the test binary rather than silently corrupting the stack.
+ *
+ * Test registration lives in test_runner.cpp.
+ */
+
+#include <unity.h>
+
+#include <stdint.h>
+#include <vector>
+
+#include "core/utils.h"
+
+namespace
+{
+    /// A buffer far longer than any single formatted line can hold.
+    std::vector<uint8_t> makeBuffer(size_t len)
+    {
+        std::vector<uint8_t> buffer(len);
+        for (size_t i = 0; i < len; i++)
+        {
+            buffer[i] = (uint8_t)(i * 31 + 7);
+        }
+        return buffer;
+    }
+}
+
+void test_hex_dump_handles_a_full_radian_frame(void)
+{
+    // 124 bytes is the real frame length, and at three characters each that is
+    // 372 characters: more than the formatter's line buffer holds.
+    std::vector<uint8_t> frame = makeBuffer(124);
+
+    show_in_hex(frame.data(), frame.size());
+    show_in_hex_array(frame.data(), frame.size());
+    show_in_hex_one_line(frame.data(), frame.size());
+    show_in_hex_one_line_GET(frame.data(), frame.size());
+
+    TEST_PASS();
+}
+
+void test_hex_dump_handles_an_oversized_buffer(void)
+{
+    // cc1101.cpp passes whatever length the radio reported, so the formatter
+    // must stay in bounds for a buffer of any size.
+    std::vector<uint8_t> big = makeBuffer(1024);
+
+    show_in_hex(big.data(), big.size());
+    show_in_hex_array(big.data(), big.size());
+    show_in_hex_one_line(big.data(), big.size());
+    show_in_hex_one_line_GET(big.data(), big.size());
+
+    TEST_PASS();
+}
+
+void test_hex_dump_handles_empty_and_null(void)
+{
+    const uint8_t one[1] = {0xA5};
+
+    show_in_hex(one, 0);
+    show_in_hex_array(one, 0);
+    show_in_hex_one_line(one, 0);
+    show_in_hex_one_line_GET(one, 0);
+
+    show_in_hex(nullptr, 0);
+    show_in_hex_one_line(nullptr, 16);
+
+    TEST_PASS();
+}
+
+void test_hex_dump_handles_exact_line_boundaries(void)
+{
+    // Lengths either side of the internal 16-byte wrap and of the point where
+    // the line buffer fills, which is where an off-by-one would land.
+    static const size_t lengths[] = {1, 15, 16, 17, 31, 32, 33, 84, 85, 86, 127, 128, 129};
+
+    for (size_t len : lengths)
+    {
+        std::vector<uint8_t> buffer = makeBuffer(len);
+        show_in_hex(buffer.data(), len);
+        show_in_hex_array(buffer.data(), len);
+        show_in_hex_one_line(buffer.data(), len);
+        show_in_hex_one_line_GET(buffer.data(), len);
+    }
+
+    TEST_PASS();
+}
+
+void test_binary_dump_handles_a_full_radian_frame(void)
+{
+    // Nine characters per byte, so this overflows even sooner than hex.
+    std::vector<uint8_t> frame = makeBuffer(124);
+
+    show_in_bin(frame.data(), frame.size());
+    show_in_bin(nullptr, 8);
+
+    TEST_PASS();
+}

--- a/test/test_embedded_unit/test_meter_history.cpp
+++ b/test/test_embedded_unit/test_meter_history.cpp
@@ -1,0 +1,303 @@
+/**
+ * @file test_meter_history.cpp
+ * @brief Unit tests for MeterHistory - monthly usage maths and JSON payload
+ *
+ * Test registration lives in test_runner.cpp.
+ */
+
+#include <unity.h>
+#include <cstring>
+#include <stdint.h>
+#include "services/meter_history.h"
+
+namespace
+{
+    // Builds a 13-slot history array from the leading values given. Remaining
+    // slots are zeroed, which is how the firmware marks "no data": countValidMonths()
+    // stops at the first zero.
+    void makeHistory(uint32_t out[13], const uint32_t *values, int count)
+    {
+        memset(out, 0, sizeof(uint32_t) * 13);
+        for (int i = 0; i < count; i++)
+        {
+            out[i] = values[i];
+        }
+    }
+}
+
+/**
+ * Test: countValidMonths stops at the first zero entry
+ */
+void test_history_count_valid_months(void)
+{
+    uint32_t history[13];
+
+    const uint32_t three[] = {100, 150, 220};
+    makeHistory(history, three, 3);
+    TEST_ASSERT_EQUAL_INT(3, MeterHistory::countValidMonths(history));
+
+    // A zero in the middle terminates the count: later entries are ignored even
+    // though they are non-zero.
+    const uint32_t gap[] = {100, 150, 0, 400, 500};
+    makeHistory(history, gap, 5);
+    TEST_ASSERT_EQUAL_INT(2, MeterHistory::countValidMonths(history));
+
+    memset(history, 0, sizeof(history));
+    TEST_ASSERT_EQUAL_INT(0, MeterHistory::countValidMonths(history));
+
+    for (int i = 0; i < 13; i++)
+    {
+        history[i] = (uint32_t)(i + 1) * 100u;
+    }
+    TEST_ASSERT_EQUAL_INT(13, MeterHistory::countValidMonths(history));
+
+    TEST_ASSERT_EQUAL_INT(0, MeterHistory::countValidMonths(nullptr));
+}
+
+/**
+ * Test: isHistoryValid detects any non-zero entry, unlike countValidMonths
+ */
+void test_history_is_valid(void)
+{
+    uint32_t history[13];
+
+    memset(history, 0, sizeof(history));
+    TEST_ASSERT_FALSE(MeterHistory::isHistoryValid(history));
+
+    // Non-zero only after a gap: no usable months, but the array is not empty
+    history[4] = 999;
+    TEST_ASSERT_TRUE(MeterHistory::isHistoryValid(history));
+    TEST_ASSERT_EQUAL_INT(0, MeterHistory::countValidMonths(history));
+
+    TEST_ASSERT_FALSE(MeterHistory::isHistoryValid(nullptr));
+}
+
+/**
+ * Test: calculateStats derives month-over-month usage
+ */
+void test_history_stats_typical(void)
+{
+    uint32_t history[13];
+    const uint32_t values[] = {100, 150, 220};
+    makeHistory(history, values, 3);
+
+    const HistoryStats stats = MeterHistory::calculateStats(history, 260);
+
+    TEST_ASSERT_EQUAL_INT(3, stats.monthCount);
+    TEST_ASSERT_EQUAL_UINT32(260, stats.currentVolume);
+
+    // The oldest month has no earlier baseline, so its usage is reported as 0
+    TEST_ASSERT_EQUAL_UINT32(0, stats.monthlyUsage[0]);
+    TEST_ASSERT_EQUAL_UINT32(50, stats.monthlyUsage[1]);
+    TEST_ASSERT_EQUAL_UINT32(70, stats.monthlyUsage[2]);
+
+    TEST_ASSERT_EQUAL_UINT32(40, stats.currentMonthUsage);
+    TEST_ASSERT_EQUAL_UINT32(160, stats.totalUsage);            // 0 + 50 + 70 + 40
+    TEST_ASSERT_EQUAL_UINT32(40, stats.averageMonthlyUsage);    // 160 / (3 + 1)
+}
+
+/**
+ * Test: calculateStats returns a zeroed struct when there is no history
+ */
+void test_history_stats_empty(void)
+{
+    uint32_t history[13];
+    memset(history, 0, sizeof(history));
+
+    const HistoryStats stats = MeterHistory::calculateStats(history, 500);
+
+    TEST_ASSERT_EQUAL_INT(0, stats.monthCount);
+    TEST_ASSERT_EQUAL_UINT32(500, stats.currentVolume);
+    TEST_ASSERT_EQUAL_UINT32(0, stats.currentMonthUsage);
+    TEST_ASSERT_EQUAL_UINT32(0, stats.totalUsage);
+    TEST_ASSERT_EQUAL_UINT32(0, stats.averageMonthlyUsage);
+}
+
+/**
+ * Test: a decreasing reading (meter reset or replacement) yields zero usage
+ * rather than a huge unsigned underflow
+ */
+void test_history_stats_handles_meter_reset(void)
+{
+    uint32_t history[13];
+    const uint32_t values[] = {900, 950, 10}; // meter replaced, counter restarts
+    makeHistory(history, values, 3);
+
+    const HistoryStats stats = MeterHistory::calculateStats(history, 60);
+
+    TEST_ASSERT_EQUAL_UINT32(50, stats.monthlyUsage[1]);
+    TEST_ASSERT_EQUAL_UINT32(0, stats.monthlyUsage[2]); // would underflow
+    TEST_ASSERT_EQUAL_UINT32(50, stats.currentMonthUsage);
+}
+
+/**
+ * Test: a current reading below the newest history entry yields zero usage
+ */
+void test_history_stats_current_below_history(void)
+{
+    uint32_t history[13];
+    const uint32_t values[] = {100, 200};
+    makeHistory(history, values, 2);
+
+    const HistoryStats stats = MeterHistory::calculateStats(history, 150);
+
+    TEST_ASSERT_EQUAL_UINT32(0, stats.currentMonthUsage);
+}
+
+/**
+ * Test: exact JSON payload published to Home Assistant
+ */
+void test_history_json_exact_payload(void)
+{
+    uint32_t history[13];
+    const uint32_t values[] = {100, 150, 220};
+    makeHistory(history, values, 3);
+
+    char buffer[256];
+    const int written = MeterHistory::generateHistoryJson(history, 260, buffer, sizeof(buffer));
+
+    const char *expected =
+        "{\"history\":[100,150,220],"
+        "\"monthly_usage\":[50,70],"
+        "\"current_month_usage\":40,"
+        "\"months_available\":3}";
+
+    TEST_ASSERT_EQUAL_STRING(expected, buffer);
+    TEST_ASSERT_EQUAL_INT((int)strlen(expected), written);
+}
+
+/**
+ * Test: monthly_usage omits the oldest month, so it is one shorter than history
+ */
+void test_history_json_single_month(void)
+{
+    uint32_t history[13];
+    const uint32_t values[] = {100};
+    makeHistory(history, values, 1);
+
+    char buffer[256];
+    const int written = MeterHistory::generateHistoryJson(history, 130, buffer, sizeof(buffer));
+
+    TEST_ASSERT_TRUE(written > 0);
+    TEST_ASSERT_EQUAL_STRING(
+        "{\"history\":[100],\"monthly_usage\":[],"
+        "\"current_month_usage\":30,\"months_available\":1}",
+        buffer);
+}
+
+/**
+ * Test: a full 13-month history fits the 512-byte buffer used by the publishers
+ */
+void test_history_json_full_thirteen_months(void)
+{
+    uint32_t history[13];
+    for (int i = 0; i < 13; i++)
+    {
+        history[i] = 1000000u + (uint32_t)i * 4321u;
+    }
+
+    char buffer[512]; // matches esphome_data_publisher.cpp
+    const int written = MeterHistory::generateHistoryJson(history, 1060000u, buffer, sizeof(buffer));
+
+    TEST_ASSERT_TRUE(written > 0);
+    TEST_ASSERT_TRUE(written < (int)sizeof(buffer));
+    TEST_ASSERT_EQUAL_INT((int)strlen(buffer), written);
+    TEST_ASSERT_EQUAL_CHAR('}', buffer[written - 1]);
+}
+
+/**
+ * Test: no history produces no payload
+ */
+void test_history_json_empty_history(void)
+{
+    uint32_t history[13];
+    memset(history, 0, sizeof(history));
+
+    char buffer[256];
+    memset(buffer, 'x', sizeof(buffer));
+
+    TEST_ASSERT_EQUAL_INT(0, MeterHistory::generateHistoryJson(history, 500, buffer, sizeof(buffer)));
+}
+
+/**
+ * Test: an undersized buffer reports failure instead of emitting truncated JSON
+ *
+ * Callers treat a positive return as "publish this", so a partial payload would
+ * reach Home Assistant as unparseable state.
+ */
+void test_history_json_rejects_undersized_buffer(void)
+{
+    uint32_t history[13];
+    const uint32_t values[] = {100, 150, 220};
+    makeHistory(history, values, 3);
+
+    // Every buffer size too small to hold the whole document must fail, and must
+    // never report writing more than the buffer holds.
+    for (int size = 1; size < 90; size++)
+    {
+        char buffer[128];
+        memset(buffer, '\xAA', sizeof(buffer));
+
+        const int written = MeterHistory::generateHistoryJson(history, 260, buffer, size);
+
+        TEST_ASSERT_EQUAL_INT(0, written);
+        // Nothing beyond the declared buffer size may be touched
+        TEST_ASSERT_EQUAL_HEX8('\xAA', (unsigned char)buffer[size]);
+    }
+}
+
+/**
+ * Test: null output buffer is handled
+ */
+void test_history_json_null_buffer(void)
+{
+    uint32_t history[13];
+    const uint32_t values[] = {100, 150};
+    makeHistory(history, values, 2);
+
+    TEST_ASSERT_EQUAL_INT(0, MeterHistory::generateHistoryJson(history, 200, nullptr, 256));
+}
+
+/**
+ * Test: month labels are relative to the newest entry
+ */
+void test_history_month_labels(void)
+{
+    char label[6];
+
+    MeterHistory::getMonthLabel(4, 5, label, sizeof(label));
+    TEST_ASSERT_EQUAL_STRING("Now", label);
+
+    MeterHistory::getMonthLabel(0, 5, label, sizeof(label));
+    TEST_ASSERT_EQUAL_STRING("-04", label);
+
+    MeterHistory::getMonthLabel(3, 5, label, sizeof(label));
+    TEST_ASSERT_EQUAL_STRING("-01", label);
+
+    // Index beyond the valid range
+    MeterHistory::getMonthLabel(9, 5, label, sizeof(label));
+    TEST_ASSERT_EQUAL_STRING("???", label);
+
+    // Must not write to a zero-sized buffer
+    char guarded[2] = {'\x7F', '\x7F'};
+    MeterHistory::getMonthLabel(0, 5, guarded, 1);
+    TEST_ASSERT_EQUAL_HEX8('\x7F', (unsigned char)guarded[0]);
+
+    MeterHistory::getMonthLabel(0, 5, nullptr, sizeof(label));
+}
+
+/**
+ * Test: the serial dump handles both populated and empty history without crashing
+ */
+void test_history_print_to_serial_is_safe(void)
+{
+    uint32_t history[13];
+    const uint32_t values[] = {100, 150, 220};
+    makeHistory(history, values, 3);
+    MeterHistory::printToSerial(history, 260, "[HISTORY]");
+
+    memset(history, 0, sizeof(history));
+    MeterHistory::printToSerial(history, 260, "[HISTORY]");
+
+    TEST_PASS();
+}

--- a/test/test_embedded_unit/test_runner.cpp
+++ b/test/test_embedded_unit/test_runner.cpp
@@ -54,6 +54,22 @@ void test_crc_deterministic(void);
 void test_crc_detects_single_bit_flip(void);
 void test_crc_is_order_sensitive(void);
 
+// --- test_meter_history.cpp ---
+void test_history_count_valid_months(void);
+void test_history_is_valid(void);
+void test_history_stats_typical(void);
+void test_history_stats_empty(void);
+void test_history_stats_handles_meter_reset(void);
+void test_history_stats_current_below_history(void);
+void test_history_json_exact_payload(void);
+void test_history_json_single_month(void);
+void test_history_json_full_thirteen_months(void);
+void test_history_json_empty_history(void);
+void test_history_json_rejects_undersized_buffer(void);
+void test_history_json_null_buffer(void);
+void test_history_month_labels(void);
+void test_history_print_to_serial_is_safe(void);
+
 void setUp(void) {}
 
 void tearDown(void) {}
@@ -104,6 +120,21 @@ int main(int argc, char **argv)
     RUN_TEST(test_crc_deterministic);
     RUN_TEST(test_crc_detects_single_bit_flip);
     RUN_TEST(test_crc_is_order_sensitive);
+
+    RUN_TEST(test_history_count_valid_months);
+    RUN_TEST(test_history_is_valid);
+    RUN_TEST(test_history_stats_typical);
+    RUN_TEST(test_history_stats_empty);
+    RUN_TEST(test_history_stats_handles_meter_reset);
+    RUN_TEST(test_history_stats_current_below_history);
+    RUN_TEST(test_history_json_exact_payload);
+    RUN_TEST(test_history_json_single_month);
+    RUN_TEST(test_history_json_full_thirteen_months);
+    RUN_TEST(test_history_json_empty_history);
+    RUN_TEST(test_history_json_rejects_undersized_buffer);
+    RUN_TEST(test_history_json_null_buffer);
+    RUN_TEST(test_history_month_labels);
+    RUN_TEST(test_history_print_to_serial_is_safe);
 
     return UNITY_END();
 }

--- a/test/test_embedded_unit/test_runner.cpp
+++ b/test/test_embedded_unit/test_runner.cpp
@@ -70,6 +70,13 @@ void test_history_json_null_buffer(void);
 void test_history_month_labels(void);
 void test_history_print_to_serial_is_safe(void);
 
+// --- test_hex_dump.cpp ---
+void test_hex_dump_handles_a_full_radian_frame(void);
+void test_hex_dump_handles_an_oversized_buffer(void);
+void test_hex_dump_handles_empty_and_null(void);
+void test_hex_dump_handles_exact_line_boundaries(void);
+void test_binary_dump_handles_a_full_radian_frame(void);
+
 void setUp(void) {}
 
 void tearDown(void) {}
@@ -135,6 +142,12 @@ int main(int argc, char **argv)
     RUN_TEST(test_history_json_null_buffer);
     RUN_TEST(test_history_month_labels);
     RUN_TEST(test_history_print_to_serial_is_safe);
+
+    RUN_TEST(test_hex_dump_handles_a_full_radian_frame);
+    RUN_TEST(test_hex_dump_handles_an_oversized_buffer);
+    RUN_TEST(test_hex_dump_handles_empty_and_null);
+    RUN_TEST(test_hex_dump_handles_exact_line_boundaries);
+    RUN_TEST(test_binary_dump_handles_a_full_radian_frame);
 
     return UNITY_END();
 }

--- a/test/test_embedded_unit/test_runner.cpp
+++ b/test/test_embedded_unit/test_runner.cpp
@@ -1,0 +1,109 @@
+/**
+ * @file test_runner.cpp
+ * @brief Single Unity entry point for the test_embedded_unit suite
+ *
+ * The suite is split across several translation units (config validation,
+ * schedule manager, utils). Unity requires exactly one `setUp`/`tearDown` pair
+ * and one `main`, so both live here and every test case is registered below.
+ *
+ * This suite runs on the host via `pio test -e native`.
+ */
+
+#include <unity.h>
+
+// --- test_config_validation.cpp ---
+void test_valid_reading_schedules(void);
+void test_invalid_reading_schedules(void);
+void test_frequency_validation(void);
+void test_meter_code_parse_valid_dashed_with_suffix(void);
+void test_meter_code_parse_valid_dashed_without_suffix(void);
+void test_meter_code_parse_rejects_non_digit(void);
+void test_meter_code_parse_rejects_missing_dash_format(void);
+void test_meter_code_parse_rejects_zero_serial(void);
+void test_meter_code_parse_rejects_serial_over_24bit(void);
+void test_meter_code_parse_rejects_short_serial(void);
+
+// --- test_schedule_manager.cpp ---
+void test_schedule_monday_friday(void);
+void test_schedule_monday_saturday(void);
+void test_schedule_monday_sunday_includes_sunday(void);
+void test_schedule_monday_only(void);
+void test_schedule_tuesday_only(void);
+void test_schedule_wednesday_only(void);
+void test_schedule_thursday_only(void);
+void test_schedule_friday_only(void);
+void test_schedule_saturday_only(void);
+void test_schedule_sunday_only(void);
+void test_schedule_invalid(void);
+void test_schedule_empty(void);
+void test_schedule_null(void);
+void test_all_schedules_all_days(void);
+void test_schedule_null_tm_is_not_a_reading_day(void);
+void test_reading_time_utc_to_local_positive_offset(void);
+void test_reading_time_utc_to_local_negative_offset(void);
+void test_reading_time_local_to_utc_roundtrip(void);
+void test_reading_time_is_clamped(void);
+void test_auto_align_uses_window_midpoint(void);
+void test_auto_align_rejects_zero_length_window(void);
+
+// --- test_utils.cpp ---
+void test_crc_known_data(void);
+void test_crc_empty_data(void);
+void test_crc_different_data(void);
+void test_crc_deterministic(void);
+void test_crc_detects_single_bit_flip(void);
+void test_crc_is_order_sensitive(void);
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    UNITY_BEGIN();
+
+    RUN_TEST(test_valid_reading_schedules);
+    RUN_TEST(test_invalid_reading_schedules);
+    RUN_TEST(test_frequency_validation);
+    RUN_TEST(test_meter_code_parse_valid_dashed_with_suffix);
+    RUN_TEST(test_meter_code_parse_valid_dashed_without_suffix);
+    RUN_TEST(test_meter_code_parse_rejects_non_digit);
+    RUN_TEST(test_meter_code_parse_rejects_missing_dash_format);
+    RUN_TEST(test_meter_code_parse_rejects_zero_serial);
+    RUN_TEST(test_meter_code_parse_rejects_serial_over_24bit);
+    RUN_TEST(test_meter_code_parse_rejects_short_serial);
+
+    RUN_TEST(test_schedule_monday_friday);
+    RUN_TEST(test_schedule_monday_saturday);
+    RUN_TEST(test_schedule_monday_sunday_includes_sunday);
+    RUN_TEST(test_schedule_monday_only);
+    RUN_TEST(test_schedule_tuesday_only);
+    RUN_TEST(test_schedule_wednesday_only);
+    RUN_TEST(test_schedule_thursday_only);
+    RUN_TEST(test_schedule_friday_only);
+    RUN_TEST(test_schedule_saturday_only);
+    RUN_TEST(test_schedule_sunday_only);
+    RUN_TEST(test_schedule_invalid);
+    RUN_TEST(test_schedule_empty);
+    RUN_TEST(test_schedule_null);
+    RUN_TEST(test_all_schedules_all_days);
+    RUN_TEST(test_schedule_null_tm_is_not_a_reading_day);
+    RUN_TEST(test_reading_time_utc_to_local_positive_offset);
+    RUN_TEST(test_reading_time_utc_to_local_negative_offset);
+    RUN_TEST(test_reading_time_local_to_utc_roundtrip);
+    RUN_TEST(test_reading_time_is_clamped);
+    RUN_TEST(test_auto_align_uses_window_midpoint);
+    RUN_TEST(test_auto_align_rejects_zero_length_window);
+
+    RUN_TEST(test_crc_known_data);
+    RUN_TEST(test_crc_empty_data);
+    RUN_TEST(test_crc_different_data);
+    RUN_TEST(test_crc_deterministic);
+    RUN_TEST(test_crc_detects_single_bit_flip);
+    RUN_TEST(test_crc_is_order_sensitive);
+
+    return UNITY_END();
+}

--- a/test/test_embedded_unit/test_runner.cpp
+++ b/test/test_embedded_unit/test_runner.cpp
@@ -14,6 +14,7 @@
 // --- test_config_validation.cpp ---
 void test_valid_reading_schedules(void);
 void test_invalid_reading_schedules(void);
+void test_both_schedule_validators_agree(void);
 void test_frequency_validation(void);
 void test_meter_code_parse_valid_dashed_with_suffix(void);
 void test_meter_code_parse_valid_dashed_without_suffix(void);
@@ -90,6 +91,7 @@ int main(int argc, char **argv)
 
     RUN_TEST(test_valid_reading_schedules);
     RUN_TEST(test_invalid_reading_schedules);
+    RUN_TEST(test_both_schedule_validators_agree);
     RUN_TEST(test_frequency_validation);
     RUN_TEST(test_meter_code_parse_valid_dashed_with_suffix);
     RUN_TEST(test_meter_code_parse_valid_dashed_without_suffix);

--- a/test/test_embedded_unit/test_schedule_manager.cpp
+++ b/test/test_embedded_unit/test_schedule_manager.cpp
@@ -1,21 +1,22 @@
 /**
  * @file test_schedule_manager.cpp
- * @brief Unit tests for ScheduleManager - validates schedule logic for all day combinations
+ * @brief Unit tests for ScheduleManager - schedule logic, timezone conversion, auto-alignment
+ *
+ * Test registration lives in test_runner.cpp.
  */
 
 #include <unity.h>
 #include <ctime>
 #include <cstring>
-#include "src/services/schedule_manager.h"
+#include "services/schedule_manager.h"
 
 // Wrapper to drive ScheduleManager using the legacy isReadingDay signature
-static ScheduleManager g_scheduleManager;
-
-bool isReadingDay(struct tm *ptm, const char *schedule)
+static bool isReadingDay(struct tm *ptm, const char *schedule)
 {
-    g_scheduleManager.setSchedule(schedule);
-    return g_scheduleManager.isReadingDay(ptm);
+    ScheduleManager::setSchedule(schedule);
+    return ScheduleManager::isReadingDay(ptm);
 }
+
 /**
  * Helper to create a tm structure for a specific day of week
  * @param dayOfWeek 0 = Sunday, 1 = Monday, ..., 6 = Saturday
@@ -221,22 +222,36 @@ void test_schedule_invalid(void)
 }
 
 /**
- * Test: Empty schedule string returns false
+ * Test: Empty schedule string falls back to Monday-Friday
  */
 void test_schedule_empty(void)
 {
     struct tm monday = createTmForDay(1);
-    TEST_ASSERT_FALSE(isReadingDay(&monday, ""));
+    struct tm sunday = createTmForDay(0);
+
+    TEST_ASSERT_TRUE(isReadingDay(&monday, ""));
+    TEST_ASSERT_FALSE(isReadingDay(&sunday, ""));
 }
 
 /**
- * Test: Null schedule string handling
+ * Test: Null schedule string must not crash and falls back to Monday-Friday
  */
 void test_schedule_null(void)
 {
     struct tm monday = createTmForDay(1);
-    // Should not crash - returns false for null
-    TEST_ASSERT_FALSE(isReadingDay(&monday, nullptr));
+    struct tm sunday = createTmForDay(0);
+
+    TEST_ASSERT_TRUE(isReadingDay(&monday, nullptr));
+    TEST_ASSERT_FALSE(isReadingDay(&sunday, nullptr));
+}
+
+/**
+ * Test: Null tm pointer must not crash and is never a reading day
+ */
+void test_schedule_null_tm_is_not_a_reading_day(void)
+{
+    ScheduleManager::setSchedule("Monday-Sunday");
+    TEST_ASSERT_FALSE(ScheduleManager::isReadingDay(nullptr));
 }
 
 /**
@@ -277,33 +292,84 @@ void test_all_schedules_all_days(void)
     }
 }
 
-// Optional: Unity test runner setup
-void setUp(void)
+/**
+ * Test: UTC reading time is converted to local using a positive (east) offset
+ */
+void test_reading_time_utc_to_local_positive_offset(void)
 {
-    // No setup needed for this test
-}
+    ScheduleManager::begin("Monday-Friday", 22, 30, 120); // UTC+2
 
-void tearDown(void)
-{
-    // No teardown needed
+    TEST_ASSERT_EQUAL_INT(22, ScheduleManager::getReadingHourUtc());
+    TEST_ASSERT_EQUAL_INT(30, ScheduleManager::getReadingMinuteUtc());
+    // 22:30 UTC + 2h wraps past midnight to 00:30 local
+    TEST_ASSERT_EQUAL_INT(0, ScheduleManager::getReadingHourLocal());
+    TEST_ASSERT_EQUAL_INT(30, ScheduleManager::getReadingMinuteLocal());
+    TEST_ASSERT_EQUAL_INT(120, ScheduleManager::getTimezoneOffsetMinutes());
 }
 
 /**
- * Unity/PlatformIO test runner entry point.
- * Ensures that the tests in this file are actually executed.
+ * Test: UTC reading time is converted to local using a negative (west) offset
  */
-void setup(void)
+void test_reading_time_utc_to_local_negative_offset(void)
 {
-    UNITY_BEGIN();
+    ScheduleManager::begin("Monday-Friday", 1, 15, -330); // UTC-5:30
 
-    // Run schedule manager tests defined in this file
-    RUN_TEST(test_schedule_null);
-    RUN_TEST(test_all_schedules_all_days);
-
-    UNITY_END();
+    // 01:15 UTC - 5:30 wraps back to 19:45 local on the previous day
+    TEST_ASSERT_EQUAL_INT(19, ScheduleManager::getReadingHourLocal());
+    TEST_ASSERT_EQUAL_INT(45, ScheduleManager::getReadingMinuteLocal());
 }
 
-void loop(void)
+/**
+ * Test: setting the local reading time round-trips back through UTC
+ */
+void test_reading_time_local_to_utc_roundtrip(void)
 {
-    // Nothing to do here; tests are run once in setup()
+    ScheduleManager::begin("Monday-Friday", 10, 0, 60); // UTC+1
+    ScheduleManager::setReadingTimeFromLocal(9, 45);
+
+    TEST_ASSERT_EQUAL_INT(9, ScheduleManager::getReadingHourLocal());
+    TEST_ASSERT_EQUAL_INT(45, ScheduleManager::getReadingMinuteLocal());
+    TEST_ASSERT_EQUAL_INT(8, ScheduleManager::getReadingHourUtc());
+    TEST_ASSERT_EQUAL_INT(45, ScheduleManager::getReadingMinuteUtc());
+}
+
+/**
+ * Test: out-of-range reading times are clamped rather than wrapped
+ */
+void test_reading_time_is_clamped(void)
+{
+    ScheduleManager::begin("Monday-Friday", 99, 99, 0);
+    TEST_ASSERT_EQUAL_INT(23, ScheduleManager::getReadingHourUtc());
+    TEST_ASSERT_EQUAL_INT(59, ScheduleManager::getReadingMinuteUtc());
+
+    ScheduleManager::setReadingTimeFromUtc(-5, -5);
+    TEST_ASSERT_EQUAL_INT(0, ScheduleManager::getReadingHourUtc());
+    TEST_ASSERT_EQUAL_INT(0, ScheduleManager::getReadingMinuteUtc());
+}
+
+/**
+ * Test: auto-alignment picks the midpoint of the meter wake window
+ */
+void test_auto_align_uses_window_midpoint(void)
+{
+    ScheduleManager::begin("Monday-Friday", 10, 0, 0);
+
+    // Window 06:00-18:00 local is 12 hours wide, midpoint 12:00
+    TEST_ASSERT_TRUE(ScheduleManager::autoAlignToMeterWindow(6, 18, true));
+    TEST_ASSERT_EQUAL_INT(12, ScheduleManager::getReadingHourLocal());
+
+    // Without midpoint, alignment lands on the start of the window
+    TEST_ASSERT_TRUE(ScheduleManager::autoAlignToMeterWindow(6, 18, false));
+    TEST_ASSERT_EQUAL_INT(6, ScheduleManager::getReadingHourLocal());
+}
+
+/**
+ * Test: a zero-length meter window is rejected and leaves the time unchanged
+ */
+void test_auto_align_rejects_zero_length_window(void)
+{
+    ScheduleManager::begin("Monday-Friday", 10, 0, 0);
+
+    TEST_ASSERT_FALSE(ScheduleManager::autoAlignToMeterWindow(8, 8, true));
+    TEST_ASSERT_EQUAL_INT(10, ScheduleManager::getReadingHourLocal());
 }

--- a/test/test_embedded_unit/test_utils.cpp
+++ b/test/test_embedded_unit/test_utils.cpp
@@ -1,42 +1,34 @@
 /**
  * @file test_utils.cpp
- * @brief Unit tests for utility functions (CRC, hex display, encoding)
+ * @brief Unit tests for the CRC-16/KERMIT checksum used by the RADIAN protocol
+ *
+ * Test registration lives in test_runner.cpp.
  */
 
 #include <unity.h>
-#include <Arduino.h>
-
-// Forward declarations
-extern unsigned long crc(unsigned char *data, int len);
-extern void display_hex(unsigned char *buf, int length);
-
-// Note: Global Unity setUp/tearDown hooks are defined in a single test runner
-// (see test_config_validation.cpp) to avoid multiple definition linker errors.
+#include <stdint.h>
+#include "core/crc_kermit.h"
 
 /**
  * Test: CRC calculation with known data
  */
 void test_crc_known_data(void)
 {
-    // Test with a simple known pattern
-    unsigned char testData[] = {0x01, 0x02, 0x03, 0x04};
-    unsigned long result = crc(testData, 4);
-
-    // CRC should be consistent for same data
-    unsigned long result2 = crc(testData, 4);
-    TEST_ASSERT_EQUAL_UINT32(result, result2);
+    // The standard CRC-16/KERMIT check value over the ASCII string "123456789"
+    // is 0x2189. crc_kermit() returns the bytes swapped, matching the order the
+    // checksum appears in on the wire, so the expected value here is 0x8921.
+    const uint8_t check[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+    TEST_ASSERT_EQUAL_HEX16(0x8921, crc_kermit(check, sizeof(check)));
 }
 
 /**
- * Test: CRC with empty data
+ * Test: CRC over an empty buffer returns the init value
  */
 void test_crc_empty_data(void)
 {
-    unsigned char emptyData[] = {};
-    unsigned long result = crc(emptyData, 0);
-
-    // Empty data should produce a specific CRC value
-    TEST_ASSERT_NOT_EQUAL(0, result);
+    const uint8_t empty[1] = {0};
+    TEST_ASSERT_EQUAL_HEX16(0x0000, crc_kermit(empty, 0));
+    TEST_ASSERT_EQUAL_HEX16(0x0000, crc_kermit(nullptr, 0));
 }
 
 /**
@@ -44,14 +36,10 @@ void test_crc_empty_data(void)
  */
 void test_crc_different_data(void)
 {
-    unsigned char data1[] = {0x01, 0x02, 0x03};
-    unsigned char data2[] = {0x04, 0x05, 0x06};
+    const uint8_t data1[] = {0x01, 0x02, 0x03};
+    const uint8_t data2[] = {0x04, 0x05, 0x06};
 
-    unsigned long crc1 = crc(data1, 3);
-    unsigned long crc2 = crc(data2, 3);
-
-    // Different data should produce different CRCs
-    TEST_ASSERT_NOT_EQUAL(crc1, crc2);
+    TEST_ASSERT_NOT_EQUAL(crc_kermit(data1, sizeof(data1)), crc_kermit(data2, sizeof(data2)));
 }
 
 /**
@@ -59,42 +47,45 @@ void test_crc_different_data(void)
  */
 void test_crc_deterministic(void)
 {
-    unsigned char testData[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    const uint8_t data[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    const uint16_t expected = crc_kermit(data, sizeof(data));
 
-    // Run CRC multiple times
-    unsigned long results[5];
     for (int i = 0; i < 5; i++)
     {
-        results[i] = crc(testData, 6);
+        TEST_ASSERT_EQUAL_HEX16(expected, crc_kermit(data, sizeof(data)));
     }
+}
 
-    // All results should be identical
-    for (int i = 1; i < 5; i++)
+/**
+ * Test: a single flipped bit changes the checksum
+ *
+ * This is the property the meter frame validation relies on to reject
+ * corrupted receptions.
+ */
+void test_crc_detects_single_bit_flip(void)
+{
+    uint8_t frame[] = {0x2F, 0x2F, 0x1E, 0x11, 0x03, 0xF1, 0x39, 0x00};
+    const uint16_t original = crc_kermit(frame, sizeof(frame));
+
+    for (size_t byte = 0; byte < sizeof(frame); byte++)
     {
-        TEST_ASSERT_EQUAL_UINT32(results[0], results[i]);
+        for (int bit = 0; bit < 8; bit++)
+        {
+            frame[byte] ^= (uint8_t)(1u << bit);
+            TEST_ASSERT_NOT_EQUAL(original, crc_kermit(frame, sizeof(frame)));
+            frame[byte] ^= (uint8_t)(1u << bit); // restore
+        }
     }
 }
 
 /**
- * Test: Display hex doesn't crash with null pointer
+ * Test: byte order affects the checksum
  */
-void test_display_hex_null_safe(void)
+void test_crc_is_order_sensitive(void)
 {
-    // This should not crash
-    display_hex(NULL, 0);
-    TEST_PASS();
+    const uint8_t forward[] = {0x11, 0x22, 0x33, 0x44};
+    const uint8_t reversed[] = {0x44, 0x33, 0x22, 0x11};
+
+    TEST_ASSERT_NOT_EQUAL(crc_kermit(forward, sizeof(forward)),
+                          crc_kermit(reversed, sizeof(reversed)));
 }
-
-/**
- * Test: Display hex with valid data
- */
-void test_display_hex_valid_data(void)
-{
-    unsigned char testData[] = {0x12, 0x34, 0x56, 0x78};
-
-    // This should not crash
-    display_hex(testData, 4);
-    TEST_PASS();
-}
-
-// Test registration and Arduino hooks are centralized in test_config_validation.cpp.

--- a/test/test_native_esphome_publisher/test_esphome_publisher.cpp
+++ b/test/test_native_esphome_publisher/test_esphome_publisher.cpp
@@ -1,0 +1,525 @@
+/**
+ * @file test_esphome_publisher.cpp
+ * @brief Host tests for ESPHomeDataPublisher
+ *
+ * The whole file is wrapped in `#ifdef USE_ESPHOME`, so the ordinary host build
+ * compiles it to nothing and it had no coverage at all. This suite builds it
+ * the way the shipped external component does and points it at recording
+ * sensor stubs, so every value Home Assistant would receive is assertable.
+ */
+
+#include <unity.h>
+
+#include <string>
+
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+#include "esphome_data_publisher.h"
+#include "utils.h"
+
+using esphome::binary_sensor::BinarySensor;
+using esphome::sensor::Sensor;
+using esphome::text_sensor::TextSensor;
+
+namespace
+{
+    /**
+     * @brief One sensor object per entity the publisher can drive.
+     *
+     * Several of the publisher's sensor pointers are static and use a
+     * "first non-null registration wins" rule, so the objects have to outlive
+     * any single publisher instance. They are declared once here and cleared
+     * between tests rather than recreated.
+     */
+    struct Sensors
+    {
+        Sensor volume, battery, counter, rssi, rssiPercent, lqi, lqiPercent, frequency;
+        Sensor totalAttempts, successfulReads, failedReads, uptime;
+        Sensor frequencyOffset, tunedFrequency, frequencyEstimate;
+
+        TextSensor timeStart, timeEnd, status, error, radioState, timestamp, history;
+        TextSensor version, meterSerial, meterYear, meterClock, meterModel;
+        TextSensor readingSchedule, readingTimeUtc;
+
+        BinarySensor activeReading, radioConnected;
+
+        void clear()
+        {
+            Sensor *numeric[] = {&volume, &battery, &counter, &rssi, &rssiPercent, &lqi,
+                                 &lqiPercent, &frequency, &totalAttempts, &successfulReads,
+                                 &failedReads, &uptime, &frequencyOffset, &tunedFrequency,
+                                 &frequencyEstimate};
+            for (Sensor *s : numeric)
+            {
+                s->clear();
+            }
+
+            TextSensor *text[] = {&timeStart, &timeEnd, &status, &error, &radioState,
+                                  &timestamp, &history, &version, &meterSerial, &meterYear,
+                                  &meterClock, &meterModel, &readingSchedule, &readingTimeUtc};
+            for (TextSensor *t : text)
+            {
+                t->clear();
+            }
+
+            activeReading.clear();
+            radioConnected.clear();
+        }
+    };
+
+    Sensors g_sensors;
+    ESPHomeDataPublisher *g_publisher = nullptr;
+
+    /// Wire every sensor up to a fresh publisher.
+    ESPHomeDataPublisher &publisher()
+    {
+        return *g_publisher;
+    }
+
+    void wireAll(ESPHomeDataPublisher &p)
+    {
+        p.set_volume_sensor(&g_sensors.volume);
+        p.set_battery_sensor(&g_sensors.battery);
+        p.set_counter_sensor(&g_sensors.counter);
+        p.set_rssi_sensor(&g_sensors.rssi);
+        p.set_rssi_percentage_sensor(&g_sensors.rssiPercent);
+        p.set_lqi_sensor(&g_sensors.lqi);
+        p.set_lqi_percentage_sensor(&g_sensors.lqiPercent);
+        p.set_time_start_sensor(&g_sensors.timeStart);
+        p.set_time_end_sensor(&g_sensors.timeEnd);
+        p.set_frequency_sensor(&g_sensors.frequency);
+
+        p.set_total_attempts_sensor(&g_sensors.totalAttempts);
+        p.set_successful_reads_sensor(&g_sensors.successfulReads);
+        p.set_failed_reads_sensor(&g_sensors.failedReads);
+        p.set_uptime_sensor(&g_sensors.uptime);
+        p.set_frequency_offset_sensor(&g_sensors.frequencyOffset);
+        p.set_tuned_frequency_sensor(&g_sensors.tunedFrequency);
+        p.set_frequency_estimate_sensor(&g_sensors.frequencyEstimate);
+
+        p.set_status_sensor(&g_sensors.status);
+        p.set_error_sensor(&g_sensors.error);
+        p.set_radio_state_sensor(&g_sensors.radioState);
+        p.set_timestamp_sensor(&g_sensors.timestamp);
+        p.set_history_sensor(&g_sensors.history);
+        p.set_version_sensor(&g_sensors.version);
+        p.set_meter_serial_sensor(&g_sensors.meterSerial);
+        p.set_meter_year_sensor(&g_sensors.meterYear);
+        p.set_meter_clock_sensor(&g_sensors.meterClock);
+        p.set_meter_model_sensor(&g_sensors.meterModel);
+        p.set_reading_schedule_sensor(&g_sensors.readingSchedule);
+        p.set_reading_time_utc_sensor(&g_sensors.readingTimeUtc);
+
+        p.set_active_reading_sensor(&g_sensors.activeReading);
+        p.set_radio_connected_sensor(&g_sensors.radioConnected);
+    }
+
+    tmeter_data sampleReading()
+    {
+        tmeter_data data{};
+        data.volume = 123456;
+        data.reads_counter = 77;
+        data.battery_left = 118;
+        data.time_start = 8;
+        data.time_end = 18;
+        data.rssi = -140;
+        data.rssi_dbm = -70;
+        data.lqi = 25;
+        data.freqest = 12;
+        data.history_available = false;
+        data.failure = ReadFailure::None;
+        return data;
+    }
+}
+
+void esphomePublisherSetUp()
+{
+    g_sensors.clear();
+    delete g_publisher;
+    g_publisher = new ESPHomeDataPublisher();
+    wireAll(*g_publisher);
+}
+
+void esphomePublisherTearDown()
+{
+}
+
+// ---------------------------------------------------------------------------
+// Meter reading
+// ---------------------------------------------------------------------------
+
+void test_pub_reading_populates_every_sensor(void)
+{
+    publisher().publishMeterReading(sampleReading(), "2026-04-27T09:59:49Z");
+
+    TEST_ASSERT_EQUAL_FLOAT(123456.0f, g_sensors.volume.last());
+    TEST_ASSERT_EQUAL_FLOAT(118.0f, g_sensors.battery.last());
+    TEST_ASSERT_EQUAL_FLOAT(77.0f, g_sensors.counter.last());
+    TEST_ASSERT_EQUAL_FLOAT(-70.0f, g_sensors.rssi.last());
+    TEST_ASSERT_EQUAL_FLOAT(25.0f, g_sensors.lqi.last());
+    TEST_ASSERT_EQUAL_STRING("08:00", g_sensors.timeStart.last());
+    TEST_ASSERT_EQUAL_STRING("18:00", g_sensors.timeEnd.last());
+    TEST_ASSERT_EQUAL_STRING("2026-04-27T09:59:49Z", g_sensors.timestamp.last());
+}
+
+void test_pub_reading_publishes_each_sensor_once(void)
+{
+    publisher().publishMeterReading(sampleReading(), "2026-04-27T09:59:49Z");
+
+    TEST_ASSERT_EQUAL_INT(1, g_sensors.volume.count());
+    TEST_ASSERT_EQUAL_INT(1, g_sensors.counter.count());
+    TEST_ASSERT_EQUAL_INT(1, g_sensors.timestamp.count());
+}
+
+void test_pub_reading_formats_wake_window_with_leading_zeros(void)
+{
+    tmeter_data data = sampleReading();
+    data.time_start = 0;
+    data.time_end = 9;
+    publisher().publishMeterReading(data, "t");
+
+    TEST_ASSERT_EQUAL_STRING("00:00", g_sensors.timeStart.last());
+    TEST_ASSERT_EQUAL_STRING("09:00", g_sensors.timeEnd.last());
+}
+
+void test_pub_reading_omits_empty_meter_clock_and_model(void)
+{
+    // An undecoded clock or identifier must leave the entity untouched rather
+    // than overwrite a good value with an empty string.
+    publisher().publishMeterReading(sampleReading(), "t");
+
+    TEST_ASSERT_FALSE(g_sensors.meterClock.published());
+    TEST_ASSERT_FALSE(g_sensors.meterModel.published());
+}
+
+void test_pub_reading_publishes_meter_clock_and_model_when_present(void)
+{
+    tmeter_data data = sampleReading();
+    snprintf(data.meter_time, sizeof(data.meter_time), "2026-04-27 09:59:49");
+    snprintf(data.meter_type, sizeof(data.meter_type), "133290AL02");
+    publisher().publishMeterReading(data, "t");
+
+    TEST_ASSERT_EQUAL_STRING("2026-04-27 09:59:49", g_sensors.meterClock.last());
+    TEST_ASSERT_EQUAL_STRING("133290AL02", g_sensors.meterModel.last());
+}
+
+void test_pub_reading_publishes_frequency_estimate_in_khz(void)
+{
+    tmeter_data data = sampleReading();
+    data.freqest = 12;
+    publisher().publishMeterReading(data, "t");
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 12 * 1.587f, g_sensors.frequencyEstimate.last());
+}
+
+void test_pub_reading_without_sensors_is_safe(void)
+{
+    // A YAML config that declares no sensors at all must not crash the device.
+    ESPHomeDataPublisher bare;
+    bare.publishMeterReading(sampleReading(), "t");
+    bare.publishStatusMessage("Ready");
+    bare.publishError("None");
+    bare.publishActiveReading(true);
+    bare.publishStatistics(1, 2, 3);
+    bare.publishUptime(60, "PT1M");
+    TEST_PASS();
+}
+
+// ---------------------------------------------------------------------------
+// Signal quality conversions
+// ---------------------------------------------------------------------------
+
+void test_pub_lqi_percentage_matches_the_shared_helper(void)
+{
+    // The publisher keeps its own copy of this conversion; both builds must
+    // report the same number for the same link quality.
+    static const int samples[] = {0, 1, 20, 25, 63, 64, 100, 127};
+    for (int lqi : samples)
+    {
+        tmeter_data data = sampleReading();
+        data.lqi = lqi;
+        g_sensors.lqiPercent.clear();
+        publisher().publishMeterReading(data, "t");
+
+        TEST_ASSERT_EQUAL_FLOAT((float)calculateLQIToPercentage(lqi),
+                                g_sensors.lqiPercent.last());
+    }
+}
+
+void test_pub_lqi_percentage_masks_the_crc_ok_bit(void)
+{
+    tmeter_data data = sampleReading();
+    data.lqi = 0x80 | 25; // CRC_OK set alongside an error count of 25
+    publisher().publishMeterReading(data, "t");
+
+    TEST_ASSERT_EQUAL_FLOAT((float)calculateLQIToPercentage(25), g_sensors.lqiPercent.last());
+}
+
+void test_pub_rssi_percentage_matches_the_shared_helper(void)
+{
+    static const int samples[] = {-130, -120, -100, -80, -70, -60, -50, -40, -20};
+    for (int dbm : samples)
+    {
+        tmeter_data data = sampleReading();
+        data.rssi_dbm = dbm;
+        g_sensors.rssiPercent.clear();
+        publisher().publishMeterReading(data, "t");
+
+        TEST_ASSERT_EQUAL_FLOAT((float)calculateMeterdBmToPercentage(dbm),
+                                g_sensors.rssiPercent.last());
+    }
+}
+
+void test_pub_rssi_percentage_is_clamped_to_0_100(void)
+{
+    static const int samples[] = {-200, -130, -70, -10, 0};
+    for (int dbm : samples)
+    {
+        tmeter_data data = sampleReading();
+        data.rssi_dbm = dbm;
+        g_sensors.rssiPercent.clear();
+        publisher().publishMeterReading(data, "t");
+
+        const float percent = g_sensors.rssiPercent.last();
+        TEST_ASSERT_TRUE(percent >= 0.0f && percent <= 100.0f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// History
+// ---------------------------------------------------------------------------
+
+void test_pub_history_publishes_json_payload(void)
+{
+    // Valid months are packed from index 0; the first zero ends the series.
+    uint32_t history[13] = {0};
+    history[0] = 100;
+    history[1] = 150;
+    history[2] = 220;
+
+    tmeter_data data = sampleReading();
+    data.volume = 260;
+    publisher().publishMeterReading(data, "t"); // caches the current volume
+    publisher().publishHistory(history, true);
+
+    TEST_ASSERT_EQUAL_STRING(
+        "{\"history\":[100,150,220],\"monthly_usage\":[50,70],"
+        "\"current_month_usage\":40,\"months_available\":3}",
+        g_sensors.history.last());
+}
+
+void test_pub_history_reports_unavailable_when_not_decoded(void)
+{
+    uint32_t history[13] = {0};
+    publisher().publishHistory(history, false);
+
+    TEST_ASSERT_EQUAL_STRING("unavailable", g_sensors.history.last());
+}
+
+void test_pub_history_reports_unavailable_for_a_null_array(void)
+{
+    publisher().publishHistory(nullptr, true);
+
+    TEST_ASSERT_EQUAL_STRING("unavailable", g_sensors.history.last());
+}
+
+void test_pub_history_without_a_sensor_is_safe(void)
+{
+    uint32_t history[13] = {0};
+    history[0] = 100;
+
+    ESPHomeDataPublisher bare;
+    bare.publishHistory(history, true);
+    TEST_PASS();
+}
+
+// ---------------------------------------------------------------------------
+// Status, radio state and errors
+// ---------------------------------------------------------------------------
+
+void test_pub_radio_state_drives_the_connected_binary_sensor(void)
+{
+    publisher().publishRadioState("Idle");
+    TEST_ASSERT_EQUAL_STRING("Idle", g_sensors.radioState.last());
+    TEST_ASSERT_TRUE(g_sensors.radioConnected.last());
+
+    publisher().publishRadioState("unavailable");
+    TEST_ASSERT_EQUAL_STRING("unavailable", g_sensors.radioState.last());
+    TEST_ASSERT_FALSE(g_sensors.radioConnected.last());
+
+    publisher().publishRadioState("Reading");
+    TEST_ASSERT_TRUE(g_sensors.radioConnected.last());
+}
+
+void test_pub_radio_state_null_is_ignored(void)
+{
+    // Guards against dereferencing a null state while deriving connectivity.
+    publisher().publishRadioState(nullptr);
+
+    TEST_ASSERT_FALSE(g_sensors.radioState.published());
+    TEST_ASSERT_FALSE(g_sensors.radioConnected.published());
+}
+
+void test_pub_status_and_error_are_published(void)
+{
+    publisher().publishStatusMessage("Reading successful");
+    publisher().publishError("None");
+
+    TEST_ASSERT_EQUAL_STRING("Reading successful", g_sensors.status.last());
+    TEST_ASSERT_EQUAL_STRING("None", g_sensors.error.last());
+}
+
+void test_pub_status_and_error_ignore_null(void)
+{
+    publisher().publishStatusMessage(nullptr);
+    publisher().publishError(nullptr);
+
+    TEST_ASSERT_FALSE(g_sensors.status.published());
+    TEST_ASSERT_FALSE(g_sensors.error.published());
+}
+
+void test_pub_active_reading_is_published(void)
+{
+    publisher().publishActiveReading(true);
+    publisher().publishActiveReading(false);
+
+    TEST_ASSERT_EQUAL_INT(2, g_sensors.activeReading.count());
+    TEST_ASSERT_TRUE(g_sensors.activeReading.states[0]);
+    TEST_ASSERT_FALSE(g_sensors.activeReading.states[1]);
+}
+
+// ---------------------------------------------------------------------------
+// Statistics, frequency and settings
+// ---------------------------------------------------------------------------
+
+void test_pub_statistics_are_published(void)
+{
+    publisher().publishStatistics(10, 7, 3);
+
+    TEST_ASSERT_EQUAL_FLOAT(10.0f, g_sensors.totalAttempts.last());
+    TEST_ASSERT_EQUAL_FLOAT(7.0f, g_sensors.successfulReads.last());
+    TEST_ASSERT_EQUAL_FLOAT(3.0f, g_sensors.failedReads.last());
+}
+
+void test_pub_frequency_offset_is_published_in_khz(void)
+{
+    publisher().publishFrequencyOffset(0.0175f);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 17.5f, g_sensors.frequencyOffset.last());
+}
+
+void test_pub_tuned_frequency_is_published_in_mhz(void)
+{
+    publisher().publishTunedFrequency(433.8375f);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 433.8375f, g_sensors.tunedFrequency.last());
+}
+
+void test_pub_negative_frequency_estimate_is_signed(void)
+{
+    publisher().publishFrequencyEstimate(-40);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, -40 * 1.587f, g_sensors.frequencyEstimate.last());
+}
+
+void test_pub_meter_settings_are_formatted_for_display(void)
+{
+    publisher().publishMeterSettings(7, 501090, "Monday-Friday", "10:00", 433.82f);
+
+    TEST_ASSERT_EQUAL_STRING("501090", g_sensors.meterSerial.last());
+    TEST_ASSERT_EQUAL_STRING("07", g_sensors.meterYear.last()); // two digits, zero padded
+    TEST_ASSERT_EQUAL_STRING("Monday-Friday", g_sensors.readingSchedule.last());
+    TEST_ASSERT_EQUAL_STRING("10:00", g_sensors.readingTimeUtc.last());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 433.82f, g_sensors.frequency.last());
+}
+
+void test_pub_meter_settings_ignore_null_strings(void)
+{
+    publisher().publishMeterSettings(21, 123456, nullptr, nullptr, 433.82f);
+
+    TEST_ASSERT_FALSE(g_sensors.readingSchedule.published());
+    TEST_ASSERT_FALSE(g_sensors.readingTimeUtc.published());
+    TEST_ASSERT_EQUAL_STRING("123456", g_sensors.meterSerial.last());
+}
+
+void test_pub_firmware_version_ignores_null(void)
+{
+    publisher().publishFirmwareVersion("3.2.0");
+    TEST_ASSERT_EQUAL_STRING("3.2.0", g_sensors.version.last());
+
+    publisher().publishFirmwareVersion(nullptr);
+    TEST_ASSERT_EQUAL_INT(1, g_sensors.version.count());
+}
+
+void test_pub_uptime_is_published(void)
+{
+    publisher().publishUptime(3600, "PT1H");
+
+    TEST_ASSERT_EQUAL_FLOAT(3600.0f, g_sensors.uptime.last());
+}
+
+void test_pub_is_always_ready(void)
+{
+    // ESPHome sensors have no connection state of their own, unlike MQTT.
+    TEST_ASSERT_TRUE(publisher().isReady());
+
+    ESPHomeDataPublisher bare;
+    TEST_ASSERT_TRUE(bare.isReady());
+}
+
+void test_pub_wifi_details_and_discovery_are_no_ops(void)
+{
+    // ESPHome reports WiFi state and performs discovery itself.
+    publisher().publishWiFiDetails("192.168.1.2", -60, 80, "aa:bb", "ssid", "cc:dd");
+    publisher().publishDiscovery();
+    TEST_PASS();
+}
+
+// ---------------------------------------------------------------------------
+// Shared, device-level sensors
+// ---------------------------------------------------------------------------
+
+void test_pub_shared_sensors_keep_their_first_registration(void)
+{
+    // Calibration and radio entities describe the one shared CC1101, so a
+    // second meter instance in the same YAML must not steal them.
+    Sensor secondOffset;
+    TextSensor secondRadioState;
+    BinarySensor secondConnected;
+
+    ESPHomeDataPublisher second;
+    second.set_frequency_offset_sensor(&secondOffset);
+    second.set_radio_state_sensor(&secondRadioState);
+    second.set_radio_connected_sensor(&secondConnected);
+
+    second.publishFrequencyOffset(0.010f);
+    second.publishRadioState("Idle");
+
+    TEST_ASSERT_FALSE(secondOffset.published());
+    TEST_ASSERT_FALSE(secondRadioState.published());
+    TEST_ASSERT_FALSE(secondConnected.published());
+
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 10.0f, g_sensors.frequencyOffset.last());
+    TEST_ASSERT_EQUAL_STRING("Idle", g_sensors.radioState.last());
+}
+
+void test_pub_per_meter_sensors_are_not_shared(void)
+{
+    // Volume and status are per-meter, so a second instance drives its own.
+    Sensor secondVolume;
+    TextSensor secondStatus;
+
+    ESPHomeDataPublisher second;
+    second.set_volume_sensor(&secondVolume);
+    second.set_status_sensor(&secondStatus);
+
+    second.publishMeterReading(sampleReading(), "t");
+    second.publishStatusMessage("Ready");
+
+    TEST_ASSERT_TRUE(secondVolume.published());
+    TEST_ASSERT_EQUAL_STRING("Ready", secondStatus.last());
+    TEST_ASSERT_FALSE(g_sensors.volume.published());
+    TEST_ASSERT_FALSE(g_sensors.status.published());
+}

--- a/test/test_native_esphome_publisher/test_runner.cpp
+++ b/test/test_native_esphome_publisher/test_runner.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file test_runner.cpp
+ * @brief Unity entry point for the ESPHome publisher host suite
+ */
+
+#include <unity.h>
+
+void esphomePublisherSetUp();
+void esphomePublisherTearDown();
+
+void test_pub_reading_populates_every_sensor(void);
+void test_pub_reading_publishes_each_sensor_once(void);
+void test_pub_reading_formats_wake_window_with_leading_zeros(void);
+void test_pub_reading_omits_empty_meter_clock_and_model(void);
+void test_pub_reading_publishes_meter_clock_and_model_when_present(void);
+void test_pub_reading_publishes_frequency_estimate_in_khz(void);
+void test_pub_reading_without_sensors_is_safe(void);
+void test_pub_lqi_percentage_matches_the_shared_helper(void);
+void test_pub_lqi_percentage_masks_the_crc_ok_bit(void);
+void test_pub_rssi_percentage_matches_the_shared_helper(void);
+void test_pub_rssi_percentage_is_clamped_to_0_100(void);
+void test_pub_history_publishes_json_payload(void);
+void test_pub_history_reports_unavailable_when_not_decoded(void);
+void test_pub_history_reports_unavailable_for_a_null_array(void);
+void test_pub_history_without_a_sensor_is_safe(void);
+void test_pub_radio_state_drives_the_connected_binary_sensor(void);
+void test_pub_radio_state_null_is_ignored(void);
+void test_pub_status_and_error_are_published(void);
+void test_pub_status_and_error_ignore_null(void);
+void test_pub_active_reading_is_published(void);
+void test_pub_statistics_are_published(void);
+void test_pub_frequency_offset_is_published_in_khz(void);
+void test_pub_tuned_frequency_is_published_in_mhz(void);
+void test_pub_negative_frequency_estimate_is_signed(void);
+void test_pub_meter_settings_are_formatted_for_display(void);
+void test_pub_meter_settings_ignore_null_strings(void);
+void test_pub_firmware_version_ignores_null(void);
+void test_pub_uptime_is_published(void);
+void test_pub_is_always_ready(void);
+void test_pub_wifi_details_and_discovery_are_no_ops(void);
+void test_pub_shared_sensors_keep_their_first_registration(void);
+void test_pub_per_meter_sensors_are_not_shared(void);
+
+void setUp(void) { esphomePublisherSetUp(); }
+void tearDown(void) { esphomePublisherTearDown(); }
+
+int main(int, char **)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_pub_reading_populates_every_sensor);
+    RUN_TEST(test_pub_reading_publishes_each_sensor_once);
+    RUN_TEST(test_pub_reading_formats_wake_window_with_leading_zeros);
+    RUN_TEST(test_pub_reading_omits_empty_meter_clock_and_model);
+    RUN_TEST(test_pub_reading_publishes_meter_clock_and_model_when_present);
+    RUN_TEST(test_pub_reading_publishes_frequency_estimate_in_khz);
+    RUN_TEST(test_pub_reading_without_sensors_is_safe);
+
+    RUN_TEST(test_pub_lqi_percentage_matches_the_shared_helper);
+    RUN_TEST(test_pub_lqi_percentage_masks_the_crc_ok_bit);
+    RUN_TEST(test_pub_rssi_percentage_matches_the_shared_helper);
+    RUN_TEST(test_pub_rssi_percentage_is_clamped_to_0_100);
+
+    RUN_TEST(test_pub_history_publishes_json_payload);
+    RUN_TEST(test_pub_history_reports_unavailable_when_not_decoded);
+    RUN_TEST(test_pub_history_reports_unavailable_for_a_null_array);
+    RUN_TEST(test_pub_history_without_a_sensor_is_safe);
+
+    RUN_TEST(test_pub_radio_state_drives_the_connected_binary_sensor);
+    RUN_TEST(test_pub_radio_state_null_is_ignored);
+    RUN_TEST(test_pub_status_and_error_are_published);
+    RUN_TEST(test_pub_status_and_error_ignore_null);
+    RUN_TEST(test_pub_active_reading_is_published);
+
+    RUN_TEST(test_pub_statistics_are_published);
+    RUN_TEST(test_pub_frequency_offset_is_published_in_khz);
+    RUN_TEST(test_pub_tuned_frequency_is_published_in_mhz);
+    RUN_TEST(test_pub_negative_frequency_estimate_is_signed);
+    RUN_TEST(test_pub_meter_settings_are_formatted_for_display);
+    RUN_TEST(test_pub_meter_settings_ignore_null_strings);
+    RUN_TEST(test_pub_firmware_version_ignores_null);
+    RUN_TEST(test_pub_uptime_is_published);
+    RUN_TEST(test_pub_is_always_ready);
+    RUN_TEST(test_pub_wifi_details_and_discovery_are_no_ops);
+
+    RUN_TEST(test_pub_shared_sensors_keep_their_first_registration);
+    RUN_TEST(test_pub_per_meter_sensors_are_not_shared);
+
+    return UNITY_END();
+}

--- a/test/test_native_esphome_reader/test_esphome_meter_reader.cpp
+++ b/test/test_native_esphome_reader/test_esphome_meter_reader.cpp
@@ -1,0 +1,286 @@
+/**
+ * @file test_esphome_meter_reader.cpp
+ * @brief Host tests for the ESPHome-only behaviour of MeterReader
+ *
+ * MeterReader compiles differently for the two deployment targets. The
+ * test_native_meter_reader suite covers the MQTT build; the branches guarded by
+ * USE_ESPHOME were compiled here but never executed by any test, which is most
+ * of what kept meter_reader.cpp off full coverage.
+ *
+ * Two differences matter to users:
+ *
+ *  - On boot the ESPHome build deliberately does not publish idle/zero states.
+ *    ESPHome restores sensor values from Home Assistant, and publishing a fresh
+ *    zero would overwrite the restored reading and put a false drop in the
+ *    history graph. A radio failure is still reported immediately, because that
+ *    is the one state the user needs to see straight away.
+ *  - Scheduled reads are held until the Home Assistant API connects, so the
+ *    first reading of the day is not lost to a publish that goes nowhere.
+ */
+
+#include <unity.h>
+
+#include <Arduino.h>
+
+#include "native_fakes.h"
+#include "services/meter_reader.h"
+// frequency_manager.h skips this include in ESPHome builds, but the fake
+// storage backend is still what the calibration is read from here.
+#include "services/storage_abstraction.h"
+
+namespace
+{
+    FakeConfig g_config;
+    FakeTime g_time;
+    RecordingPublisher g_publisher;
+}
+
+void esphomeReaderSetUp()
+{
+    resetAllFakes();
+    g_config = FakeConfig();
+    g_time = FakeTime();
+    g_publisher.reset();
+}
+
+// ---------------------------------------------------------------------------
+// Boot behaviour
+// ---------------------------------------------------------------------------
+
+void test_esphome_begin_does_not_publish_idle_states(void)
+{
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+
+    TEST_ASSERT_TRUE(reader.isRadioConnected());
+
+    // None of these may be published on a healthy boot: ESPHome restores them
+    // from Home Assistant and a fresh value would overwrite the restored one.
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.radioStates.size());
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.statuses.size());
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.errors.size());
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.activeReadingFlags.size());
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.statistics.size());
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.readings.size());
+}
+
+void test_esphome_begin_publishes_settings_and_calibration(void)
+{
+    // The stored calibration is published at boot so it is visible in Home
+    // Assistant immediately, confirming it survived the reboot.
+    StorageAbstraction::saveFloat("freq_offset", 0.0125f, 0xABCD);
+    g_config.frequency = 433.82f;
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+
+    TEST_ASSERT_EQUAL(1, g_publisher.settingsPublishes);
+    TEST_ASSERT_EQUAL(1, (int)g_publisher.frequencyOffsets.size());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0125f, g_publisher.frequencyOffsets.back());
+    TEST_ASSERT_EQUAL(1, (int)g_publisher.tunedFrequencies.size());
+    // Loose tolerance: 433.8325 is at the edge of what a 32-bit float resolves.
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 433.8325f, g_publisher.tunedFrequencies.back());
+}
+
+void test_esphome_begin_reports_a_radio_failure_immediately(void)
+{
+    fakeRadio().initSucceeds = false;
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+
+    TEST_ASSERT_FALSE(reader.isRadioConnected());
+    TEST_ASSERT_EQUAL_STRING("unavailable", g_publisher.lastRadioState().c_str());
+    TEST_ASSERT_EQUAL_STRING("Error", g_publisher.lastStatus().c_str());
+    TEST_ASSERT_EQUAL_STRING("CC1101 radio not responding - check SPI wiring",
+                             g_publisher.lastError().c_str());
+}
+
+void test_esphome_begin_without_a_publisher_is_safe(void)
+{
+    MeterReader reader(&g_config, &g_time, nullptr);
+    reader.begin();
+
+    TEST_ASSERT_TRUE(reader.isRadioConnected());
+}
+
+// ---------------------------------------------------------------------------
+// Home Assistant connection gating
+// ---------------------------------------------------------------------------
+
+void test_esphome_scheduled_read_waits_for_home_assistant(void)
+{
+    g_config.schedule = "Monday-Friday";
+    g_config.readHourUTC = 10;
+    g_config.readMinuteUTC = 0;
+    fakeRadio().responses.push_back(FakeRadio::success());
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    g_publisher.reset();
+
+    // 2025-06-10 is a Tuesday. The schedule matches, but Home Assistant has not
+    // connected yet, so the read must not start.
+    g_time.setUtc(2025, 6, 10, 10, 0, 0);
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(0, (int)fakeRadio().calls.size());
+
+    reader.setHAConnected(true);
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+}
+
+void test_esphome_losing_home_assistant_stops_scheduled_reads(void)
+{
+    g_config.schedule = "Monday-Friday";
+    fakeRadio().responses.push_back(FakeRadio::success());
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    reader.setHAConnected(true);
+    g_publisher.reset();
+
+    g_time.setUtc(2025, 6, 10, 10, 0, 0);
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+
+    reader.setHAConnected(false);
+    g_time.setUtc(2025, 6, 11, 10, 0, 0);
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+}
+
+void test_esphome_manual_read_does_not_wait_for_home_assistant(void)
+{
+    // The gate applies to the schedule only: a button press must still work, so
+    // a user can diagnose the device before Home Assistant is up.
+    fakeRadio().responses.push_back(FakeRadio::success(4242));
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    g_publisher.reset();
+
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+    TEST_ASSERT_EQUAL(1, (int)g_publisher.readings.size());
+    TEST_ASSERT_EQUAL(4242, g_publisher.readings[0].data.volume);
+}
+
+// ---------------------------------------------------------------------------
+// Reading behaviour, ESPHome build
+// ---------------------------------------------------------------------------
+
+void test_esphome_successful_read_publishes_the_same_sequence(void)
+{
+    fakeRadio().responses.push_back(FakeRadio::success(56789));
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    g_publisher.reset();
+
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL(1, (int)g_publisher.readings.size());
+    TEST_ASSERT_EQUAL_STRING("Idle", g_publisher.lastRadioState().c_str());
+    TEST_ASSERT_EQUAL_STRING("Reading successful", g_publisher.lastStatus().c_str());
+    TEST_ASSERT_FALSE(reader.isReadingInProgress());
+    TEST_ASSERT_FALSE(g_publisher.activeReadingFlags.back());
+}
+
+void test_esphome_failed_read_reaches_the_cooldown(void)
+{
+    g_config.maxRetries = 1;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::CrcFailed));
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    g_publisher.reset();
+
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL_STRING("Failed after max retries", g_publisher.lastStatus().c_str());
+    TEST_ASSERT_EQUAL_STRING(read_failure_message(ReadFailure::CrcFailed, false),
+                             g_publisher.lastError().c_str());
+
+    unsigned long attempts = 0, successes = 0, failures = 0;
+    reader.getStatistics(attempts, successes, failures);
+    TEST_ASSERT_EQUAL_UINT32(1, attempts);
+    TEST_ASSERT_EQUAL_UINT32(1, failures);
+}
+
+void test_esphome_stop_reading_returns_to_idle(void)
+{
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    g_publisher.reset();
+
+    reader.triggerReading(false);
+    TEST_ASSERT_TRUE(reader.isReadingInProgress());
+
+    reader.stopReading();
+
+    TEST_ASSERT_FALSE(reader.isReadingInProgress());
+    TEST_ASSERT_EQUAL_STRING("Reading stopped", g_publisher.lastStatus().c_str());
+    TEST_ASSERT_EQUAL_STRING("Idle", g_publisher.lastRadioState().c_str());
+}
+
+void test_esphome_reset_frequency_offset_retunes_and_publishes(void)
+{
+    StorageAbstraction::saveFloat("freq_offset", 0.030f, 0xABCD);
+    g_config.frequency = 433.82f;
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    g_publisher.reset();
+
+    reader.resetFrequencyOffset();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 433.82f, fakeRadio().lastInitFrequency());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, g_publisher.frequencyOffsets.back());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 433.82f, g_publisher.tunedFrequencies.back());
+}
+
+void test_esphome_frequency_scan_publishes_the_new_offset(void)
+{
+    g_config.frequency = 433.82f;
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    g_publisher.reset();
+
+    // A carrier 20 kHz above the base frequency, within the narrow scan range.
+    fakeRadio().carrierFrequency = 433.84f;
+    fakeRadio().carrierWidthMHz = 0.006f;
+
+    reader.performFrequencyScan();
+
+    TEST_ASSERT_FALSE(g_publisher.frequencyOffsets.empty());
+    TEST_ASSERT_TRUE(FrequencyManager::getOffset() > 0.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, FrequencyManager::getOffset(),
+                             g_publisher.frequencyOffsets.back());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, FrequencyManager::getTunedFrequency(),
+                             g_publisher.tunedFrequencies.back());
+}
+
+void test_esphome_statistics_are_republished_periodically(void)
+{
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+    reader.setHAConnected(true);
+    g_publisher.reset();
+
+    reader.loop();
+    const int baseline = (int)g_publisher.statistics.size();
+
+    nativeClockAdvance(300000);
+    reader.loop();
+
+    TEST_ASSERT_EQUAL(baseline + 1, (int)g_publisher.statistics.size());
+}

--- a/test/test_native_esphome_reader/test_runner.cpp
+++ b/test/test_native_esphome_reader/test_runner.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file test_runner.cpp
+ * @brief Unity entry point for the ESPHome-mode MeterReader host suite
+ */
+
+#include <unity.h>
+
+void esphomeReaderSetUp();
+
+void test_esphome_begin_does_not_publish_idle_states(void);
+void test_esphome_begin_publishes_settings_and_calibration(void);
+void test_esphome_begin_reports_a_radio_failure_immediately(void);
+void test_esphome_begin_without_a_publisher_is_safe(void);
+void test_esphome_scheduled_read_waits_for_home_assistant(void);
+void test_esphome_losing_home_assistant_stops_scheduled_reads(void);
+void test_esphome_manual_read_does_not_wait_for_home_assistant(void);
+void test_esphome_successful_read_publishes_the_same_sequence(void);
+void test_esphome_failed_read_reaches_the_cooldown(void);
+void test_esphome_stop_reading_returns_to_idle(void);
+void test_esphome_reset_frequency_offset_retunes_and_publishes(void);
+void test_esphome_frequency_scan_publishes_the_new_offset(void);
+void test_esphome_statistics_are_republished_periodically(void);
+
+void setUp(void) { esphomeReaderSetUp(); }
+
+void tearDown(void) {}
+
+int main(int, char **)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_esphome_begin_does_not_publish_idle_states);
+    RUN_TEST(test_esphome_begin_publishes_settings_and_calibration);
+    RUN_TEST(test_esphome_begin_reports_a_radio_failure_immediately);
+    RUN_TEST(test_esphome_begin_without_a_publisher_is_safe);
+
+    RUN_TEST(test_esphome_scheduled_read_waits_for_home_assistant);
+    RUN_TEST(test_esphome_losing_home_assistant_stops_scheduled_reads);
+    RUN_TEST(test_esphome_manual_read_does_not_wait_for_home_assistant);
+
+    RUN_TEST(test_esphome_successful_read_publishes_the_same_sequence);
+    RUN_TEST(test_esphome_failed_read_reaches_the_cooldown);
+    RUN_TEST(test_esphome_stop_reading_returns_to_idle);
+    RUN_TEST(test_esphome_reset_frequency_offset_retunes_and_publishes);
+    RUN_TEST(test_esphome_frequency_scan_publishes_the_new_offset);
+    RUN_TEST(test_esphome_statistics_are_republished_periodically);
+
+    return UNITY_END();
+}

--- a/test/test_native_meter_fixtures/test_native_meter_fixtures.cpp
+++ b/test/test_native_meter_fixtures/test_native_meter_fixtures.cpp
@@ -1198,6 +1198,18 @@ void test_radian_parse_clock_and_type_are_best_effort(void)
     }
 }
 
+// Transmit-path tests, defined in test_transmit_frame.cpp
+void test_request_frame_round_trips_through_the_receiver(void);
+void test_request_frame_carries_the_meter_identity(void);
+void test_request_frame_crc_is_valid_after_the_round_trip(void);
+void test_request_frame_round_trips_for_boundary_identities(void);
+void test_request_frame_starts_with_the_sync_pattern(void);
+void test_request_frame_length_is_stable(void);
+void test_request_frames_differ_between_meters(void);
+void test_request_frame_is_deterministic(void);
+void test_serial_encoding_round_trips_arbitrary_payloads(void);
+void test_serial_encoding_round_trips_all_byte_values(void);
+
 int main(int argc, char **argv)
 {
     (void)argc;
@@ -1226,5 +1238,17 @@ int main(int argc, char **argv)
     RUN_TEST(test_fixture_frames_reject_every_single_bit_flip);
     RUN_TEST(test_read_failure_messages_are_distinct);
     RUN_TEST(test_tmeter_data_defaults_to_no_failure);
+
+    // Transmit path
+    RUN_TEST(test_request_frame_round_trips_through_the_receiver);
+    RUN_TEST(test_request_frame_carries_the_meter_identity);
+    RUN_TEST(test_request_frame_crc_is_valid_after_the_round_trip);
+    RUN_TEST(test_request_frame_round_trips_for_boundary_identities);
+    RUN_TEST(test_request_frame_starts_with_the_sync_pattern);
+    RUN_TEST(test_request_frame_length_is_stable);
+    RUN_TEST(test_request_frames_differ_between_meters);
+    RUN_TEST(test_request_frame_is_deterministic);
+    RUN_TEST(test_serial_encoding_round_trips_arbitrary_payloads);
+    RUN_TEST(test_serial_encoding_round_trips_all_byte_values);
     return UNITY_END();
 }

--- a/test/test_native_meter_fixtures/test_native_meter_fixtures.cpp
+++ b/test/test_native_meter_fixtures/test_native_meter_fixtures.cpp
@@ -1054,6 +1054,150 @@ void test_tmeter_data_defaults_to_no_failure(void)
     TEST_ASSERT_TRUE(ReadFailure::None == zeroed.failure);
 }
 
+// ---------------------------------------------------------------------------
+// Mutation coverage against the captured frames.
+//
+// The CRC trailer is the only thing standing between a corrupted reception and
+// a bogus reading published to Home Assistant, so verify it exhaustively rather
+// than with a single hand-picked flipped bit: every one-bit corruption of a
+// real, CRC-valid frame must be rejected.
+// ---------------------------------------------------------------------------
+void test_fixture_frames_reject_every_single_bit_flip(void)
+{
+    FixtureLoadResult loaded = load_fixtures();
+    if (!loaded.fixture_file_found)
+    {
+        TEST_IGNORE_MESSAGE("fixtures.lst not found; skipping mutation coverage");
+        return;
+    }
+
+    size_t frames_checked = 0;
+
+    for (const Fixture &fx : loaded.fixtures)
+    {
+        if (!fx.expected_crc_valid || fx.decoded.size() < 4)
+        {
+            continue;
+        }
+
+        const uint8_t length_field = fx.decoded[0];
+        const size_t frame_len = length_field ? (size_t)length_field : fx.decoded.size();
+        if (frame_len > fx.decoded.size())
+        {
+            continue; // advertises more than was captured; CRC check is skipped
+        }
+
+        // Byte 0 is the length field. Corrupting it changes where the CRC is
+        // read from, and a length beyond the buffer is deliberately accepted as
+        // a compatibility shim, so it is excluded here and covered separately
+        // in test_radian_validate_crc.
+        for (size_t byte = 1; byte < frame_len; byte++)
+        {
+            for (int bit = 0; bit < 8; bit++)
+            {
+                std::vector<uint8_t> corrupted = fx.decoded;
+                corrupted[byte] ^= (uint8_t)(1u << bit);
+
+                char msg[128];
+                snprintf(msg, sizeof(msg),
+                         "%s: flipping bit %d of byte %u was not caught by the CRC",
+                         fx.name.c_str(), bit, (unsigned)byte);
+                TEST_ASSERT_FALSE_MESSAGE(
+                    radian_validate_crc(corrupted.data(), corrupted.size()), msg);
+            }
+        }
+
+        frames_checked++;
+    }
+
+    TEST_ASSERT_TRUE_MESSAGE(frames_checked > 0,
+                             "No CRC-valid fixture frames available to mutate");
+}
+
+// The meter clock and identifier are best-effort extras: out-of-range or
+// non-printable bytes must blank those fields without discarding an otherwise
+// valid reading.
+void test_radian_parse_clock_and_type_are_best_effort(void)
+{
+    // Well-formed frame with a valid clock (27/04/2026 09:59:49) and the ASCII
+    // identifier "133290AL02" at bytes [32..41].
+    uint8_t base[120];
+    make_test_buf(base, sizeof(base), 774431UL, 6, 18);
+    base[24] = 27; // day
+    base[25] = 4;  // month
+    base[26] = 26; // year -> 2026
+    base[28] = 9;  // hour
+    base[29] = 59; // minute
+    base[30] = 49; // second
+    memcpy(&base[32], "133290AL02", 10);
+    base[42] = 0x00;
+
+    struct radian_primary_data out;
+    TEST_ASSERT_TRUE(radian_parse_primary_data(base, sizeof(base), &out));
+    TEST_ASSERT_TRUE(out.clock_valid);
+    TEST_ASSERT_EQUAL_STRING("133290AL02", out.meter_type);
+
+    // Each out-of-range clock component must clear clock_valid on its own while
+    // the reading itself is still accepted.
+    struct ClockMutation
+    {
+        size_t offset;
+        uint8_t value;
+        const char *what;
+    };
+    const ClockMutation invalid_clocks[] = {
+        {24, 0, "day 0"},
+        {24, 32, "day 32"},
+        {25, 0, "month 0"},
+        {25, 13, "month 13"},
+        {28, 24, "hour 24"},
+        {29, 60, "minute 60"},
+        {30, 60, "second 60"},
+    };
+
+    for (const ClockMutation &m : invalid_clocks)
+    {
+        uint8_t buf[120];
+        memcpy(buf, base, sizeof(buf));
+        buf[m.offset] = m.value;
+
+        TEST_ASSERT_TRUE_MESSAGE(radian_parse_primary_data(buf, sizeof(buf), &out), m.what);
+        TEST_ASSERT_FALSE_MESSAGE(out.clock_valid, m.what);
+        // The reading itself survives an unset meter clock.
+        TEST_ASSERT_EQUAL_UINT32(774431UL, out.volume);
+    }
+
+    // A non-printable byte inside the identifier discards the whole string
+    // rather than publishing a partial one.
+    {
+        uint8_t buf[120];
+        memcpy(buf, base, sizeof(buf));
+        buf[36] = 0x07;
+        TEST_ASSERT_TRUE(radian_parse_primary_data(buf, sizeof(buf), &out));
+        TEST_ASSERT_EQUAL_STRING("", out.meter_type);
+        TEST_ASSERT_TRUE(out.clock_valid);
+    }
+
+    // A leading NUL means "no identifier".
+    {
+        uint8_t buf[120];
+        memcpy(buf, base, sizeof(buf));
+        buf[32] = 0x00;
+        TEST_ASSERT_TRUE(radian_parse_primary_data(buf, sizeof(buf), &out));
+        TEST_ASSERT_EQUAL_STRING("", out.meter_type);
+    }
+
+    // Bytes [32..42] with no NUL must stay inside meter_type[12].
+    {
+        uint8_t buf[120];
+        memcpy(buf, base, sizeof(buf));
+        memset(&buf[32], 'A', 11);
+        TEST_ASSERT_TRUE(radian_parse_primary_data(buf, sizeof(buf), &out));
+        TEST_ASSERT_EQUAL_STRING("AAAAAAAAAAA", out.meter_type);
+        TEST_ASSERT_EQUAL_size_t(11, strlen(out.meter_type));
+    }
+}
+
 int main(int argc, char **argv)
 {
     (void)argc;
@@ -1076,8 +1220,10 @@ int main(int argc, char **argv)
     RUN_TEST(test_radian_reading_within_history_bounds_skips_when_insufficient);
     RUN_TEST(test_radian_parse_extended_fields_home001);
     RUN_TEST(test_radian_parse_extended_fields_absent_when_short);
+    RUN_TEST(test_radian_parse_clock_and_type_are_best_effort);
     RUN_TEST(test_replay_meter_fixtures);
     RUN_TEST(test_replay_raw_meter_fixtures);
+    RUN_TEST(test_fixture_frames_reject_every_single_bit_flip);
     RUN_TEST(test_read_failure_messages_are_distinct);
     RUN_TEST(test_tmeter_data_defaults_to_no_failure);
     return UNITY_END();

--- a/test/test_native_meter_fixtures/test_transmit_frame.cpp
+++ b/test/test_native_meter_fixtures/test_transmit_frame.cpp
@@ -1,0 +1,293 @@
+/**
+ * @file test_transmit_frame.cpp
+ * @brief Round-trip tests for the RADIAN request frame the device transmits
+ *
+ * Everything before this file tested the receive path. The transmit path had no
+ * coverage at all, yet a wrong interrogation frame is indistinguishable from a
+ * meter that is out of range: the device simply never gets an answer.
+ *
+ * Make_Radian_Master_req() builds the frame and encode2serial_1_3() applies the
+ * serial framing. Rather than assert the encoder's output byte by byte, which
+ * would only restate the implementation, these tests push the encoded frame
+ * back through radian_decode_4bitpbit() (the receiver used against real
+ * captures) and check the original payload comes back out. The two halves were
+ * written for opposite directions, so agreeing on framing, bit order and CRC is
+ * real evidence rather than a tautology.
+ */
+
+#include <unity.h>
+
+#include <cstring>
+
+#include "core/crc_kermit.h"
+#include "core/radian_decoder.h"
+#include "core/utils.h"
+
+namespace
+{
+    // Length of the literal preamble Make_Radian_Master_req() prepends. It is
+    // sent as raw bytes, not through the serial encoder, so the round trip
+    // starts after it.
+    constexpr int SYNC_PATTERN_LEN = 9;
+
+    // The unencoded request payload: 17 bytes of fields plus a 2-byte CRC.
+    constexpr int PAYLOAD_LEN = 19;
+
+    /**
+     * @brief Turn an encode2serial_1_3() frame into the 4x oversampled sample
+     *        stream a receiver sees on air.
+     *
+     * The radio transmits at 9.6 kbps while the protocol signals at 2.4 kbps,
+     * so every logical bit occupies four identical samples, packed MSB-first
+     * exactly as the CC1101 delivers them.
+     *
+     * Two adjustments are needed to line the encoder up with the receiver:
+     *
+     *  - encode2serial_1_3() emits the first byte's start bit before any data,
+     *    whereas the receiver locks onto the stream mid-byte and treats the
+     *    first sample run as data. On air that leading bit falls inside the
+     *    preamble the receiver has already skipped, so it is dropped here.
+     *  - the frame ends in stop bits, and the receiver commits a byte only when
+     *    it processes the following separator. A separator plus an idle run is
+     *    appended so the last byte is emitted.
+     *
+     * @return Number of sample bytes written, or 0 if they would not fit.
+     */
+    int frameToAir(const uint8_t *encoded, int encodedLen, uint8_t *out, int outMax)
+    {
+        const int bitCount = encodedLen * 8 - 1 + 1 + 8; // drop start, add separator + idle
+        const int needed = bitCount * 4 / 8;
+        if (needed > outMax)
+        {
+            return 0;
+        }
+
+        std::memset(out, 0, (size_t)needed);
+        int outBit = 0;
+
+        auto emit = [&](bool value) {
+            for (int repeat = 0; repeat < 4; repeat++)
+            {
+                if (value)
+                {
+                    out[outBit / 8] |= (uint8_t)(1 << (7 - (outBit % 8)));
+                }
+                outBit++;
+            }
+        };
+
+        for (int bit = 1; bit < encodedLen * 8; bit++)
+        {
+            emit((encoded[bit / 8] >> (7 - (bit % 8))) & 1);
+        }
+
+        emit(false); // separator terminating the last byte
+        for (int i = 0; i < 8; i++)
+        {
+            emit(true); // idle, so the separator run is flushed
+        }
+
+        return needed;
+    }
+
+    /// Build a request frame and decode it back, returning the payload length.
+    int roundTrip(uint8_t year, uint32_t serial, uint8_t *payload, int payloadMax)
+    {
+        uint8_t frame[128] = {0};
+        const int frameLen = Make_Radian_Master_req(frame, year, serial);
+        TEST_ASSERT_TRUE(frameLen > SYNC_PATTERN_LEN);
+        TEST_ASSERT_TRUE(frameLen <= (int)sizeof(frame));
+
+        uint8_t air[1024];
+        const int airLen = frameToAir(frame + SYNC_PATTERN_LEN,
+                                      frameLen - SYNC_PATTERN_LEN,
+                                      air, (int)sizeof(air));
+        TEST_ASSERT_TRUE(airLen > 0);
+
+        return (int)radian_decode_4bitpbit(air, airLen, payload, payloadMax);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Round trip
+// ---------------------------------------------------------------------------
+
+void test_request_frame_round_trips_through_the_receiver(void)
+{
+    uint8_t payload[64] = {0};
+    const int len = roundTrip(21, 123456, payload, (int)sizeof(payload));
+
+    TEST_ASSERT_EQUAL_INT(PAYLOAD_LEN, len);
+
+    // The fixed RADIAN request header, as built by Make_Radian_Master_req().
+    static const uint8_t expectedHeader[4] = {0x13, 0x10, 0x00, 0x45};
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedHeader, payload, 4);
+}
+
+void test_request_frame_carries_the_meter_identity(void)
+{
+    uint8_t payload[64] = {0};
+    const int len = roundTrip(21, 123456, payload, (int)sizeof(payload));
+    TEST_ASSERT_EQUAL_INT(PAYLOAD_LEN, len);
+
+    // Year then serial, big-endian across bytes 4..7.
+    TEST_ASSERT_EQUAL_UINT8(21, payload[4]);
+    TEST_ASSERT_EQUAL_UINT8((123456 >> 16) & 0xFF, payload[5]);
+    TEST_ASSERT_EQUAL_UINT8((123456 >> 8) & 0xFF, payload[6]);
+    TEST_ASSERT_EQUAL_UINT8(123456 & 0xFF, payload[7]);
+}
+
+void test_request_frame_crc_is_valid_after_the_round_trip(void)
+{
+    uint8_t payload[64] = {0};
+    const int len = roundTrip(21, 123456, payload, (int)sizeof(payload));
+    TEST_ASSERT_EQUAL_INT(PAYLOAD_LEN, len);
+
+    const uint16_t crc = crc_kermit(payload, PAYLOAD_LEN - 2);
+    TEST_ASSERT_EQUAL_UINT8((crc >> 8) & 0xFF, payload[PAYLOAD_LEN - 2]);
+    TEST_ASSERT_EQUAL_UINT8(crc & 0xFF, payload[PAYLOAD_LEN - 1]);
+}
+
+void test_request_frame_round_trips_for_boundary_identities(void)
+{
+    struct Identity
+    {
+        uint8_t year;
+        uint32_t serial;
+    };
+
+    // Serial is carried in three bytes, so the top of the range is 0xFFFFFF.
+    static const Identity identities[] = {
+        {0, 0},
+        {0, 1},
+        {99, 0xFFFFFF},
+        {21, 0x00FF00},
+        {17, 501090},
+        {24, 1234567 & 0xFFFFFF},
+    };
+
+    for (const Identity &id : identities)
+    {
+        uint8_t payload[64] = {0};
+        const int len = roundTrip(id.year, id.serial, payload, (int)sizeof(payload));
+
+        TEST_ASSERT_EQUAL_INT(PAYLOAD_LEN, len);
+        TEST_ASSERT_EQUAL_UINT8(id.year, payload[4]);
+        TEST_ASSERT_EQUAL_UINT8((id.serial >> 16) & 0xFF, payload[5]);
+        TEST_ASSERT_EQUAL_UINT8((id.serial >> 8) & 0xFF, payload[6]);
+        TEST_ASSERT_EQUAL_UINT8(id.serial & 0xFF, payload[7]);
+
+        const uint16_t crc = crc_kermit(payload, PAYLOAD_LEN - 2);
+        TEST_ASSERT_EQUAL_UINT8((crc >> 8) & 0xFF, payload[PAYLOAD_LEN - 2]);
+        TEST_ASSERT_EQUAL_UINT8(crc & 0xFF, payload[PAYLOAD_LEN - 1]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Frame construction
+// ---------------------------------------------------------------------------
+
+void test_request_frame_starts_with_the_sync_pattern(void)
+{
+    static const uint8_t expectedSync[SYNC_PATTERN_LEN] = {
+        0x50, 0x00, 0x00, 0x00, 0x03, 0xFF, 0xFF, 0xFF, 0xFF};
+
+    uint8_t frame[128] = {0};
+    Make_Radian_Master_req(frame, 21, 123456);
+
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedSync, frame, SYNC_PATTERN_LEN);
+}
+
+void test_request_frame_length_is_stable(void)
+{
+    // The frame is fixed-format, so its length must not depend on the identity.
+    // A shorter frame for some meters would mean the CC1101 was fed a different
+    // number of bytes than the TX loop expects.
+    uint8_t frame[128] = {0};
+    const int reference = Make_Radian_Master_req(frame, 21, 123456);
+
+    TEST_ASSERT_EQUAL_INT(reference, Make_Radian_Master_req(frame, 0, 0));
+    TEST_ASSERT_EQUAL_INT(reference, Make_Radian_Master_req(frame, 99, 0xFFFFFF));
+    TEST_ASSERT_TRUE(reference > SYNC_PATTERN_LEN);
+}
+
+void test_request_frames_differ_between_meters(void)
+{
+    // Two meters must never be interrogated by the same bytes: identical frames
+    // would mean the identity was dropped somewhere in the encoding.
+    uint8_t frameA[128] = {0};
+    uint8_t frameB[128] = {0};
+
+    const int lenA = Make_Radian_Master_req(frameA, 21, 123456);
+    const int lenB = Make_Radian_Master_req(frameB, 21, 123457);
+
+    TEST_ASSERT_EQUAL_INT(lenA, lenB);
+    TEST_ASSERT_TRUE(std::memcmp(frameA, frameB, (size_t)lenA) != 0);
+}
+
+void test_request_frame_is_deterministic(void)
+{
+    uint8_t first[128] = {0};
+    uint8_t second[128] = {0};
+
+    const int lenFirst = Make_Radian_Master_req(first, 17, 501090);
+    const int lenSecond = Make_Radian_Master_req(second, 17, 501090);
+
+    TEST_ASSERT_EQUAL_INT(lenFirst, lenSecond);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(first, second, lenFirst);
+}
+
+// ---------------------------------------------------------------------------
+// Serial framing
+// ---------------------------------------------------------------------------
+
+void test_serial_encoding_round_trips_arbitrary_payloads(void)
+{
+    // encode2serial_1_3() is the framing layer on its own: whatever goes in
+    // must come back out of the receiver unchanged.
+    uint8_t input[16];
+    for (int i = 0; i < (int)sizeof(input); i++)
+    {
+        input[i] = (uint8_t)(i * 17 + 3);
+    }
+
+    uint8_t encoded[128] = {0};
+    const int encodedLen = encode2serial_1_3(input, (int)sizeof(input), encoded);
+    TEST_ASSERT_TRUE(encodedLen > (int)sizeof(input));
+
+    uint8_t air[1024];
+    const int airLen = frameToAir(encoded, encodedLen, air, (int)sizeof(air));
+    TEST_ASSERT_TRUE(airLen > 0);
+
+    uint8_t decoded[64] = {0};
+    const int decodedLen = (int)radian_decode_4bitpbit(air, airLen, decoded, (int)sizeof(decoded));
+
+    TEST_ASSERT_EQUAL_INT((int)sizeof(input), decodedLen);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(input, decoded, (int)sizeof(input));
+}
+
+void test_serial_encoding_round_trips_all_byte_values(void)
+{
+    uint8_t input[256];
+    for (int i = 0; i < 256; i++)
+    {
+        input[i] = (uint8_t)i;
+    }
+
+    // Encode in blocks so the decoder's output buffer stays a sane size.
+    for (int block = 0; block < 256; block += 16)
+    {
+        uint8_t encoded[128] = {0};
+        const int encodedLen = encode2serial_1_3(&input[block], 16, encoded);
+
+        uint8_t air[1024];
+        const int airLen = frameToAir(encoded, encodedLen, air, (int)sizeof(air));
+        TEST_ASSERT_TRUE(airLen > 0);
+
+        uint8_t decoded[64] = {0};
+        const int decodedLen = (int)radian_decode_4bitpbit(air, airLen, decoded, (int)sizeof(decoded));
+
+        TEST_ASSERT_EQUAL_INT(16, decodedLen);
+        TEST_ASSERT_EQUAL_UINT8_ARRAY(&input[block], decoded, 16);
+    }
+}

--- a/test/test_native_meter_reader/test_frequency_manager.cpp
+++ b/test/test_native_meter_reader/test_frequency_manager.cpp
@@ -1,0 +1,380 @@
+/**
+ * @file test_frequency_manager.cpp
+ * @brief Host tests for the frequency calibration engine
+ *
+ * The deep scan is the longest-running and least observable part of the
+ * firmware: on hardware a full sweep takes minutes and its decisions are only
+ * visible in the log. Against the fake radio in fakes.cpp, which answers only
+ * while tuned inside a simulated response window, the same code runs in
+ * milliseconds and every decision is assertable.
+ */
+
+#include <unity.h>
+
+#include <cmath>
+
+#include <Arduino.h>
+
+#include "native_fakes.h"
+#include "services/frequency_manager.h"
+
+namespace
+{
+    constexpr float BASE_FREQ = 433.82f;
+    constexpr float FREQEST_TO_MHZ = 0.001587f;
+
+    bool radioInit(float freq) { return cc1101_init(freq); }
+    tmeter_data readMeter() { return get_meter_data_for_meter(21, 123456); }
+
+    /// Register the fake radio with FrequencyManager and initialise it.
+    void beginManager()
+    {
+        FrequencyManager::setRadioInitCallback(radioInit);
+        FrequencyManager::setMeterReadCallback(readMeter);
+        FrequencyManager::begin(BASE_FREQ);
+    }
+
+    /// Place the simulated carrier at base + offsetKHz.
+    void placeCarrier(float offsetKHz, float widthKHz = 10.0f)
+    {
+        fakeRadio().carrierFrequency = BASE_FREQ + offsetKHz / 1000.0f;
+        fakeRadio().carrierWidthMHz = widthKHz / 1000.0f;
+    }
+
+    /**
+     * @brief Assert that the scan ended tuned somewhere the meter answers.
+     *
+     * The zoom pass stops at the first frequency that decodes, which is the
+     * lower edge of the response window rather than its centre, so the result
+     * is only guaranteed to fall inside the window (plus the one scan step the
+     * zoom starts below it). Adaptive FREQEST tracking refines it from there.
+     */
+    void assertLockedInsideWindow(float expectedOffsetKHz, float widthKHz, float stepKHz)
+    {
+        const float errorKHz = std::fabs(FrequencyManager::getOffset() * 1000.0f - expectedOffsetKHz);
+        TEST_ASSERT_TRUE_MESSAGE(errorKHz <= widthKHz + stepKHz,
+                                 "scan locked outside the meter's response window");
+    }
+}
+
+void frequencyManagerSetUp()
+{
+    resetAllFakes();
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation and persistence
+// ---------------------------------------------------------------------------
+
+void test_freq_begin_without_callbacks_is_refused(void)
+{
+    // begin() must not touch storage when it cannot drive the radio, otherwise
+    // a misconfigured caller would silently run with an unusable manager.
+    const float result = FrequencyManager::begin(BASE_FREQ);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, result);
+    TEST_ASSERT_EQUAL(0, fakeStorage().beginCalls);
+}
+
+void test_freq_begin_starts_uncalibrated_when_storage_is_empty(void)
+{
+    beginManager();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, BASE_FREQ, FrequencyManager::getTunedFrequency());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, BASE_FREQ, FrequencyManager::getBaseFrequency());
+}
+
+void test_freq_offset_survives_a_reboot(void)
+{
+    beginManager();
+    FrequencyManager::saveFrequencyOffset(-0.0175f);
+
+    // Simulate a restart: static state is cleared but storage is not.
+    FrequencyManager::setOffset(0.0f);
+    beginManager();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, -0.0175f, FrequencyManager::getOffset());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, BASE_FREQ - 0.0175f, FrequencyManager::getTunedFrequency());
+}
+
+void test_freq_offset_outside_the_valid_range_is_discarded(void)
+{
+    // A corrupted cell must not tune the radio hundreds of kHz away.
+    StorageAbstraction::saveFloat("freq_offset", 5.0f, 0xABCD);
+    beginManager();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+}
+
+void test_freq_offset_with_a_wrong_magic_is_discarded(void)
+{
+    StorageAbstraction::saveFloat("freq_offset", 0.020f, 0x1234);
+    beginManager();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+}
+
+void test_freq_auto_scan_is_requested_only_while_uncalibrated(void)
+{
+    beginManager();
+    FrequencyManager::setAutoScanEnabled(true);
+    TEST_ASSERT_TRUE(FrequencyManager::shouldPerformAutoScan());
+
+    FrequencyManager::saveFrequencyOffset(0.010f);
+    TEST_ASSERT_FALSE(FrequencyManager::shouldPerformAutoScan());
+
+    FrequencyManager::setAutoScanEnabled(false);
+    FrequencyManager::setOffset(0.0f);
+    TEST_ASSERT_FALSE(FrequencyManager::shouldPerformAutoScan());
+}
+
+// ---------------------------------------------------------------------------
+// Deep scan
+// ---------------------------------------------------------------------------
+
+void test_freq_scan_finds_a_carrier_above_the_base_frequency(void)
+{
+    beginManager();
+    placeCarrier(30.0f, 6.0f);
+
+    FrequencyManager::performDeepFrequencyScan(0.050f, 0.0025f);
+
+    TEST_ASSERT_TRUE(FrequencyManager::getOffset() > 0.0f);
+    assertLockedInsideWindow(30.0f, 6.0f, 2.5f);
+}
+
+void test_freq_scan_finds_a_carrier_below_the_base_frequency(void)
+{
+    beginManager();
+    placeCarrier(-25.0f, 6.0f);
+
+    FrequencyManager::performDeepFrequencyScan(0.050f, 0.0025f);
+
+    TEST_ASSERT_TRUE(FrequencyManager::getOffset() < 0.0f);
+    assertLockedInsideWindow(-25.0f, 6.0f, 2.5f);
+}
+
+void test_freq_scan_persists_its_result(void)
+{
+    beginManager();
+    placeCarrier(20.0f, 6.0f);
+
+    FrequencyManager::performDeepFrequencyScan(0.050f, 0.0025f);
+
+    const float saved = StorageAbstraction::loadFloat("freq_offset", 99.0f, 0xABCD);
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, FrequencyManager::getOffset(), saved);
+}
+
+void test_freq_scan_leaves_the_radio_tuned_to_the_result(void)
+{
+    beginManager();
+    placeCarrier(15.0f, 6.0f);
+
+    FrequencyManager::performDeepFrequencyScan(0.050f, 0.0025f);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, FrequencyManager::getTunedFrequency(),
+                             fakeRadio().lastInitFrequency());
+}
+
+void test_freq_scan_without_a_carrier_keeps_the_base_frequency(void)
+{
+    beginManager();
+    fakeRadio().carrierFrequency = 0.0f; // Meter never answers
+
+    FrequencyManager::performDeepFrequencyScan(0.020f, 0.0025f);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, BASE_FREQ, fakeRadio().lastInitFrequency());
+    TEST_ASSERT_EQUAL(0, fakeStorage().saveCalls);
+}
+
+void test_freq_scan_aborts_when_the_radio_stops_responding(void)
+{
+    beginManager();
+    placeCarrier(10.0f, 6.0f);
+    fakeRadio().initSucceeds = false;
+
+    FrequencyManager::performDeepFrequencyScan(0.050f, 0.0025f);
+
+    // One failed init attempt, then out: no point sweeping a dead radio.
+    TEST_ASSERT_EQUAL(0, (int)fakeRadio().calls.size());
+    TEST_ASSERT_EQUAL(0, fakeStorage().saveCalls);
+}
+
+void test_freq_scan_can_be_cancelled_and_restores_the_known_good_tuning(void)
+{
+    beginManager();
+    FrequencyManager::saveFrequencyOffset(0.012f);
+    placeCarrier(30.0f, 6.0f);
+
+    // A scan clears the cancel flag when it starts, so the request has to come
+    // from inside the sweep, as it does when the user presses stop.
+    fakeRadio().cancelScanAfterCalls = 3;
+
+    FrequencyManager::performDeepFrequencyScan(0.050f, 0.0025f);
+
+    TEST_ASSERT_EQUAL(3, (int)fakeRadio().calls.size());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.012f, FrequencyManager::getOffset());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, BASE_FREQ + 0.012f, fakeRadio().lastInitFrequency());
+}
+
+void test_freq_scan_keeps_a_good_stored_offset_when_the_candidate_is_worse(void)
+{
+    // Issue #104: a strong response tens of kHz off the true carrier must not
+    // be allowed to overwrite a calibration that is already better centred.
+    beginManager();
+    placeCarrier(0.0f, 30.0f); // Wide window centred exactly on the base frequency
+    FrequencyManager::saveFrequencyOffset(0.0f);
+
+    FrequencyManager::performDeepFrequencyScan(0.050f, 0.0025f);
+
+    // The window map hits the low edge first, so the candidate is off centre.
+    // The quality guard compares |FREQEST| and keeps the stored offset.
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+}
+
+void test_freq_scan_replaces_a_stored_offset_that_no_longer_decodes(void)
+{
+    // The meter has drifted well away from where it used to be found.
+    beginManager();
+    FrequencyManager::saveFrequencyOffset(-0.040f);
+    placeCarrier(35.0f, 5.0f);
+
+    FrequencyManager::performDeepFrequencyScan(0.060f, 0.0025f);
+
+    TEST_ASSERT_TRUE(FrequencyManager::getOffset() > 0.0f);
+    assertLockedInsideWindow(35.0f, 5.0f, 2.5f);
+}
+
+void test_freq_scan_narrow_range_visits_fewer_steps_than_a_deep_sweep(void)
+{
+    beginManager();
+    fakeRadio().carrierFrequency = 0.0f;
+
+    FrequencyManager::performDeepFrequencyScan(0.020f, 0.001f);
+    const int narrowSteps = (int)fakeRadio().calls.size();
+
+    fakeRadio().calls.clear();
+    FrequencyManager::performDeepFrequencyScan(0.150f, 0.0025f);
+    const int deepSteps = (int)fakeRadio().calls.size();
+
+    TEST_ASSERT_GREATER_THAN(narrowSteps, deepSteps);
+}
+
+// ---------------------------------------------------------------------------
+// Adaptive tracking
+// ---------------------------------------------------------------------------
+
+void test_freq_adaptive_tracking_waits_for_the_threshold(void)
+{
+    beginManager();
+    FrequencyManager::setAdaptiveThreshold(5);
+
+    for (int i = 0; i < 4; i++)
+    {
+        FrequencyManager::adaptiveFrequencyTracking(50);
+        TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+    }
+
+    FrequencyManager::adaptiveFrequencyTracking(50);
+    TEST_ASSERT_FLOAT_WITHIN(0.0005f, 50 * FREQEST_TO_MHZ * 0.5f, FrequencyManager::getOffset());
+}
+
+void test_freq_adaptive_tracking_applies_half_the_average_error(void)
+{
+    beginManager();
+    FrequencyManager::setAdaptiveThreshold(4);
+
+    // Average of 10, 20, 30, 40 is 25 LSB; half of that is applied.
+    FrequencyManager::adaptiveFrequencyTracking(10);
+    FrequencyManager::adaptiveFrequencyTracking(20);
+    FrequencyManager::adaptiveFrequencyTracking(30);
+    FrequencyManager::adaptiveFrequencyTracking(40);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.0005f, 25 * FREQEST_TO_MHZ * 0.5f, FrequencyManager::getOffset());
+}
+
+void test_freq_adaptive_tracking_cancels_symmetric_noise(void)
+{
+    beginManager();
+    FrequencyManager::setAdaptiveThreshold(4);
+
+    FrequencyManager::adaptiveFrequencyTracking(30);
+    FrequencyManager::adaptiveFrequencyTracking(-30);
+    FrequencyManager::adaptiveFrequencyTracking(25);
+    FrequencyManager::adaptiveFrequencyTracking(-25);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+}
+
+void test_freq_adaptive_tracking_corrects_downwards(void)
+{
+    beginManager();
+    FrequencyManager::setAdaptiveThreshold(2);
+
+    FrequencyManager::adaptiveFrequencyTracking(-60);
+    FrequencyManager::adaptiveFrequencyTracking(-60);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.0005f, -60 * FREQEST_TO_MHZ * 0.5f, FrequencyManager::getOffset());
+    TEST_ASSERT_TRUE(FrequencyManager::getOffset() < 0.0f);
+}
+
+void test_freq_adaptive_tracking_retunes_and_saves_after_adjusting(void)
+{
+    beginManager();
+    FrequencyManager::setAdaptiveThreshold(2);
+    fakeRadio().initFrequencies.clear();
+
+    FrequencyManager::adaptiveFrequencyTracking(40);
+    FrequencyManager::adaptiveFrequencyTracking(40);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, FrequencyManager::getTunedFrequency(),
+                             fakeRadio().lastInitFrequency());
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, FrequencyManager::getOffset(),
+                             StorageAbstraction::loadFloat("freq_offset", 99.0f, 0xABCD));
+}
+
+void test_freq_reset_adaptive_tracking_discards_the_accumulator(void)
+{
+    beginManager();
+    FrequencyManager::setAdaptiveThreshold(3);
+
+    FrequencyManager::adaptiveFrequencyTracking(60);
+    FrequencyManager::adaptiveFrequencyTracking(60);
+    FrequencyManager::resetAdaptiveTracking();
+    FrequencyManager::adaptiveFrequencyTracking(60);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+}
+
+void test_freq_scan_result_is_a_plain_tmeter_data_by_value(void)
+{
+    // PR #138: a divergent local copy of tmeter_data in frequency_manager.h
+    // undersized the caller's return slot and corrupted the stack during a
+    // scan. Reading a full struct back through the scan callback path and
+    // checking every field guards against that regressing.
+    beginManager();
+
+    tmeter_data probe = FakeRadio::success(555555, 77);
+    probe.history_available = true;
+    for (int i = 0; i < 13; i++)
+    {
+        probe.history[i] = (uint32_t)(0xA0000000u + (uint32_t)i);
+    }
+    snprintf(probe.meter_time, sizeof(probe.meter_time), "2026-04-27 09:59:49");
+    snprintf(probe.meter_type, sizeof(probe.meter_type), "133290AL02");
+    fakeRadio().responses.push_back(probe);
+
+    tmeter_data result = readMeter();
+
+    TEST_ASSERT_EQUAL_INT(555555, result.volume);
+    TEST_ASSERT_EQUAL_INT8(77, result.freqest);
+    TEST_ASSERT_TRUE(result.history_available);
+    for (int i = 0; i < 13; i++)
+    {
+        TEST_ASSERT_EQUAL_UINT32(0xA0000000u + (uint32_t)i, result.history[i]);
+    }
+    TEST_ASSERT_EQUAL_STRING("2026-04-27 09:59:49", result.meter_time);
+    TEST_ASSERT_EQUAL_STRING("133290AL02", result.meter_type);
+}

--- a/test/test_native_meter_reader/test_meter_reader.cpp
+++ b/test/test_native_meter_reader/test_meter_reader.cpp
@@ -1,0 +1,574 @@
+/**
+ * @file test_meter_reader.cpp
+ * @brief Host tests for the MeterReader orchestrator
+ *
+ * MeterReader owns the retry sequence, the post-failure cooldown, the schedule
+ * gate and the order in which results reach Home Assistant. All of that is
+ * reachable on the host through the injected interfaces plus the fake CC1101
+ * driver in fakes.cpp, so none of it needs a radio to test.
+ */
+
+#include <unity.h>
+
+#include <Arduino.h>
+
+#include "native_fakes.h"
+#include "services/meter_reader.h"
+
+namespace
+{
+    FakeConfig g_config;
+    FakeTime g_time;
+    RecordingPublisher g_publisher;
+
+    // Retry delay constant mirrored from meter_reader.cpp (file-local there).
+    constexpr unsigned long RETRY_DELAY_MS = 5000;
+
+    /// Construct a reader wired to the shared fakes and run begin().
+    MeterReader makeReader()
+    {
+        MeterReader reader(&g_config, &g_time, &g_publisher);
+        reader.begin();
+        g_publisher.reset(); // Discard the boot-time publishes
+        return reader;
+    }
+
+    /// Run loop() enough times to cross a retry deadline that has expired.
+    void advanceAndLoop(MeterReader &reader, unsigned long ms)
+    {
+        nativeClockAdvance(ms);
+        reader.loop();
+    }
+}
+
+void meterReaderSetUp()
+{
+    resetAllFakes();
+    g_config = FakeConfig();
+    g_time = FakeTime();
+    g_publisher.reset();
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation
+// ---------------------------------------------------------------------------
+
+void test_begin_reports_radio_failure(void)
+{
+    fakeRadio().initSucceeds = false;
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+
+    TEST_ASSERT_FALSE(reader.isRadioConnected());
+    TEST_ASSERT_EQUAL_STRING("unavailable", g_publisher.lastRadioState().c_str());
+    TEST_ASSERT_TRUE(g_publisher.sawStatus("Error"));
+    TEST_ASSERT_TRUE(g_publisher.sawError("CC1101 radio not responding"));
+}
+
+void test_begin_tunes_radio_to_base_plus_stored_offset(void)
+{
+    // A calibration of +12 kHz survives from a previous run.
+    StorageAbstraction::saveFloat("freq_offset", 0.012f, 0xABCD);
+    g_config.frequency = 433.82f;
+
+    MeterReader reader(&g_config, &g_time, &g_publisher);
+    reader.begin();
+
+    TEST_ASSERT_TRUE(reader.isRadioConnected());
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 433.832f, fakeRadio().lastInitFrequency());
+}
+
+void test_begin_converts_utc_reading_time_to_local(void)
+{
+    // 23:30 UTC with a +90 minute offset lands at 01:00 the next local day.
+    g_config.readHourUTC = 23;
+    g_config.readMinuteUTC = 30;
+    g_config.timezoneOffsetMinutes = 90;
+    fakeRadio().responses.push_back(FakeRadio::success());
+
+    MeterReader reader = makeReader();
+
+    g_time.setUtc(2025, 6, 10, 23, 30, 0);
+    nativeClockAdvance(1000);
+    reader.loop();
+
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+}
+
+// ---------------------------------------------------------------------------
+// Successful read
+// ---------------------------------------------------------------------------
+
+void test_successful_read_publishes_once_and_returns_to_idle(void)
+{
+    fakeRadio().responses.push_back(FakeRadio::success(98765));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL(1, (int)g_publisher.readings.size());
+    TEST_ASSERT_EQUAL(98765, g_publisher.readings[0].data.volume);
+    TEST_ASSERT_FALSE(reader.isReadingInProgress());
+    TEST_ASSERT_EQUAL_STRING("Idle", g_publisher.lastRadioState().c_str());
+    TEST_ASSERT_EQUAL_STRING("Reading successful", g_publisher.lastStatus().c_str());
+
+    // Active reading must be raised then cleared exactly once.
+    TEST_ASSERT_EQUAL(2, (int)g_publisher.activeReadingFlags.size());
+    TEST_ASSERT_TRUE(g_publisher.activeReadingFlags[0]);
+    TEST_ASSERT_FALSE(g_publisher.activeReadingFlags[1]);
+
+    unsigned long attempts = 0, successes = 0, failures = 0;
+    reader.getStatistics(attempts, successes, failures);
+    TEST_ASSERT_EQUAL_UINT32(1, attempts);
+    TEST_ASSERT_EQUAL_UINT32(1, successes);
+    TEST_ASSERT_EQUAL_UINT32(0, failures);
+}
+
+void test_successful_read_passes_configured_meter_identity(void)
+{
+    g_config.meterYear = 19;
+    g_config.meterSerial = 987654;
+    fakeRadio().responses.push_back(FakeRadio::success());
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+    TEST_ASSERT_EQUAL_UINT8(19, fakeRadio().calls[0].year);
+    TEST_ASSERT_EQUAL_UINT32(987654, fakeRadio().calls[0].serial);
+}
+
+void test_successful_read_publishes_history_only_when_available(void)
+{
+    tmeter_data withHistory = FakeRadio::success();
+    withHistory.history_available = true;
+    for (int i = 0; i < 13; i++)
+    {
+        withHistory.history[i] = (uint32_t)(1000 + i * 10);
+    }
+    fakeRadio().responses.push_back(withHistory);
+    fakeRadio().responses.push_back(FakeRadio::success()); // history_available = false
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    TEST_ASSERT_EQUAL(1, g_publisher.historyPublishes);
+
+    reader.triggerReading(false);
+    TEST_ASSERT_EQUAL(1, g_publisher.historyPublishes);
+}
+
+void test_reading_is_skipped_when_publisher_not_ready(void)
+{
+    fakeRadio().responses.push_back(FakeRadio::success());
+    MeterReader reader = makeReader();
+
+    g_publisher.ready = false;
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL(0, (int)fakeRadio().calls.size());
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.readings.size());
+    TEST_ASSERT_FALSE(reader.isReadingInProgress());
+}
+
+// ---------------------------------------------------------------------------
+// Retry sequence
+// ---------------------------------------------------------------------------
+
+void test_failed_read_schedules_retry_after_delay(void)
+{
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+    TEST_ASSERT_TRUE(reader.isReadingInProgress());
+    TEST_ASSERT_EQUAL_STRING("Retry scheduled", g_publisher.lastStatus().c_str());
+
+    // Nothing happens before the delay expires.
+    advanceAndLoop(reader, RETRY_DELAY_MS - 1);
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+
+    advanceAndLoop(reader, 1);
+    TEST_ASSERT_EQUAL(2, (int)fakeRadio().calls.size());
+}
+
+void test_retry_sequence_keeps_active_reading_raised_until_it_ends(void)
+{
+    g_config.maxRetries = 3;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+    fakeRadio().responses.push_back(FakeRadio::success());
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    advanceAndLoop(reader, RETRY_DELAY_MS);
+    advanceAndLoop(reader, RETRY_DELAY_MS);
+
+    TEST_ASSERT_EQUAL(3, (int)fakeRadio().calls.size());
+    TEST_ASSERT_EQUAL(1, (int)g_publisher.readings.size());
+
+    // The sensor is cleared exactly once, at the very end: it must not drop to
+    // false between attempts and make the sequence look finished.
+    int clears = 0;
+    for (bool flag : g_publisher.activeReadingFlags)
+    {
+        if (!flag)
+        {
+            clears++;
+        }
+    }
+    TEST_ASSERT_EQUAL(1, clears);
+    TEST_ASSERT_FALSE(g_publisher.activeReadingFlags.back());
+    TEST_ASSERT_EQUAL_STRING("Idle", g_publisher.lastRadioState().c_str());
+}
+
+void test_read_gives_up_after_max_retries(void)
+{
+    g_config.maxRetries = 3;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    advanceAndLoop(reader, RETRY_DELAY_MS);
+    advanceAndLoop(reader, RETRY_DELAY_MS);
+
+    TEST_ASSERT_EQUAL(3, (int)fakeRadio().calls.size());
+    TEST_ASSERT_FALSE(reader.isReadingInProgress());
+    TEST_ASSERT_EQUAL_STRING("Failed after max retries", g_publisher.lastStatus().c_str());
+    TEST_ASSERT_EQUAL_STRING("Idle", g_publisher.lastRadioState().c_str());
+
+    // No further attempts once the sequence has ended.
+    advanceAndLoop(reader, RETRY_DELAY_MS * 4);
+    TEST_ASSERT_EQUAL(3, (int)fakeRadio().calls.size());
+
+    unsigned long attempts = 0, successes = 0, failures = 0;
+    reader.getStatistics(attempts, successes, failures);
+    TEST_ASSERT_EQUAL_UINT32(3, attempts);
+    TEST_ASSERT_EQUAL_UINT32(0, successes);
+    TEST_ASSERT_EQUAL_UINT32(1, failures);
+}
+
+void test_single_retry_configuration_fails_immediately(void)
+{
+    g_config.maxRetries = 1;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+    TEST_ASSERT_FALSE(reader.isReadingInProgress());
+    TEST_ASSERT_EQUAL_STRING("Failed after max retries", g_publisher.lastStatus().c_str());
+}
+
+void test_final_error_keeps_the_most_informative_failure(void)
+{
+    // A run of corrupted frames ending in one silent timeout is still an RF
+    // quality problem, so the final message must not fall back to "no response".
+    g_config.maxRetries = 3;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::CrcFailed));
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::CrcFailed));
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    advanceAndLoop(reader, RETRY_DELAY_MS);
+    advanceAndLoop(reader, RETRY_DELAY_MS);
+
+    TEST_ASSERT_EQUAL_STRING(read_failure_message(ReadFailure::CrcFailed, false),
+                             g_publisher.lastError().c_str());
+}
+
+void test_no_reply_failure_reports_the_no_response_message(void)
+{
+    g_config.maxRetries = 2;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    advanceAndLoop(reader, RETRY_DELAY_MS);
+
+    TEST_ASSERT_EQUAL_STRING(read_failure_message(ReadFailure::NoReply, false),
+                             g_publisher.lastError().c_str());
+}
+
+void test_success_after_failures_clears_the_error(void)
+{
+    g_config.maxRetries = 3;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::CrcFailed));
+    fakeRadio().responses.push_back(FakeRadio::success());
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    advanceAndLoop(reader, RETRY_DELAY_MS);
+
+    TEST_ASSERT_EQUAL_STRING("None", reader.getLastError());
+
+    // The retry counter must be clear, so the next failure starts from attempt 1.
+    fakeRadio().responses.clear();
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+    fakeRadio().calls.clear();
+    reader.triggerReading(false);
+    TEST_ASSERT_TRUE(reader.isReadingInProgress());
+    TEST_ASSERT_EQUAL_STRING("Retry scheduled", g_publisher.lastStatus().c_str());
+}
+
+void test_zero_volume_reading_counts_as_a_failure(void)
+{
+    // A frame that decodes to zero volume carries no usable index, so it must
+    // be treated as a failed attempt rather than published as a real reading.
+    tmeter_data zeroVolume = FakeRadio::success();
+    zeroVolume.volume = 0;
+    g_config.maxRetries = 1;
+    fakeRadio().responses.push_back(zeroVolume);
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.readings.size());
+    TEST_ASSERT_EQUAL_STRING("Failed after max retries", g_publisher.lastStatus().c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency guard and manual stop
+// ---------------------------------------------------------------------------
+
+void test_trigger_is_ignored_while_a_sequence_is_running(void)
+{
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    TEST_ASSERT_TRUE(reader.isReadingInProgress());
+
+    reader.triggerReading(false);
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+}
+
+void test_stop_cancels_a_pending_retry(void)
+{
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    reader.stopReading();
+
+    TEST_ASSERT_FALSE(reader.isReadingInProgress());
+    TEST_ASSERT_EQUAL_STRING("Reading stopped", g_publisher.lastStatus().c_str());
+    TEST_ASSERT_EQUAL_STRING("Idle", g_publisher.lastRadioState().c_str());
+
+    advanceAndLoop(reader, RETRY_DELAY_MS * 4);
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+}
+
+void test_stop_when_idle_does_not_publish_state(void)
+{
+    MeterReader reader = makeReader();
+    reader.stopReading();
+
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.statuses.size());
+    TEST_ASSERT_EQUAL(0, (int)g_publisher.radioStates.size());
+}
+
+// ---------------------------------------------------------------------------
+// Scheduling
+// ---------------------------------------------------------------------------
+
+void test_scheduled_read_triggers_once_at_the_configured_time(void)
+{
+    // 2025-06-10 is a Tuesday.
+    g_config.schedule = "Monday-Friday";
+    g_config.readHourUTC = 10;
+    g_config.readMinuteUTC = 0;
+    fakeRadio().responses.push_back(FakeRadio::success());
+
+    MeterReader reader = makeReader();
+
+    g_time.setUtc(2025, 6, 10, 9, 59, 59);
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(0, (int)fakeRadio().calls.size());
+
+    g_time.setUtc(2025, 6, 10, 10, 0, 0);
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+
+    // Edge detection: staying inside the same minute must not re-trigger.
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+}
+
+void test_scheduled_read_is_skipped_on_a_non_reading_day(void)
+{
+    // 2025-06-08 is a Sunday.
+    g_config.schedule = "Monday-Friday";
+    fakeRadio().responses.push_back(FakeRadio::success());
+
+    MeterReader reader = makeReader();
+
+    g_time.setUtc(2025, 6, 8, 10, 0, 0);
+    nativeClockAdvance(1000);
+    reader.loop();
+
+    TEST_ASSERT_EQUAL(0, (int)fakeRadio().calls.size());
+}
+
+void test_scheduled_read_waits_for_time_sync(void)
+{
+    fakeRadio().responses.push_back(FakeRadio::success());
+    MeterReader reader = makeReader();
+
+    g_time.synced = false;
+    g_time.setUtc(2025, 6, 10, 10, 0, 0);
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(0, (int)fakeRadio().calls.size());
+
+    g_time.synced = true;
+    nativeClockAdvance(1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+}
+
+void test_cooldown_blocks_scheduled_reads_until_it_expires(void)
+{
+    g_config.maxRetries = 1;
+    g_config.retryCooldownMs = 60000;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+
+    // Still inside the cooldown: the schedule must not start another read.
+    g_time.setUtc(2025, 6, 10, 10, 0, 0);
+    nativeClockAdvance(g_config.retryCooldownMs - 1000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+
+    // Cooldown expired: the next matching schedule tick reads again.
+    nativeClockAdvance(2000);
+    reader.loop();
+    TEST_ASSERT_EQUAL(2, (int)fakeRadio().calls.size());
+}
+
+void test_statistics_are_republished_periodically(void)
+{
+    MeterReader reader = makeReader();
+
+    reader.loop();
+    const int baseline = (int)g_publisher.statistics.size();
+
+    nativeClockAdvance(300000);
+    reader.loop();
+
+    TEST_ASSERT_EQUAL(baseline + 1, (int)g_publisher.statistics.size());
+}
+
+// ---------------------------------------------------------------------------
+// Frequency handling driven from the reader
+// ---------------------------------------------------------------------------
+
+void test_auto_scan_on_failure_runs_once_per_failure_streak(void)
+{
+    g_config.maxRetries = 1;
+    g_config.autoScanOnFailure = true;
+    g_config.retryCooldownMs = 1;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+
+    reader.triggerReading(false);
+    TEST_ASSERT_TRUE(g_publisher.sawStatus("Auto frequency scan after failed reads"));
+
+    g_publisher.reset();
+    reader.triggerReading(false);
+    TEST_ASSERT_FALSE(g_publisher.sawStatus("Auto frequency scan after failed reads"));
+}
+
+void test_auto_scan_on_failure_is_rearmed_by_a_success(void)
+{
+    g_config.maxRetries = 1;
+    g_config.autoScanOnFailure = true;
+    g_config.retryCooldownMs = 1;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+
+    fakeRadio().responses.clear();
+    fakeRadio().responses.push_back(FakeRadio::success());
+    reader.triggerReading(false);
+
+    fakeRadio().responses.clear();
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+    g_publisher.reset();
+    reader.triggerReading(false);
+
+    TEST_ASSERT_TRUE(g_publisher.sawStatus("Auto frequency scan after failed reads"));
+}
+
+void test_auto_scan_on_failure_stays_off_when_disabled(void)
+{
+    g_config.maxRetries = 1;
+    g_config.autoScanOnFailure = false;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+
+    TEST_ASSERT_FALSE(g_publisher.sawStatus("Auto frequency scan after failed reads"));
+}
+
+void test_reset_frequency_offset_clears_storage_and_retunes(void)
+{
+    StorageAbstraction::saveFloat("freq_offset", 0.030f, 0xABCD);
+    g_config.frequency = 433.82f;
+
+    MeterReader reader = makeReader();
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 433.85f, fakeRadio().lastInitFrequency());
+
+    reader.resetFrequencyOffset();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 433.82f, fakeRadio().lastInitFrequency());
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, StorageAbstraction::loadFloat("freq_offset", 99.0f, 0xABCD));
+    TEST_ASSERT_FALSE(g_publisher.frequencyOffsets.empty());
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, g_publisher.frequencyOffsets.back());
+}
+
+void test_successful_reads_feed_adaptive_frequency_tracking(void)
+{
+    // Ten reads each reporting the same sizeable error must move the offset by
+    // half the average error, and persist it.
+    g_config.frequency = 433.82f;
+    fakeRadio().responses.push_back(FakeRadio::success(1000, 40));
+
+    MeterReader reader = makeReader();
+    for (int i = 0; i < 10; i++)
+    {
+        reader.triggerReading(false);
+    }
+
+    const float expected = 10 * (40 * 0.001587f) / 10 * 0.5f;
+    TEST_ASSERT_FLOAT_WITHIN(0.0005f, expected, FrequencyManager::getOffset());
+    TEST_ASSERT_FLOAT_WITHIN(0.0005f, expected,
+                             StorageAbstraction::loadFloat("freq_offset", 0.0f, 0xABCD));
+}
+
+void test_small_frequency_errors_do_not_move_the_offset(void)
+{
+    // 1 LSB is about 1.59 kHz, below the 2 kHz adaptation threshold.
+    fakeRadio().responses.push_back(FakeRadio::success(1000, 1));
+
+    MeterReader reader = makeReader();
+    for (int i = 0; i < 10; i++)
+    {
+        reader.triggerReading(false);
+    }
+
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, 0.0f, FrequencyManager::getOffset());
+}

--- a/test/test_native_meter_reader/test_meter_reader.cpp
+++ b/test/test_native_meter_reader/test_meter_reader.cpp
@@ -456,6 +456,26 @@ void test_cooldown_blocks_scheduled_reads_until_it_expires(void)
     TEST_ASSERT_EQUAL(2, (int)fakeRadio().calls.size());
 }
 
+void test_cooldown_applies_to_a_failure_at_time_zero(void)
+{
+    // millis() legitimately returns 0 for the first millisecond after boot, so
+    // the cooldown must not be keyed on the timestamp being non-zero.
+    nativeClockSet(0);
+    g_config.maxRetries = 1;
+    g_config.retryCooldownMs = 60000;
+    fakeRadio().responses.push_back(FakeRadio::failure(ReadFailure::NoReply));
+
+    MeterReader reader = makeReader();
+    reader.triggerReading(false);
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+
+    g_time.setUtc(2025, 6, 10, 10, 0, 0);
+    nativeClockAdvance(1000);
+    reader.loop();
+
+    TEST_ASSERT_EQUAL(1, (int)fakeRadio().calls.size());
+}
+
 void test_statistics_are_republished_periodically(void)
 {
     MeterReader reader = makeReader();

--- a/test/test_native_meter_reader/test_runner.cpp
+++ b/test/test_native_meter_reader/test_runner.cpp
@@ -1,0 +1,143 @@
+/**
+ * @file test_runner.cpp
+ * @brief Unity entry point for the MeterReader / FrequencyManager host suite
+ *
+ * Unity allows exactly one setUp/tearDown/main per test binary, so every test
+ * case in this folder is declared and registered here.
+ */
+
+#include <unity.h>
+
+#include "native_fakes.h"
+
+void meterReaderSetUp();
+void frequencyManagerSetUp();
+
+// test_meter_reader.cpp
+void test_begin_reports_radio_failure(void);
+void test_begin_tunes_radio_to_base_plus_stored_offset(void);
+void test_begin_converts_utc_reading_time_to_local(void);
+void test_successful_read_publishes_once_and_returns_to_idle(void);
+void test_successful_read_passes_configured_meter_identity(void);
+void test_successful_read_publishes_history_only_when_available(void);
+void test_reading_is_skipped_when_publisher_not_ready(void);
+void test_failed_read_schedules_retry_after_delay(void);
+void test_retry_sequence_keeps_active_reading_raised_until_it_ends(void);
+void test_read_gives_up_after_max_retries(void);
+void test_single_retry_configuration_fails_immediately(void);
+void test_final_error_keeps_the_most_informative_failure(void);
+void test_no_reply_failure_reports_the_no_response_message(void);
+void test_success_after_failures_clears_the_error(void);
+void test_zero_volume_reading_counts_as_a_failure(void);
+void test_trigger_is_ignored_while_a_sequence_is_running(void);
+void test_stop_cancels_a_pending_retry(void);
+void test_stop_when_idle_does_not_publish_state(void);
+void test_scheduled_read_triggers_once_at_the_configured_time(void);
+void test_scheduled_read_is_skipped_on_a_non_reading_day(void);
+void test_scheduled_read_waits_for_time_sync(void);
+void test_cooldown_blocks_scheduled_reads_until_it_expires(void);
+void test_statistics_are_republished_periodically(void);
+void test_auto_scan_on_failure_runs_once_per_failure_streak(void);
+void test_auto_scan_on_failure_is_rearmed_by_a_success(void);
+void test_auto_scan_on_failure_stays_off_when_disabled(void);
+void test_reset_frequency_offset_clears_storage_and_retunes(void);
+void test_successful_reads_feed_adaptive_frequency_tracking(void);
+void test_small_frequency_errors_do_not_move_the_offset(void);
+
+// test_frequency_manager.cpp
+void test_freq_begin_without_callbacks_is_refused(void);
+void test_freq_begin_starts_uncalibrated_when_storage_is_empty(void);
+void test_freq_offset_survives_a_reboot(void);
+void test_freq_offset_outside_the_valid_range_is_discarded(void);
+void test_freq_offset_with_a_wrong_magic_is_discarded(void);
+void test_freq_auto_scan_is_requested_only_while_uncalibrated(void);
+void test_freq_scan_finds_a_carrier_above_the_base_frequency(void);
+void test_freq_scan_finds_a_carrier_below_the_base_frequency(void);
+void test_freq_scan_persists_its_result(void);
+void test_freq_scan_leaves_the_radio_tuned_to_the_result(void);
+void test_freq_scan_without_a_carrier_keeps_the_base_frequency(void);
+void test_freq_scan_aborts_when_the_radio_stops_responding(void);
+void test_freq_scan_can_be_cancelled_and_restores_the_known_good_tuning(void);
+void test_freq_scan_keeps_a_good_stored_offset_when_the_candidate_is_worse(void);
+void test_freq_scan_replaces_a_stored_offset_that_no_longer_decodes(void);
+void test_freq_scan_narrow_range_visits_fewer_steps_than_a_deep_sweep(void);
+void test_freq_adaptive_tracking_waits_for_the_threshold(void);
+void test_freq_adaptive_tracking_applies_half_the_average_error(void);
+void test_freq_adaptive_tracking_cancels_symmetric_noise(void);
+void test_freq_adaptive_tracking_corrects_downwards(void);
+void test_freq_adaptive_tracking_retunes_and_saves_after_adjusting(void);
+void test_freq_reset_adaptive_tracking_discards_the_accumulator(void);
+void test_freq_scan_result_is_a_plain_tmeter_data_by_value(void);
+
+void setUp(void)
+{
+    // Both files share the same baseline: every fake and all of the static
+    // state inside FrequencyManager is reset before each case.
+    meterReaderSetUp();
+    frequencyManagerSetUp();
+}
+
+void tearDown(void) {}
+
+int main(int, char **)
+{
+    UNITY_BEGIN();
+
+    // MeterReader
+    RUN_TEST(test_begin_reports_radio_failure);
+    RUN_TEST(test_begin_tunes_radio_to_base_plus_stored_offset);
+    RUN_TEST(test_begin_converts_utc_reading_time_to_local);
+    RUN_TEST(test_successful_read_publishes_once_and_returns_to_idle);
+    RUN_TEST(test_successful_read_passes_configured_meter_identity);
+    RUN_TEST(test_successful_read_publishes_history_only_when_available);
+    RUN_TEST(test_reading_is_skipped_when_publisher_not_ready);
+    RUN_TEST(test_failed_read_schedules_retry_after_delay);
+    RUN_TEST(test_retry_sequence_keeps_active_reading_raised_until_it_ends);
+    RUN_TEST(test_read_gives_up_after_max_retries);
+    RUN_TEST(test_single_retry_configuration_fails_immediately);
+    RUN_TEST(test_final_error_keeps_the_most_informative_failure);
+    RUN_TEST(test_no_reply_failure_reports_the_no_response_message);
+    RUN_TEST(test_success_after_failures_clears_the_error);
+    RUN_TEST(test_zero_volume_reading_counts_as_a_failure);
+    RUN_TEST(test_trigger_is_ignored_while_a_sequence_is_running);
+    RUN_TEST(test_stop_cancels_a_pending_retry);
+    RUN_TEST(test_stop_when_idle_does_not_publish_state);
+    RUN_TEST(test_scheduled_read_triggers_once_at_the_configured_time);
+    RUN_TEST(test_scheduled_read_is_skipped_on_a_non_reading_day);
+    RUN_TEST(test_scheduled_read_waits_for_time_sync);
+    RUN_TEST(test_cooldown_blocks_scheduled_reads_until_it_expires);
+    RUN_TEST(test_statistics_are_republished_periodically);
+    RUN_TEST(test_auto_scan_on_failure_runs_once_per_failure_streak);
+    RUN_TEST(test_auto_scan_on_failure_is_rearmed_by_a_success);
+    RUN_TEST(test_auto_scan_on_failure_stays_off_when_disabled);
+    RUN_TEST(test_reset_frequency_offset_clears_storage_and_retunes);
+    RUN_TEST(test_successful_reads_feed_adaptive_frequency_tracking);
+    RUN_TEST(test_small_frequency_errors_do_not_move_the_offset);
+
+    // FrequencyManager
+    RUN_TEST(test_freq_begin_without_callbacks_is_refused);
+    RUN_TEST(test_freq_begin_starts_uncalibrated_when_storage_is_empty);
+    RUN_TEST(test_freq_offset_survives_a_reboot);
+    RUN_TEST(test_freq_offset_outside_the_valid_range_is_discarded);
+    RUN_TEST(test_freq_offset_with_a_wrong_magic_is_discarded);
+    RUN_TEST(test_freq_auto_scan_is_requested_only_while_uncalibrated);
+    RUN_TEST(test_freq_scan_finds_a_carrier_above_the_base_frequency);
+    RUN_TEST(test_freq_scan_finds_a_carrier_below_the_base_frequency);
+    RUN_TEST(test_freq_scan_persists_its_result);
+    RUN_TEST(test_freq_scan_leaves_the_radio_tuned_to_the_result);
+    RUN_TEST(test_freq_scan_without_a_carrier_keeps_the_base_frequency);
+    RUN_TEST(test_freq_scan_aborts_when_the_radio_stops_responding);
+    RUN_TEST(test_freq_scan_can_be_cancelled_and_restores_the_known_good_tuning);
+    RUN_TEST(test_freq_scan_keeps_a_good_stored_offset_when_the_candidate_is_worse);
+    RUN_TEST(test_freq_scan_replaces_a_stored_offset_that_no_longer_decodes);
+    RUN_TEST(test_freq_scan_narrow_range_visits_fewer_steps_than_a_deep_sweep);
+    RUN_TEST(test_freq_adaptive_tracking_waits_for_the_threshold);
+    RUN_TEST(test_freq_adaptive_tracking_applies_half_the_average_error);
+    RUN_TEST(test_freq_adaptive_tracking_cancels_symmetric_noise);
+    RUN_TEST(test_freq_adaptive_tracking_corrects_downwards);
+    RUN_TEST(test_freq_adaptive_tracking_retunes_and_saves_after_adjusting);
+    RUN_TEST(test_freq_reset_adaptive_tracking_discards_the_accumulator);
+    RUN_TEST(test_freq_scan_result_is_a_plain_tmeter_data_by_value);
+
+    return UNITY_END();
+}

--- a/test/test_native_meter_reader/test_runner.cpp
+++ b/test/test_native_meter_reader/test_runner.cpp
@@ -36,6 +36,7 @@ void test_scheduled_read_triggers_once_at_the_configured_time(void);
 void test_scheduled_read_is_skipped_on_a_non_reading_day(void);
 void test_scheduled_read_waits_for_time_sync(void);
 void test_cooldown_blocks_scheduled_reads_until_it_expires(void);
+void test_cooldown_applies_to_a_failure_at_time_zero(void);
 void test_statistics_are_republished_periodically(void);
 void test_auto_scan_on_failure_runs_once_per_failure_streak(void);
 void test_auto_scan_on_failure_is_rearmed_by_a_success(void);
@@ -106,6 +107,7 @@ int main(int, char **)
     RUN_TEST(test_scheduled_read_is_skipped_on_a_non_reading_day);
     RUN_TEST(test_scheduled_read_waits_for_time_sync);
     RUN_TEST(test_cooldown_blocks_scheduled_reads_until_it_expires);
+    RUN_TEST(test_cooldown_applies_to_a_failure_at_time_zero);
     RUN_TEST(test_statistics_are_republished_periodically);
     RUN_TEST(test_auto_scan_on_failure_runs_once_per_failure_streak);
     RUN_TEST(test_auto_scan_on_failure_is_rearmed_by_a_success);


### PR DESCRIPTION
Builds out host-based testing for the parts of the firmware that previously could only be exercised on a device, and fixes the defects that turned up along the way.

Host tests go from 20 to 187. Line coverage over the tested sources is 91.7%, functions 95.1%, branches 61.2%. Nothing here needs a board, a radio or a meter.

## Why

`test/test_embedded_unit/` was dead code. It could not link anywhere: `test_utils.cpp` called `crc()` and `display_hex()`, neither of which exists in the repo; its runner registered 2 of 14 test functions; and `test_config_validation.cpp` tested a pasted local copy of the schedule validator rather than the production one. Two of its assertions contradicted the actual fallback behaviour.

Beyond that, `MeterReader`, `FrequencyManager`, `MeterHistory`, the transmit path and `ESPHomeDataPublisher` had no coverage at all. Between them that is the retry and cooldown logic, the frequency calibration engine, the interrogation frame, and everything published to Home Assistant.

## Defects found

Each of these was found by writing the test, not by reading the code.

- **Stack buffer overflow when dumping a received frame as hex.** `show_in_hex_formatted()` accumulated into a 256-byte stack array with no bound. `snprintf` returns the length it *would* have written, so once the line filled, `line_pos` ran past the array size and the remaining-space argument, an unsigned subtraction, underflowed to a huge value instead of clamping. `cc1101.cpp` calls `show_in_hex_one_line(rxBuffer, pktLen)` with a whole received frame whenever one looks like RADIAN; at three characters per byte the line fills after 85 bytes, so a 124-byte frame wrote roughly 120 bytes past the end. The formatting runs regardless of log level. The new tests reproduce it as an access violation against the old code.
- **`MeterHistory::generateHistoryJson()` could return a length greater than the supplied buffer** and emit truncated, unparseable JSON that callers would then publish. It now refuses to truncate and returns 0.
- **`ESPHomeDataPublisher::publishRadioState(nullptr)` dereferenced the null.** The text sensor was guarded but the `strcmp` deriving the CC1101 Connected binary sensor was not.
- **The post-failure cooldown was skipped when a read failed at `millis() == 0`.** It used a non-zero timestamp as its "running" flag, so a failure in the first millisecond after boot left the scheduler free to retry immediately.

Also fixed: `ScheduleManager::isValidSchedule(nullptr)` passed the null straight to `strcmp`.

## User-visible change: ESPHome RSSI percentage

The ESPHome publisher carried its own copy of the dBm-to-percentage conversion, mapping −120..−50 dBm onto 0-100%, while the shared helper in `utils.cpp` maps −120..−40. The same reading was therefore **logged as one figure and published as another**: −70 dBm appeared as 62% in the device log and 71% in the `rssi_percentage` sensor. That is a contradiction inside a single build, not just a difference between the two deployment targets.

Both now use the shared helper. ESPHome values drop slightly:

| RSSI | Before | After |
| --- | ---: | ---: |
| −100 dBm | 28% | 25% |
| −70 dBm | 71% | 62% |
| −50 dBm | 100% | 87% |

Expect a one-off step down in Home Assistant history and retune any automation thresholds set against that entity. MQTT values and the LQI percentage are unchanged. Recorded in the changelog, and both READMEs now note that the scale is an arbitrary display convenience rather than a calibrated measurement.

## What was added

Five host suites, across two PlatformIO environments:

| Suite | Covers |
| --- | --- |
| `test_embedded_unit/` | Repaired and host-enabled. Schedule rules, meter code parsing, CRC-16/KERMIT, history maths and JSON, hex/binary dump bounds |
| `test_native_meter_fixtures/` | Existing capture replay, plus a transmit round trip and exhaustive single-bit-flip mutation over every fixture |
| `test_native_meter_reader/` | Retry backoff, cooldown, schedule gating and edge detection, failure classification, publish ordering, scan lock and abort, calibration quality guard, adaptive FREQEST tracking |
| `test_native_esphome_publisher/` | Sensor population and formatting, history payload and fallbacks, null handling, unit conversions, shared-sensor registration |
| `test_native_esphome_reader/` | The `USE_ESPHOME` branches of `MeterReader`: no idle states published at boot, scheduled reads gated on the Home Assistant API |

Three pieces of infrastructure make that possible:

- **`test/native_shims/Arduino.h`** — minimal Arduino stand-in, on the include path only for the host environments. The clock is virtual and advanced explicitly by the tests, so retry delays and cooldowns run instantly and deterministically. Nothing ever sleeps.
- **`test/native_fakes.{h,cpp}`** — link-time replacements for the CC1101 free functions, `StorageAbstraction` and the WiFi serial mirror, plus recording implementations of the three adapter interfaces. The fake radio either replays a script of outcomes or simulates a carrier at a chosen offset that answers only inside its response window with a proportional FREQEST. That is what makes a deep frequency scan testable in milliseconds instead of the minutes a real sweep takes.
- **`[env:native_esphome]`** — builds the shared sources the way the shipped external component does, with `USE_ESPHOME` defined and the source tree flattened onto the include path, against recording ESPHome sensor stubs. Those stubs are on that environment's include path only, so `__has_include("esphome/core/log.h")` stays false for the MQTT-mode suites.

The transmit round trip is worth calling out: rather than assert the encoder's output byte by byte, which would only restate the implementation, `Make_Radian_Master_req()` output is oversampled as the radio would put it on air and pushed back through `radian_decode_4bitpbit()`, the same receiver the captured fixtures run through. The two halves were written for opposite directions, so agreeing on framing, bit order and CRC is real evidence.

Both host environments now build with `-fstack-protector-all`, so a future overrun aborts the test binary rather than corrupting memory quietly.

## Running it

```powershell
pip install -r scripts/requirements-dev.txt   # first time only
./scripts/run-tests.ps1 -Build
```

`scripts/run-tests.ps1` runs the same steps as CI in the same order and prints a pass/fail summary. Steps whose tooling is missing are reported as skipped rather than failing. `-Coverage` adds the gcovr report, `-All` does both, `-Serial` shows the firmware's own log output.

CI runs `pio test -e native_esphome` alongside `pio test -e native`, and coverage now includes `utils.cpp`, `frequency_manager.cpp`, `meter_history.cpp`, `meter_reader.cpp` and `esphome_data_publisher.cpp`.

## Not covered

The MQTT publishing and Home Assistant discovery in `main.cpp` talk to `EspMQTTClient` and WiFi inline, so there is no link seam to exploit. Testing it needs a real extraction into a publisher class, which is a refactor rather than a test change. It remains the largest untested surface. The boot sequence, `wifi_serial.cpp` and OTA are deliberately left alone.

`ESPHOME-release/` changes are generated output from the pre-commit hook.
