### PR TITLE
Log which meter a frequency scan targets in multi-meter setups

### DIFF
--- a/ESPHOME-release/everblu_meter/meter_reader.cpp
+++ b/ESPHOME-release/everblu_meter/meter_reader.cpp
@@ -498,10 +498,18 @@ void MeterReader::handleFailedRead(ReadFailure reason)
         // manual scan still get recalibrated. The guard is reset on the next
         // successful read so we don't burn power scanning on every cooldown
         // when the meter is genuinely unreachable (e.g. dead battery).
+        //
+        // In multi-meter setups this always scans against THIS meter (the one
+        // that just exhausted its retries) - activateCallbackContext() was set
+        // for it at the start of performReading(), so the scan's RF responses
+        // come from the same meter, not whichever meter last pressed a button.
         if (m_config->isAutoScanOnFailureEnabled() && !m_autoScanAfterFailureDone)
         {
             m_autoScanAfterFailureDone = true;
-            LOG_W("everblu_meter", "Running automatic frequency scan to check for meter offset drift... (disable with auto_scan_on_failure / AUTO_SCAN_ON_FAILURE_ENABLED)");
+            LOG_W("everblu_meter",
+                  "Running automatic frequency scan for meter %02u-%06lu after failed reads... "
+                  "(disable with auto_scan_on_failure / AUTO_SCAN_ON_FAILURE_ENABLED)",
+                  m_config->getMeterYear(), (unsigned long) m_config->getMeterSerial());
             m_publisher->publishStatusMessage("Auto frequency scan after failed reads");
             // Narrow ±20 kHz / 1 kHz scan: fast re-tune after drift failure.
             // The full ±150 kHz deep scan is reserved for manual commands and
@@ -558,7 +566,20 @@ void MeterReader::performFrequencyScan()
         return;
     }
 
-    LOG_I("everblu_meter", "Starting frequency scan...");
+    // Two DIFFERENT things are being reported here, and in a multi-meter setup
+    // they can disagree:
+    //   - the meter INTERROGATED is this instance's meter (activateCallbackContext
+    //     above points the shared FrequencyManager callbacks at this reader);
+    //   - the frequency SWEPT is centred on FrequencyManager's single global
+    //     s_baseFrequency, which is whichever meter entry ran begin() LAST.
+    // If the two lines below show a centre that isn't this meter's configured
+    // frequency, the entries disagree on `frequency` and the scan window (and
+    // the narrow auto-scan-on-failure window especially) may be centred wrongly.
+    LOG_I("everblu_meter", "Starting frequency scan using meter %02u-%06lu (%s)...",
+          m_config->getMeterYear(), (unsigned long) m_config->getMeterSerial(),
+          m_config->isMeterGas() ? "gas" : "water");
+    LOG_I("everblu_meter", "Scan centred on %.6f MHz (this meter is configured for %.6f MHz)",
+          FrequencyManager::getBaseFrequency(), m_config->getFrequency());
 
     // Non-blocking: loop() steps the scan and publishes the result when it ends.
     FrequencyManager::beginDeepFrequencyScan();

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -9,56 +9,58 @@ Native ESPHome external component for reading EverBlu Cyble Enhanced water and g
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Documentation](#documentation)
-  - [For End Users](#for-end-users)
-  - [For Developers](#for-developers)
-- [Quick Start](#quick-start)
-- [Breaking Change: SPI Configuration Required](#breaking-change-spi-configuration-required)
-  - [1. Use as External Component](#1-use-as-external-component)
-  - [2. Build and Upload](#2-build-and-upload)
-- [ESPHome Device Builder (Visual Dashboard)](#esphome-device-builder-visual-dashboard)
-- [Board-Specific Configuration](#board-specific-configuration)
-  - [Arduino Nano ESP32 (ESP32S3)](#arduino-nano-esp32-esp32s3)
-  - [Other ESP32 Boards](#other-esp32-boards)
-- [Configuration Reference](#configuration-reference)
-  - [Key Parameters](#key-parameters)
-  - [Schedule Options](#schedule-options)
-  - [Custom Schedule Example](#custom-schedule-example)
-  - [Logging](#logging)
-  - [Timezone Adjustment](#timezone-adjustment)
-- [Features](#features)
-- [Example Configurations](#example-configurations)
-- [Hardware Requirements](#hardware-requirements)
-  - [Wiring (ESP8266 D1 Mini)](#wiring-esp8266-d1-mini)
-  - [Wiring (ESP32)](#wiring-esp32)
-- [Benefits](#benefits)
-  - [vs. Standalone MQTT Mode](#vs-standalone-mqtt-mode)
-  - [ESPHome Mode Advantages](#esphome-mode-advantages)
-- [Home Assistant Best Practice: Utility Meter Helper](#home-assistant-best-practice-utility-meter-helper)
-  - [Migrating Sensor History Between Platforms](#migrating-sensor-history-between-platforms)
-  - [Historical Data from Meter](#historical-data-from-meter)
-- [Architecture](#architecture)
-- [Available Sensors](#available-sensors)
-  - [Numeric Sensors](#numeric-sensors)
-  - [Text Sensors](#text-sensors)
-  - [Binary Sensors](#binary-sensors)
-  - [Control Buttons](#control-buttons)
-- [Common Configuration Patterns](#common-configuration-patterns)
-  - [Water Meter - Basic](#water-meter---basic)
-  - [Gas Meter - Basic](#gas-meter---basic)
-  - [With Full Monitoring](#with-full-monitoring)
-- [Troubleshooting](#troubleshooting)
-  - [Corrupted or Invalid Volume Readings](#corrupted-or-invalid-volume-readings)
-  - [No Meter Response](#no-meter-response)
-  - [Signal Quality Issues](#signal-quality-issues)
-- [Quick Troubleshooting](#quick-troubleshooting)
-  - [Quick Fixes](#quick-fixes)
-- [License](#license)
-- [Credits](#credits)
-- [Links](#links)
-- [Development: Code Style & Formatting](#development-code-style--formatting)
-  - [Running the formatter](#running-the-formatter)
-  - [Linting & pre-commit](#linting--pre-commit)
+- [ESPHome Integration for EverBlu Cyble Enhanced Meters](#esphome-integration-for-everblu-cyble-enhanced-meters)
+  - [Documentation](#documentation)
+    - [For End Users](#for-end-users)
+    - [For Developers](#for-developers)
+  - [Quick Start](#quick-start)
+  - [Breaking Change: SPI Configuration Required](#breaking-change-spi-configuration-required)
+    - [1. Use as External Component](#1-use-as-external-component)
+    - [2. Build and Upload](#2-build-and-upload)
+  - [ESPHome Device Builder (Visual Dashboard)](#esphome-device-builder-visual-dashboard)
+  - [Board-Specific Configuration](#board-specific-configuration)
+    - [Arduino Nano ESP32 (ESP32S3)](#arduino-nano-esp32-esp32s3)
+    - [Other ESP32 Boards](#other-esp32-boards)
+  - [Configuration Reference](#configuration-reference)
+    - [Key Parameters](#key-parameters)
+    - [Schedule Options](#schedule-options)
+    - [Custom Schedule Example](#custom-schedule-example)
+    - [Logging](#logging)
+    - [Timezone Adjustment](#timezone-adjustment)
+  - [Features](#features)
+  - [Example Configurations](#example-configurations)
+  - [Hardware Requirements](#hardware-requirements)
+    - [Wiring (ESP8266 D1 Mini)](#wiring-esp8266-d1-mini)
+    - [Wiring (ESP32)](#wiring-esp32)
+  - [Benefits](#benefits)
+    - [vs. Standalone MQTT Mode](#vs-standalone-mqtt-mode)
+    - [ESPHome Mode Advantages](#esphome-mode-advantages)
+  - [Home Assistant Best Practice: Utility Meter Helper](#home-assistant-best-practice-utility-meter-helper)
+    - [Migrating Sensor History Between Platforms](#migrating-sensor-history-between-platforms)
+    - [Historical Data from Meter](#historical-data-from-meter)
+  - [Architecture](#architecture)
+  - [Available Sensors](#available-sensors)
+    - [Numeric Sensors](#numeric-sensors)
+    - [Text Sensors](#text-sensors)
+    - [Binary Sensors](#binary-sensors)
+    - [Control Buttons](#control-buttons)
+    - [Frequency scans in multi-meter setups](#frequency-scans-in-multi-meter-setups)
+  - [Common Configuration Patterns](#common-configuration-patterns)
+    - [Water Meter - Basic](#water-meter---basic)
+    - [Gas Meter - Basic](#gas-meter---basic)
+    - [With Full Monitoring](#with-full-monitoring)
+  - [Troubleshooting](#troubleshooting)
+    - [Corrupted or Invalid Volume Readings](#corrupted-or-invalid-volume-readings)
+    - [No Meter Response](#no-meter-response)
+    - [Signal Quality Issues](#signal-quality-issues)
+  - [Quick Troubleshooting](#quick-troubleshooting)
+    - [Quick Fixes](#quick-fixes)
+  - [License](#license)
+  - [Credits](#credits)
+  - [Links](#links)
+  - [Development: Code Style \& Formatting](#development-code-style--formatting)
+    - [Running the formatter](#running-the-formatter)
+    - [Linting \& pre-commit](#linting--pre-commit)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -586,6 +588,50 @@ EverbluMeterComponent (ESPHome)
 - **stop_reading_button** - Cancel the current read/retry sequence. Also requests best-effort cancellation of an in-progress deep frequency scan (it bails at the next step; see [#133](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/133))
 - **deep_scan_button** - Trigger a Deep frequency scan (±150 kHz, fine 2.5 kHz steps, maps the response window then zooms to the carrier centre)
 - **reset_frequency_button** - Reset the frequency offset
+
+### Frequency scans in multi-meter setups
+
+Frequency calibration is **radio-global, not per-meter**. There is one base
+frequency, one stored offset and one tuned frequency for the whole device, no
+matter how many `everblu_meter:` entries you declare. A scan therefore has two
+separate properties that can disagree:
+
+| Property | Scope |
+| --- | --- |
+| Which meter answers the scan | Per-entry: the meter on the `everblu_meter:` entry that triggered it |
+| Which frequency range is swept | Global: centred on the single base frequency |
+| Where the resulting offset is stored | Global: one value, applied to every meter |
+
+The meter that answers is whichever entry triggered the scan. For a manual
+`deep_scan_button` press that is the entry declaring the button. For the
+automatic scan run by `auto_scan_on_failure` (enabled by default) it is the
+meter that just exhausted its own `max_retries`, which need not be the entry
+the button was declared on. Both cases are named in the log:
+
+```text
+Starting frequency scan using meter 20-0257750 (water)...
+Scan centred on 433.820007 MHz (this meter is configured for 433.782712 MHz)
+Running automatic frequency scan for meter 20-0259301 after failed reads...
+```
+
+The swept range, however, is **not** per-meter. It is centred on the base
+frequency held in the shared `FrequencyManager`, which is set by whichever
+entry initialised **last** during boot. Because of this:
+
+> [!IMPORTANT]
+> Every `everblu_meter:` entry sharing one CC1101 must be given the **same**
+> `frequency:` value. If they differ, only the last entry's value takes effect
+> and the others are silently ignored, so scans (and normal reads) run at a
+> frequency that no longer matches those meters' configuration. The wide
+> ±150 kHz manual deep scan will usually still find the carrier, but the narrow
+> ±20 kHz `auto_scan_on_failure` window can end up centred well away from it.
+
+If you need genuinely independent calibration per meter, use one CC1101 (and
+one ESP) per meter. Declare `deep_scan_button`, `reset_frequency_button` and
+the offset/tuned-frequency sensors on the **first** meter entry only, as in
+[example-multi-meter.yaml](example-multi-meter.yaml); adding extra scan buttons
+on other entries only changes which meter answers, not the swept range or the
+shared offset.
 
 ## Common Configuration Patterns
 

--- a/ESPHOME/example-multi-meter.yaml
+++ b/ESPHOME/example-multi-meter.yaml
@@ -102,9 +102,26 @@ everblu_meter:
     request_reading_button:
       name: "${meter_1_prefix} Read Meter Now"
       device_id: water_meter_device_1
-    # Frequency calibration is a property of the shared CC1101 radio, not the meter.
-    # Declare these buttons/sensors on ONE meter only (here, the first). They are
-    # global: any meter's reads/scans update this single set of entities.
+    # Frequency calibration is a property of the shared CC1101 radio, not the
+    # meter. Declare these buttons/sensors on METER 1 ONLY - there is one base
+    # frequency, one offset and one tuned frequency for the whole device.
+    #
+    # Every entry must use the SAME `frequency:` value (all entries here use the
+    # default). FrequencyManager::begin() is called per entry and overwrites a
+    # single global, so only the LAST entry's value takes effect and any others
+    # are silently ignored.
+    #
+    # A scan has two properties that can disagree:
+    #   - which METER answers: the entry that triggered the scan. For this button
+    #     that is meter 1; for the automatic auto_scan_on_failure scan it is
+    #     whichever meter just exhausted its own retries.
+    #   - which FREQUENCIES are swept: always centred on the single global base
+    #     frequency, never on the triggering entry's `frequency:`.
+    # Both are logged at scan start, e.g.
+    #   Starting frequency scan using meter 20-0257750 (water)...
+    #   Scan centred on 433.820007 MHz (this meter is configured for 433.820007 MHz)
+    #
+    # For genuinely independent calibration, use one CC1101 (and one ESP) per meter.
     deep_scan_button:
       name: "Radio Deep Frequency Scan"
     reset_frequency_button:
@@ -227,8 +244,13 @@ everblu_meter:
     stop_reading_button:
       name: "${meter_2_prefix} Stop Reading"
       device_id: water_meter_device_2
-    # Frequency calibration buttons/sensors are radio-global and declared on the
-    # first meter only (see water_meter_1 above); they act on the shared CC1101.
+    # No frequency calibration entities here. deep_scan_button,
+    # reset_frequency_button and the offset/tuned-frequency sensors are
+    # radio-global and are declared on meter 1 only (see water_meter_1 above).
+    #
+    # Do NOT set `frequency:` here to a different value from water_meter_1 -
+    # there is a single global base frequency and the last entry to initialise
+    # silently wins.
 
     volume:
       name: "${meter_2_prefix} Water Volume"

--- a/src/services/meter_reader.cpp
+++ b/src/services/meter_reader.cpp
@@ -498,10 +498,18 @@ void MeterReader::handleFailedRead(ReadFailure reason)
         // manual scan still get recalibrated. The guard is reset on the next
         // successful read so we don't burn power scanning on every cooldown
         // when the meter is genuinely unreachable (e.g. dead battery).
+        //
+        // In multi-meter setups this always scans against THIS meter (the one
+        // that just exhausted its retries) - activateCallbackContext() was set
+        // for it at the start of performReading(), so the scan's RF responses
+        // come from the same meter, not whichever meter last pressed a button.
         if (m_config->isAutoScanOnFailureEnabled() && !m_autoScanAfterFailureDone)
         {
             m_autoScanAfterFailureDone = true;
-            LOG_W("everblu_meter", "Running automatic frequency scan to check for meter offset drift... (disable with auto_scan_on_failure / AUTO_SCAN_ON_FAILURE_ENABLED)");
+            LOG_W("everblu_meter",
+                  "Running automatic frequency scan for meter %02u-%06lu after failed reads... "
+                  "(disable with auto_scan_on_failure / AUTO_SCAN_ON_FAILURE_ENABLED)",
+                  m_config->getMeterYear(), (unsigned long) m_config->getMeterSerial());
             m_publisher->publishStatusMessage("Auto frequency scan after failed reads");
             // Narrow ±20 kHz / 1 kHz scan: fast re-tune after drift failure.
             // The full ±150 kHz deep scan is reserved for manual commands and
@@ -558,7 +566,20 @@ void MeterReader::performFrequencyScan()
         return;
     }
 
-    LOG_I("everblu_meter", "Starting frequency scan...");
+    // Two DIFFERENT things are being reported here, and in a multi-meter setup
+    // they can disagree:
+    //   - the meter INTERROGATED is this instance's meter (activateCallbackContext
+    //     above points the shared FrequencyManager callbacks at this reader);
+    //   - the frequency SWEPT is centred on FrequencyManager's single global
+    //     s_baseFrequency, which is whichever meter entry ran begin() LAST.
+    // If the two lines below show a centre that isn't this meter's configured
+    // frequency, the entries disagree on `frequency` and the scan window (and
+    // the narrow auto-scan-on-failure window especially) may be centred wrongly.
+    LOG_I("everblu_meter", "Starting frequency scan using meter %02u-%06lu (%s)...",
+          m_config->getMeterYear(), (unsigned long) m_config->getMeterSerial(),
+          m_config->isMeterGas() ? "gas" : "water");
+    LOG_I("everblu_meter", "Scan centred on %.6f MHz (this meter is configured for %.6f MHz)",
+          FrequencyManager::getBaseFrequency(), m_config->getFrequency());
 
     // Non-blocking: loop() steps the scan and publishes the result when it ends.
     FrequencyManager::beginDeepFrequencyScan();

--- a/test/test_native_meter_reader/test_meter_reader.cpp
+++ b/test/test_native_meter_reader/test_meter_reader.cpp
@@ -660,6 +660,27 @@ void test_a_running_scan_blocks_reads_and_further_scan_requests(void)
     drainFrequencyScan(reader);
 }
 
+void test_a_gas_meter_scans_the_same_as_a_water_meter(void)
+{
+    // Meter type only changes how a reading is reported, never how the radio is
+    // calibrated, so a gas-configured reader must drive the sweep identically.
+    // This also covers the gas arm of the scan-start diagnostics, which is the
+    // only place performFrequencyScan() branches on meter type.
+    g_config.meterIsGas = true;
+    g_config.frequency = 433.82f;
+
+    MeterReader reader = makeReader();
+    reader.performFrequencyScan();
+
+    TEST_ASSERT_TRUE(FrequencyManager::isScanInProgress());
+    TEST_ASSERT_EQUAL_STRING("Frequency Scanning", g_publisher.lastRadioState().c_str());
+
+    drainFrequencyScan(reader);
+
+    TEST_ASSERT_FALSE(FrequencyManager::isScanInProgress());
+    TEST_ASSERT_EQUAL_STRING("Idle", g_publisher.lastRadioState().c_str());
+}
+
 void test_reset_frequency_offset_clears_storage_and_retunes(void)
 {
     StorageAbstraction::saveFloat("freq_offset", 0.030f, 0xABCD);

--- a/test/test_native_meter_reader/test_runner.cpp
+++ b/test/test_native_meter_reader/test_runner.cpp
@@ -44,6 +44,7 @@ void test_auto_scan_on_failure_is_rearmed_by_a_success(void);
 void test_auto_scan_on_failure_stays_off_when_disabled(void);
 void test_a_scan_is_only_stepped_by_the_reader_that_started_it(void);
 void test_a_running_scan_blocks_reads_and_further_scan_requests(void);
+void test_a_gas_meter_scans_the_same_as_a_water_meter(void);
 void test_reset_frequency_offset_clears_storage_and_retunes(void);
 void test_successful_reads_feed_adaptive_frequency_tracking(void);
 void test_small_frequency_errors_do_not_move_the_offset(void);
@@ -131,6 +132,7 @@ int main(int, char **)
     RUN_TEST(test_auto_scan_on_failure_stays_off_when_disabled);
     RUN_TEST(test_a_scan_is_only_stepped_by_the_reader_that_started_it);
     RUN_TEST(test_a_running_scan_blocks_reads_and_further_scan_requests);
+    RUN_TEST(test_a_gas_meter_scans_the_same_as_a_water_meter);
     RUN_TEST(test_reset_frequency_offset_clears_storage_and_retunes);
     RUN_TEST(test_successful_reads_feed_adaptive_frequency_tracking);
     RUN_TEST(test_small_frequency_errors_do_not_move_the_offset);


### PR DESCRIPTION
## Summary

In a multi-meter setup (several `everblu_meter:` entries sharing one CC1101) there was no way to tell which meter a frequency scan was actually interrogating, and the documentation was misleading about what is per-meter versus radio-global.

## What is actually per-meter

Investigating this surfaced that a scan has two independent properties which can disagree:

| Property | Scope |
| --- | --- |
| Which meter answers the scan | **Per-entry** |
| Which frequency range is swept | **Global** |
| Where the resulting offset is stored | **Global** |

*Which meter answers* is per-entry. `set_parent(var)` binds each button to its own component, so `performFrequencyScan()` calls `activateCallbackContext()` and the scan interrogates that entry's year/serial. The `auto_scan_on_failure` scan likewise runs on whichever reader just exhausted its own `max_retries`, which need not be the entry declaring the button.

*Which frequencies are swept* is **not** per-meter. `FrequencyManager` is entirely static, and `MeterReader::begin()` calls `FrequencyManager::begin(frequency)` in every component's `setup()`, each overwriting the single global `s_baseFrequency`. The last entry to initialise wins, so entries configured with differing `frequency:` values are silently ignored except for the last one. The wide ±150 kHz manual scan usually still finds the carrier, but the narrow ±20 kHz `auto_scan_on_failure` window can end up centred well away from it.

## Changes

- `src/services/meter_reader.cpp`
  - `performFrequencyScan()` logs the meter code being interrogated, plus the scan centre alongside that entry's configured frequency so a mismatch is visible at a glance.
  - `handleFailedRead()` names the meter in the auto-scan-on-failure warning.
- `ESPHOME/README.md` - new "Frequency scans in multi-meter setups" section with the scope table and an explicit warning that all entries sharing a radio must use the same `frequency:`.
- `ESPHOME/example-multi-meter.yaml` - corrected comments; calibration buttons/sensors stay on meter 1 only.
- `ESPHOME-release/everblu_meter/meter_reader.cpp` - regenerated via `prepare-component-release.ps1`.

Example log output:

```text
Starting frequency scan using meter 20-0257750 (water)...
Scan centred on 433.820007 MHz (this meter is configured for 433.782712 MHz)
Running automatic frequency scan for meter 20-0259301 after failed reads...
```

## Notes for the reviewer

This is diagnostics and documentation only: no behaviour change to the scan or read paths.

Two follow-ups are deliberately **not** included here, and are worth deciding separately:

1. Whether ESPHome config validation should reject differing `frequency:` values across entries sharing an SPI bus, rather than silently letting the last one win.
2. Whether `dump_config` should report the effective global frequency instead of the per-entry value (it currently prints the per-entry one, which can be untrue at runtime).

## Testing

`pio test -e native` - 161/161 passing.
