### PR TITLE
Fail radio init when the CC1101 SPI link cannot be trusted

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,7 @@ on:
       - test/native_esphome/**
       - test/native_fakes.*
       - test/native_shims/**
+      - test/test_native_cc1101_link/**
       - test/test_native_esphome_publisher/**
       - test/test_native_meter_fixtures/**
       - test/test_native_meter_reader/**
@@ -26,6 +27,7 @@ on:
       - test/native_esphome/**
       - test/native_fakes.*
       - test/native_shims/**
+      - test/test_native_cc1101_link/**
       - test/test_native_esphome_publisher/**
       - test/test_native_meter_fixtures/**
       - test/test_native_meter_reader/**
@@ -79,6 +81,7 @@ jobs:
         run: |
           pio test -e native -v
           pio test -e native_esphome -v
+          pio test -e native_cc1101 -v
 
       - name: Collect coverage
         # --object-directory spans both native environments, which compile several
@@ -89,6 +92,7 @@ jobs:
         run: |
           gcovr \
             --root . \
+            --filter src/core/cc1101.cpp \
             --filter src/core/crc_kermit.cpp \
             --filter src/core/radian_parser.cpp \
             --filter src/core/radian_decoder.cpp \

--- a/.github/workflows/meter-fixture-tests.yml
+++ b/.github/workflows/meter-fixture-tests.yml
@@ -11,6 +11,7 @@ on:
       - test/native_esphome/**
       - test/native_fakes.*
       - test/native_shims/**
+      - test/test_native_cc1101_link/**
       - test/test_native_esphome_publisher/**
       - test/test_native_meter_fixtures/**
       - test/test_native_meter_reader/**
@@ -26,6 +27,7 @@ on:
       - test/native_esphome/**
       - test/native_fakes.*
       - test/native_shims/**
+      - test/test_native_cc1101_link/**
       - test/test_native_esphome_publisher/**
       - test/test_native_meter_fixtures/**
       - test/test_native_meter_reader/**
@@ -82,3 +84,7 @@ jobs:
       - name: Run native ESPHome publisher tests
         run: |
           pio test -e native_esphome -v
+
+      - name: Run native CC1101 driver tests
+        run: |
+          pio test -e native_cc1101 -v

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -663,6 +663,92 @@ void cc1101_configureRF_0(float freq)
   SPIWriteBurstReg(PATABLE_ADDR, PA, 8);
 }
 
+/**
+ * Verify the SPI link to the CC1101 before trusting anything the radio reports.
+ *
+ * The previous check only rejected VERSION 0x00 and 0xFF, which let a broken bus pass
+ * whenever MISO was stuck at any other constant. Every register then read back that same
+ * value, so RSSI/LQI/MARCSTATE and the whole RX FIFO looked like plausible-but-wrong data
+ * and the failure surfaced much later as an unexplained CRC error.
+ *
+ * The decisive test is a write/read-back on a scratch register using two complementary
+ * patterns. A constant MISO cannot follow both, so this catches a stuck line at any value,
+ * a missing device, a wrong MISO pin, a bus multiplexer left in the wrong position, and a
+ * second SPI device holding the line. SYNC1/SYNC0 are used as the scratch pair because
+ * cc1101_configureRF_0() rewrites both immediately afterwards.
+ *
+ * @return true when the radio is present and the bus is trustworthy.
+ */
+static bool cc1101_verify_spi_link(void)
+{
+  // Round 1 then round 2 use complementary patterns, so between them every data bit is
+  // driven both high and low in each direction.
+  static const uint8_t kProbe[2][2] = {{0xAA, 0x55}, {0x55, 0xAA}};
+  bool readback_ok = true;
+  for (uint8_t round = 0; round < 2 && readback_ok; round++)
+  {
+    halRfWriteReg(SYNC1, kProbe[round][0]);
+    halRfWriteReg(SYNC0, kProbe[round][1]);
+    if (halRfReadReg(SYNC1) != kProbe[round][0] || halRfReadReg(SYNC0) != kProbe[round][1])
+    {
+      readback_ok = false;
+    }
+  }
+
+  uint8_t partnum = halRfReadReg(PARTNUM_ADDR);
+  uint8_t version = halRfReadReg(VERSION_ADDR);
+
+  if (!readback_ok)
+  {
+    // Distinguish "every read returns the same byte" (stuck/undriven MISO, or another
+    // device owning the line) from a generally unreliable bus, so the remedy is specific.
+    uint8_t marcstate = halRfReadReg(MARCSTATE_ADDR);
+    bool stuck_at_constant = (partnum == version) && (version == marcstate);
+
+    LOG_E("everblu_meter", "CC1101 SPI self-test FAILED - register write/read-back did not match (PARTNUM: 0x%02X, VERSION: 0x%02X, MARCSTATE: 0x%02X)", partnum, version, marcstate);
+    if (stuck_at_constant)
+    {
+      LOG_E("everblu_meter", "Every register read returned 0x%02X, so MISO is stuck and the radio is not really being read. Check: 1) miso_pin is correct for this board 2) any bus-routing/mux GPIO is set to reach the CC1101 3) other SPI radios (nRF24, SX127x) on this bus are isolated or hold their CS high 4) 3.3V supply and CS/SCK/MOSI wiring.", version);
+    }
+    else
+    {
+      LOG_E("everblu_meter", "Check: 1) CS/SCK/MOSI/MISO wiring and pin assignment 2) 3.3V power supply 3) lower the SPI data_rate 4) other SPI devices sharing this bus.");
+    }
+    return false;
+  }
+
+  // The link works. Re-read VERSION a few times: a device that answers correctly but
+  // inconsistently points at contention from another device or an over-fast/noisy bus.
+  for (uint8_t i = 0; i < 8; i++)
+  {
+    uint8_t repeat = halRfReadReg(VERSION_ADDR);
+    if (repeat != version)
+    {
+      LOG_W("everblu_meter", "CC1101 VERSION register is unstable (0x%02X then 0x%02X) - the SPI bus is unreliable. Suspect another device on this bus driving MISO, an over-fast data_rate, or long/noisy wiring.", version, repeat);
+      break;
+    }
+  }
+
+  // Print the detection banner only once to avoid flooding logs during frequency scans.
+  static bool s_reported_ok = false;
+  if (!s_reported_ok)
+  {
+    s_reported_ok = true;
+    // Silicon revisions seen in the wild; clones may report something else but still work,
+    // so an unknown value is a warning rather than a hard failure now that read-back passed.
+    if (version == 0x04 || version == 0x14)
+    {
+      LOG_I("everblu_meter", "Radio found OK, SPI self-test passed (PARTNUM: 0x%02X, VERSION: 0x%02X)", partnum, version);
+    }
+    else
+    {
+      LOG_W("everblu_meter", "SPI self-test passed but VERSION 0x%02X is not a known CC1101 revision (expected 0x04 or 0x14) - continuing, but confirm this is a genuine CC1101 if reads fail.", version);
+    }
+  }
+
+  return true;
+}
+
 bool cc1101_init(float freq)
 {
 #ifdef USE_ESPHOME
@@ -699,25 +785,9 @@ bool cc1101_init(float freq)
   cc1101_reset();
   delay(1);
 
-  // Verify CC1101 is present by reading version register
-  uint8_t partnum = halRfReadReg(PARTNUM_ADDR);
-  uint8_t version = halRfReadReg(VERSION_ADDR);
-
-  // Check if version register returns a valid value (not 0x00 or 0xFF)
-  // PARTNUM may be 0x00 on some variants, so we rely mainly on VERSION
-  if (version == 0x00 || version == 0xFF)
+  if (!cc1101_verify_spi_link())
   {
-    LOG_E("everblu_meter", "CC1101 radio not responding (PARTNUM: 0x%02X, VERSION: 0x%02X)", partnum, version);
-    LOG_E("everblu_meter", "Check: 1) Wiring connections 2) 3.3V power supply 3) SPI pins");
     return false;
-  }
-
-  // Print the detection banner only once to avoid flooding logs during scans
-  static bool s_reported_ok = false;
-  if (!s_reported_ok)
-  {
-    LOG_I("everblu_meter", "Radio found OK (PARTNUM: 0x%02X, VERSION: 0x%02X)", partnum, version);
-    s_reported_ok = true;
   }
 
   cc1101_configureRF_0(freq);

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,7 +40,7 @@ upload_speed = 460800
 monitor_filters = direct
 ; Unit tests are pure logic and run on the host via `pio test -e native`.
 ; Nothing in test/ needs real hardware, so exclude every suite here.
-test_ignore = test_native_meter_fixtures, test_embedded_unit, test_native_meter_reader, test_native_esphome_publisher, test_native_esphome_reader
+test_ignore = test_native_meter_fixtures, test_embedded_unit, test_native_meter_reader, test_native_esphome_publisher, test_native_esphome_reader, test_native_cc1101_link
 
 ; ============================================================================
 ; ESP8266 Environments
@@ -239,6 +239,60 @@ build_flags =
     -lgcov
 build_unflags =
     -O2
+
+; ============================================================================
+; Native CC1101 Driver Test Environment (host/CI, no hardware)
+; ============================================================================
+; The only environment that compiles the real src/core/cc1101.cpp on the host.
+; Every other host suite replaces the driver with FakeRadio, which is right for
+; testing the services above it but leaves the driver's own SPI handling
+; untested. Here the Arduino SPI shim in test/native_shims/SPI.h stands in for
+; the bus, and test/test_native_cc1101_link/native_cc1101_device.h stands in for
+; the radio, so the boot-time link self-test runs against a simulated CC1101 and
+; against the bus faults that self-test exists to catch.
+;
+; EVERBLU_NATIVE_REAL_CC1101 switches off the CC1101 link seam in
+; test/native_fakes.cpp, which would otherwise define the same symbols twice.
+; ============================================================================
+[env:native_cc1101]
+platform = native
+test_framework = unity
+test_build_src = yes
+test_filter =
+    test_native_cc1101_link
+build_src_filter =
+    +<core/cc1101.cpp>
+    +<core/crc_kermit.cpp>
+    +<core/radian_parser.cpp>
+    +<core/radian_decoder.cpp>
+    +<core/utils.cpp>
+    +<services/frequency_manager.cpp>
+    +<services/meter_history.cpp>
+    +<services/schedule_manager.cpp>
+build_flags =
+    -DEVERBLU_NATIVE_REAL_CC1101
+    -Isrc
+    -Itest/native_shims
+    -Itest
+    ; The driver reads its GDO pin numbers from private.h on a real build. Pin
+    ; the host equivalents so the GDO2 default guard is satisfied without
+    ; picking up a developer's local include/private.h.
+    -DGDO0=5
+    -DGDO2=4
+    ; Likewise for the SPI pins, which the driver only defines for ESP8266/ESP32.
+    -DSPI_CSK=14
+    -DSPI_MISO=12
+    -DSPI_MOSI=13
+    -DSPI_SS=15
+    -DWIFI_SERIAL_MONITOR_ENABLED=1
+    -std=gnu++17
+    ; Abort on a stack buffer overrun instead of corrupting memory silently.
+    -fstack-protector-all
+    --coverage
+    -lgcov
+build_unflags =
+    -O2
+
 ; Interactive host program for decoding RADIAN hex frame dumps from the serial
 ; log.  Run with:  pio run -e hex_decoder && .pio/build/hex_decoder/program
 ;

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -132,9 +132,12 @@ try {
 
     # Host test suites. -e native covers the MQTT-mode code; -e native_esphome
     # rebuilds the shared sources with USE_ESPHOME so the ESPHome publisher,
-    # which is otherwise compiled out entirely, is exercised too.
+    # which is otherwise compiled out entirely, is exercised too; -e native_cc1101
+    # links the real CC1101 driver against a simulated SPI bus, which the other
+    # two replace with FakeRadio.
     Invoke-Step "Host tests (native)" { pio test -e native }
     Invoke-Step "Host tests (native_esphome)" { pio test -e native_esphome }
+    Invoke-Step "Host tests (native_cc1101)" { pio test -e native_cc1101 }
 
     # ESPHome YAML schema validation. These import the real ESPHome validators,
     # so they need both esphome and pytest.

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -663,6 +663,92 @@ void cc1101_configureRF_0(float freq)
   SPIWriteBurstReg(PATABLE_ADDR, PA, 8);
 }
 
+/**
+ * Verify the SPI link to the CC1101 before trusting anything the radio reports.
+ *
+ * The previous check only rejected VERSION 0x00 and 0xFF, which let a broken bus pass
+ * whenever MISO was stuck at any other constant. Every register then read back that same
+ * value, so RSSI/LQI/MARCSTATE and the whole RX FIFO looked like plausible-but-wrong data
+ * and the failure surfaced much later as an unexplained CRC error.
+ *
+ * The decisive test is a write/read-back on a scratch register using two complementary
+ * patterns. A constant MISO cannot follow both, so this catches a stuck line at any value,
+ * a missing device, a wrong MISO pin, a bus multiplexer left in the wrong position, and a
+ * second SPI device holding the line. SYNC1/SYNC0 are used as the scratch pair because
+ * cc1101_configureRF_0() rewrites both immediately afterwards.
+ *
+ * @return true when the radio is present and the bus is trustworthy.
+ */
+static bool cc1101_verify_spi_link(void)
+{
+  // Round 1 then round 2 use complementary patterns, so between them every data bit is
+  // driven both high and low in each direction.
+  static const uint8_t kProbe[2][2] = {{0xAA, 0x55}, {0x55, 0xAA}};
+  bool readback_ok = true;
+  for (uint8_t round = 0; round < 2 && readback_ok; round++)
+  {
+    halRfWriteReg(SYNC1, kProbe[round][0]);
+    halRfWriteReg(SYNC0, kProbe[round][1]);
+    if (halRfReadReg(SYNC1) != kProbe[round][0] || halRfReadReg(SYNC0) != kProbe[round][1])
+    {
+      readback_ok = false;
+    }
+  }
+
+  uint8_t partnum = halRfReadReg(PARTNUM_ADDR);
+  uint8_t version = halRfReadReg(VERSION_ADDR);
+
+  if (!readback_ok)
+  {
+    // Distinguish "every read returns the same byte" (stuck/undriven MISO, or another
+    // device owning the line) from a generally unreliable bus, so the remedy is specific.
+    uint8_t marcstate = halRfReadReg(MARCSTATE_ADDR);
+    bool stuck_at_constant = (partnum == version) && (version == marcstate);
+
+    LOG_E("everblu_meter", "CC1101 SPI self-test FAILED - register write/read-back did not match (PARTNUM: 0x%02X, VERSION: 0x%02X, MARCSTATE: 0x%02X)", partnum, version, marcstate);
+    if (stuck_at_constant)
+    {
+      LOG_E("everblu_meter", "Every register read returned 0x%02X, so MISO is stuck and the radio is not really being read. Check: 1) miso_pin is correct for this board 2) any bus-routing/mux GPIO is set to reach the CC1101 3) other SPI radios (nRF24, SX127x) on this bus are isolated or hold their CS high 4) 3.3V supply and CS/SCK/MOSI wiring.", version);
+    }
+    else
+    {
+      LOG_E("everblu_meter", "Check: 1) CS/SCK/MOSI/MISO wiring and pin assignment 2) 3.3V power supply 3) lower the SPI data_rate 4) other SPI devices sharing this bus.");
+    }
+    return false;
+  }
+
+  // The link works. Re-read VERSION a few times: a device that answers correctly but
+  // inconsistently points at contention from another device or an over-fast/noisy bus.
+  for (uint8_t i = 0; i < 8; i++)
+  {
+    uint8_t repeat = halRfReadReg(VERSION_ADDR);
+    if (repeat != version)
+    {
+      LOG_W("everblu_meter", "CC1101 VERSION register is unstable (0x%02X then 0x%02X) - the SPI bus is unreliable. Suspect another device on this bus driving MISO, an over-fast data_rate, or long/noisy wiring.", version, repeat);
+      break;
+    }
+  }
+
+  // Print the detection banner only once to avoid flooding logs during frequency scans.
+  static bool s_reported_ok = false;
+  if (!s_reported_ok)
+  {
+    s_reported_ok = true;
+    // Silicon revisions seen in the wild; clones may report something else but still work,
+    // so an unknown value is a warning rather than a hard failure now that read-back passed.
+    if (version == 0x04 || version == 0x14)
+    {
+      LOG_I("everblu_meter", "Radio found OK, SPI self-test passed (PARTNUM: 0x%02X, VERSION: 0x%02X)", partnum, version);
+    }
+    else
+    {
+      LOG_W("everblu_meter", "SPI self-test passed but VERSION 0x%02X is not a known CC1101 revision (expected 0x04 or 0x14) - continuing, but confirm this is a genuine CC1101 if reads fail.", version);
+    }
+  }
+
+  return true;
+}
+
 bool cc1101_init(float freq)
 {
 #ifdef USE_ESPHOME
@@ -699,25 +785,9 @@ bool cc1101_init(float freq)
   cc1101_reset();
   delay(1);
 
-  // Verify CC1101 is present by reading version register
-  uint8_t partnum = halRfReadReg(PARTNUM_ADDR);
-  uint8_t version = halRfReadReg(VERSION_ADDR);
-
-  // Check if version register returns a valid value (not 0x00 or 0xFF)
-  // PARTNUM may be 0x00 on some variants, so we rely mainly on VERSION
-  if (version == 0x00 || version == 0xFF)
+  if (!cc1101_verify_spi_link())
   {
-    LOG_E("everblu_meter", "CC1101 radio not responding (PARTNUM: 0x%02X, VERSION: 0x%02X)", partnum, version);
-    LOG_E("everblu_meter", "Check: 1) Wiring connections 2) 3.3V power supply 3) SPI pins");
     return false;
-  }
-
-  // Print the detection banner only once to avoid flooding logs during scans
-  static bool s_reported_ok = false;
-  if (!s_reported_ok)
-  {
-    LOG_I("everblu_meter", "Radio found OK (PARTNUM: 0x%02X, VERSION: 0x%02X)", partnum, version);
-    s_reported_ok = true;
   }
 
   cc1101_configureRF_0(freq);

--- a/test/README.md
+++ b/test/README.md
@@ -46,6 +46,20 @@ Behaviour of the two stateful services, driven against fake hardware.
 - `test_frequency_manager.cpp` - deep scan lock and abort paths, the calibration
   quality guard, persistence round-trips and adaptive FREQEST tracking
 
+### `test_native_cc1101_link/`
+
+The boot-time SPI link self-test in `cc1101_init()`.
+
+This is the only suite that links the real `src/core/cc1101.cpp`. It runs under
+`[env:native_cc1101]`, where `test/native_shims/SPI.h` stands in for the bus and
+`native_cc1101_device.h` stands in for the radio, so the driver's own SPI
+handling is exercised rather than replaced by `FakeRadio`.
+
+Covers the healthy path, a MISO line stuck at any constant (including 0x0F and
+0x14, values the old identity-only check would have accepted), an absent radio,
+an unknown silicon revision, an unstable bus, and re-running the self-test on
+the repeated `cc1101_init()` calls a frequency scan makes.
+
 ### `test_native_esphome_publisher/`
 
 ESPHomeDataPublisher, built the way the shipped external component builds it.
@@ -75,6 +89,13 @@ It replaces three things at link time:
 | CC1101 free functions (`cc1101_init`, `get_meter_data_for_meter`, ...) | No radio on the host |
 | `StorageAbstraction` | No EEPROM or NVS on the host |
 | `WifiSerialStream` / `WiFiSerial` | No network stack; log output goes to stdout. Only compiled when `WIFI_SERIAL_MONITOR_ENABLED` is `1`, which `env:native` sets so the mirror path stays covered on the host |
+
+The CC1101 replacement is skipped when `EVERBLU_NATIVE_REAL_CC1101` is defined,
+which `[env:native_cc1101]` sets so the real driver can be linked instead.
+That environment simulates the layer below the driver rather than the driver
+itself: `test/native_shims/SPI.h` routes every transfer to a handler, and
+`test/test_native_cc1101_link/native_cc1101_device.h` answers as a CC1101 whose
+MISO line can be made to stick, float or misbehave on demand.
 
 The fake radio answers in one of two modes. Scripted mode consumes a queue of
 `tmeter_data` outcomes, repeating the last entry once the script runs out.
@@ -108,6 +129,9 @@ pio test -e native
 
 # The ESPHome-mode suite
 pio test -e native_esphome
+
+# The CC1101 driver suite
+pio test -e native_cc1101
 
 # One suite
 pio test -e native -f test_embedded_unit

--- a/test/native_fakes.cpp
+++ b/test/native_fakes.cpp
@@ -70,6 +70,11 @@ tmeter_data FakeRadio::failure(ReadFailure reason)
     return data;
 }
 
+// The CC1101 link seam is skipped by [env:native_cc1101], which compiles the real
+// src/core/cc1101.cpp against a simulated SPI bus instead. Everything else in
+// this file (FakeRadio itself, storage, WiFi serial) is still needed there.
+#ifndef EVERBLU_NATIVE_REAL_CC1101
+
 void setMHZ(float mhz)
 {
     fakeRadio().initFrequencies.push_back(mhz);
@@ -145,6 +150,8 @@ struct tmeter_data get_meter_data(void)
 {
     return get_meter_data_for_meter(0, 0);
 }
+
+#endif // EVERBLU_NATIVE_REAL_CC1101
 
 // ---------------------------------------------------------------------------
 // FakeStorage and the StorageAbstraction link seam

--- a/test/native_shims/Arduino.h
+++ b/test/native_shims/Arduino.h
@@ -183,4 +183,72 @@ using String = std::string;
 #define LOW 0
 #endif
 
+using byte = uint8_t;
+
+// ---------------------------------------------------------------------------
+// GPIO
+// ---------------------------------------------------------------------------
+//
+// Pin levels are a plain host-side array. That lets a test read back what the
+// firmware drove, and drive what the firmware is about to read, which is what
+// makes the CC1101 GDO pins observable without hardware.
+
+#ifndef INPUT
+#define INPUT 0
+#endif
+#ifndef OUTPUT
+#define OUTPUT 1
+#endif
+#ifndef INPUT_PULLUP
+#define INPUT_PULLUP 2
+#endif
+
+inline constexpr int kNativePinCount = 64;
+
+inline uint8_t *nativePinLevels()
+{
+    static uint8_t levels[kNativePinCount] = {0};
+    return levels;
+}
+
+inline uint8_t *nativePinModes()
+{
+    static uint8_t modes[kNativePinCount] = {0};
+    return modes;
+}
+
+inline void nativePinReset()
+{
+    memset(nativePinLevels(), 0, kNativePinCount);
+    memset(nativePinModes(), 0, kNativePinCount);
+}
+
+inline void pinMode(uint8_t pin, uint8_t mode)
+{
+    if (pin >= kNativePinCount)
+    {
+        return;
+    }
+    nativePinModes()[pin] = mode;
+    // A pull-up leaves the line high until something drives it, which is what
+    // the firmware relies on to detect a disconnected GDO2.
+    if (mode == INPUT_PULLUP)
+    {
+        nativePinLevels()[pin] = HIGH;
+    }
+}
+
+inline void digitalWrite(uint8_t pin, uint8_t level)
+{
+    if (pin < kNativePinCount)
+    {
+        nativePinLevels()[pin] = level ? HIGH : LOW;
+    }
+}
+
+inline int digitalRead(uint8_t pin)
+{
+    return (pin < kNativePinCount) ? nativePinLevels()[pin] : LOW;
+}
+
 #endif // EVERBLU_NATIVE_ARDUINO_SHIM_H

--- a/test/native_shims/SPI.h
+++ b/test/native_shims/SPI.h
@@ -1,0 +1,88 @@
+/**
+ * @file SPI.h
+ * @brief Minimal Arduino SPI shim for the PlatformIO `native` (host) build
+ *
+ * This header is NOT part of the firmware. It exists so that `src/core/cc1101.cpp`
+ * can be compiled and unit-tested on a desktop host, where no SPI peripheral is
+ * available. It is pulled in only by `[env:native_cc1101]`, via
+ * `-I test/native_shims` in `platformio.ini`.
+ *
+ * Every byte the driver exchanges with the radio passes through
+ * `SPI.transfer(buffer, length)`, so installing a handler here is enough to put a
+ * simulated CC1101 (and any bus fault we want to reproduce) behind the whole
+ * driver. See `test/test_native_cc1101_link/native_cc1101_device.h`.
+ *
+ * Scope is deliberately narrow: only the members `cc1101.cpp` actually calls.
+ */
+
+#ifndef EVERBLU_NATIVE_SPI_SHIM_H
+#define EVERBLU_NATIVE_SPI_SHIM_H
+
+#include <Arduino.h>
+
+#ifndef MSBFIRST
+#define MSBFIRST 1
+#endif
+#ifndef SPI_MODE0
+#define SPI_MODE0 0
+#endif
+
+class SPISettings
+{
+public:
+    SPISettings() = default;
+    SPISettings(uint32_t, uint8_t, uint8_t) {}
+};
+
+/**
+ * Handler invoked for every SPI transfer. The buffer is exchanged in place, the
+ * same way real SPI works: on entry it holds the bytes clocked out on MOSI, and
+ * on return it must hold the bytes clocked back in on MISO.
+ */
+using NativeSpiTransferHandler = void (*)(uint8_t *buffer, size_t length);
+
+inline NativeSpiTransferHandler &nativeSpiHandler()
+{
+    static NativeSpiTransferHandler handler = nullptr;
+    return handler;
+}
+
+inline void nativeSpiSetHandler(NativeSpiTransferHandler handler)
+{
+    nativeSpiHandler() = handler;
+}
+
+class NativeSPI
+{
+public:
+    void begin() {}
+    void begin(int, int, int, int) {}
+    void pins(int, int, int, int) {}
+    void beginTransaction(const SPISettings &) {}
+    void endTransaction() {}
+
+    void transfer(void *buffer, size_t length)
+    {
+        uint8_t *bytes = static_cast<uint8_t *>(buffer);
+        if (nativeSpiHandler() != nullptr)
+        {
+            nativeSpiHandler()(bytes, length);
+        }
+        else
+        {
+            // No handler installed means nothing is on the bus, so MISO reads as
+            // an undriven line rather than as plausible data.
+            memset(bytes, 0xFF, length);
+        }
+    }
+
+    uint8_t transfer(uint8_t out)
+    {
+        transfer(&out, 1);
+        return out;
+    }
+};
+
+inline NativeSPI SPI;
+
+#endif // EVERBLU_NATIVE_SPI_SHIM_H

--- a/test/test_native_cc1101_link/native_cc1101_device.h
+++ b/test/test_native_cc1101_link/native_cc1101_device.h
@@ -1,0 +1,203 @@
+/**
+ * @file native_cc1101_device.h
+ * @brief A simulated CC1101 on the host SPI bus, with bus-fault injection
+ *
+ * `src/core/cc1101.cpp` reaches the radio through exactly one function,
+ * `wiringPiSPIDataRW()`, which on the host resolves to `SPI.transfer()` in
+ * `test/native_shims/SPI.h`. Installing this device as the transfer handler
+ * therefore puts a whole simulated radio behind the real driver, unmodified.
+ *
+ * The device models a healthy CC1101 register file. Faults are injected as a
+ * filter over MISO rather than by breaking the device, which mirrors the real
+ * failures: the radio is usually fine and it is the line back from it that is
+ * wrong (unconnected MISO pin, a board bus-mux left in the wrong position, or
+ * another SPI device on the bus holding the line).
+ */
+
+#ifndef EVERBLU_NATIVE_CC1101_DEVICE_H
+#define EVERBLU_NATIVE_CC1101_DEVICE_H
+
+#include <Arduino.h>
+#include <SPI.h>
+
+/** Genuine CC1101 silicon revision, as reported by the VERSION register. */
+inline constexpr uint8_t kCc1101Version = 0x14;
+/** Genuine CC1101 PARTNUM register value. */
+inline constexpr uint8_t kCc1101PartNum = 0x00;
+
+/** How the simulated bus mangles the bytes coming back on MISO. */
+enum class NativeSpiFault : uint8_t
+{
+    None,           ///< Healthy bus: the driver reads back what it wrote.
+    StuckConstant,  ///< MISO held at a fixed value (see NativeCC1101::stuckValue).
+    UnstableStatus, ///< Marginal bus: status reads alternate correct/corrupt.
+};
+
+struct NativeCC1101
+{
+    // ---- Fault injection -------------------------------------------------
+    NativeSpiFault fault = NativeSpiFault::None;
+    uint8_t stuckValue = 0xFF;
+
+    // ---- Observability ---------------------------------------------------
+    uint32_t transfers = 0;
+    uint32_t statusReads = 0;
+    uint32_t resetStrobes = 0;
+
+    // ---- Simulated silicon ----------------------------------------------
+    uint8_t config[0x40] = {0}; ///< Config registers 0x00-0x3F
+    uint8_t partnum = kCc1101PartNum;
+    uint8_t version = kCc1101Version;
+    uint8_t marcstate = 0x01; ///< IDLE after reset; SRX moves it to RX
+
+    void reset() { *this = NativeCC1101{}; }
+};
+
+inline NativeCC1101 &nativeCC1101()
+{
+    static NativeCC1101 device;
+    return device;
+}
+
+namespace native_cc1101_detail
+{
+
+/**
+ * Value a healthy device would return for one register read.
+ *
+ * @param address 6-bit register address taken from the header byte.
+ * @param is_status True for the status-register space. The CC1101 requires the
+ *        burst bit for those, so a read of PARTNUM (0xF0) arrives as a burst
+ *        read of address 0x30.
+ */
+inline uint8_t readRegister(NativeCC1101 &device, uint8_t address, bool is_status)
+{
+    if (is_status)
+    {
+        switch (address)
+        {
+        case 0x30: // PARTNUM
+            return device.partnum;
+        case 0x31: // VERSION
+            return device.version;
+        case 0x35: // MARCSTATE
+            return device.marcstate;
+        default:
+            // Status registers that are not modelled (FREQEST, LQI, RSSI,
+            // TXBYTES, RXBYTES) read as zero rather than as something that
+            // could be mistaken for a real measurement.
+            return 0x00;
+        }
+    }
+    if (address >= 0x3E) // PATABLE and the FIFOs are not modelled
+    {
+        return 0x00;
+    }
+    return device.config[address];
+}
+
+/** Apply the simulated bus fault to one byte on its way back to the driver. */
+inline uint8_t applyFault(NativeCC1101 &device, uint8_t value, bool is_status)
+{
+    switch (device.fault)
+    {
+    case NativeSpiFault::StuckConstant:
+        // A stuck line affects every byte, which is exactly what makes it so
+        // hard to spot from the decoded results alone.
+        return device.stuckValue;
+    case NativeSpiFault::UnstableStatus:
+        // A bus that mostly works but is contended or clocked too fast. Only
+        // every other status read is corrupted, so any single read still looks
+        // credible and only a repeated read exposes the fault.
+        return (is_status && (device.statusReads % 2 == 0)) ? (uint8_t)(value ^ 0xFF) : value;
+    case NativeSpiFault::None:
+    default:
+        return value;
+    }
+}
+
+} // namespace native_cc1101_detail
+
+/**
+ * SPI transfer handler: decodes one CC1101 bus transaction in place.
+ *
+ * Header byte layout is the CC1101's: bit 7 read/write, bit 6 burst, bits 5-0
+ * address. Command strobes are single-byte writes.
+ */
+inline void nativeCC1101Transfer(uint8_t *buffer, size_t length)
+{
+    NativeCC1101 &device = nativeCC1101();
+    device.transfers++;
+
+    if (length == 0)
+    {
+        return;
+    }
+
+    const uint8_t header = buffer[0];
+    const uint8_t address = (uint8_t)(header & 0x3F);
+    const bool is_read = (header & 0x80) != 0;
+    const bool is_burst = (header & 0x40) != 0;
+
+    // The header byte itself clocks back the chip status byte.
+    buffer[0] = native_cc1101_detail::applyFault(device, 0x00, false);
+
+    // A single-byte transfer is a command strobe.
+    if (length == 1)
+    {
+        if (address == 0x30) // SRES
+        {
+            device.resetStrobes++;
+            device.marcstate = 0x01;
+            memset(device.config, 0, sizeof(device.config));
+        }
+        else if (address == 0x34) // SRX
+        {
+            device.marcstate = 0x0D;
+        }
+        else if (address == 0x36) // SIDLE
+        {
+            device.marcstate = 0x01;
+        }
+        return;
+    }
+
+    if (is_read)
+    {
+        // Status registers share the address space with the command strobes and
+        // are told apart by the burst bit, which the driver always sets for them
+        // and never sets for a single config-register read.
+        const bool is_status = is_burst && address >= 0x30;
+        for (size_t i = 1; i < length; i++)
+        {
+            const uint8_t reg = (is_burst && !is_status) ? (uint8_t)(address + (i - 1)) : address;
+            const uint8_t raw = native_cc1101_detail::readRegister(device, reg, is_status);
+            buffer[i] = native_cc1101_detail::applyFault(device, raw, is_status);
+            if (is_status)
+            {
+                device.statusReads++;
+            }
+        }
+        return;
+    }
+
+    // Write: store what the driver sent, so a later read-back can return it.
+    for (size_t i = 1; i < length; i++)
+    {
+        const uint8_t reg = is_burst ? (uint8_t)(address + (i - 1)) : address;
+        if (reg < 0x3E)
+        {
+            device.config[reg] = buffer[i];
+        }
+        buffer[i] = native_cc1101_detail::applyFault(device, 0x00, false);
+    }
+}
+
+/** Put a freshly reset simulated CC1101 on the host SPI bus. */
+inline void nativeCC1101Install()
+{
+    nativeCC1101().reset();
+    nativeSpiSetHandler(&nativeCC1101Transfer);
+}
+
+#endif // EVERBLU_NATIVE_CC1101_DEVICE_H

--- a/test/test_native_cc1101_link/test_cc1101_link.cpp
+++ b/test/test_native_cc1101_link/test_cc1101_link.cpp
@@ -1,0 +1,141 @@
+/**
+ * @file test_cc1101_link.cpp
+ * @brief Boot-time SPI link self-test in cc1101_init()
+ *
+ * These run the real `src/core/cc1101.cpp` against a simulated CC1101 on a
+ * simulated SPI bus, so the write/read-back probe itself is under test rather
+ * than a re-implementation of it.
+ *
+ * Motivation (issue #136): a board whose MISO line was stuck returned the same
+ * byte for every register. The old check only rejected VERSION 0x00 and 0xFF, so
+ * a line stuck at 0x0F sailed through and the firmware reported "Radio found
+ * OK". Every later read - RSSI, LQI, MARCSTATE, the whole RX FIFO - was that one
+ * constant, and the fault surfaced hundreds of lines later as an unexplained CRC
+ * failure that looked like a weak radio link.
+ */
+
+#include <unity.h>
+
+#include "native_cc1101_device.h"
+#include "core/cc1101.h"
+
+static constexpr float kTestFrequency = 433.82f;
+
+/** SYNC1/SYNC0, the scratch pair the probe writes through. */
+static constexpr uint8_t kSync1Register = 0x04;
+static constexpr uint8_t kSync0Register = 0x05;
+
+void test_cc1101_init_succeeds_on_a_healthy_bus(void)
+{
+    nativeCC1101Install();
+
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+    TEST_ASSERT_GREATER_THAN_UINT32(0, nativeCC1101().resetStrobes);
+}
+
+void test_cc1101_init_rejects_miso_stuck_at_0x0f(void)
+{
+    // The exact failure reported from a LilyGO T-Embed CC1101 Plus: every
+    // register, the status byte and the whole RX FIFO read back as 0x0F.
+    nativeCC1101Install();
+    nativeCC1101().fault = NativeSpiFault::StuckConstant;
+    nativeCC1101().stuckValue = 0x0F;
+
+    TEST_ASSERT_FALSE(cc1101_init(kTestFrequency));
+}
+
+void test_cc1101_init_rejects_miso_stuck_at_any_constant(void)
+{
+    // 0x00 and 0xFF were the only values the old check caught. Nothing about a
+    // stuck line makes those two special, so every constant must be rejected.
+    const uint8_t stuck_values[] = {0x00, 0x01, 0x0F, 0x14, 0x55, 0xAA, 0xFF};
+
+    for (uint8_t stuck : stuck_values)
+    {
+        nativeCC1101Install();
+        nativeCC1101().fault = NativeSpiFault::StuckConstant;
+        nativeCC1101().stuckValue = stuck;
+
+        char message[64];
+        snprintf(message, sizeof(message), "MISO stuck at 0x%02X was accepted", stuck);
+        TEST_ASSERT_FALSE_MESSAGE(cc1101_init(kTestFrequency), message);
+    }
+}
+
+void test_cc1101_init_rejects_a_stuck_value_that_looks_like_a_real_version(void)
+{
+    // 0x14 is a genuine CC1101 silicon revision, so an identity check alone
+    // would be fooled by a line stuck at that value. The write/read-back probe
+    // is what makes the verdict independent of the value observed.
+    nativeCC1101Install();
+    nativeCC1101().fault = NativeSpiFault::StuckConstant;
+    nativeCC1101().stuckValue = kCc1101Version;
+
+    TEST_ASSERT_FALSE(cc1101_init(kTestFrequency));
+}
+
+void test_cc1101_init_rejects_an_absent_radio(void)
+{
+    // Nothing on the bus at all: no handler, so MISO floats high.
+    nativeCC1101().reset();
+    nativeSpiSetHandler(nullptr);
+
+    TEST_ASSERT_FALSE(cc1101_init(kTestFrequency));
+
+    nativeCC1101Install(); // leave the bus usable for the next test
+}
+
+void test_cc1101_init_accepts_an_unknown_silicon_revision(void)
+{
+    // Clones report revisions we do not recognise. Once the read-back probe has
+    // passed we know we are really talking to something, so an unknown VERSION
+    // is a warning rather than a refusal to start.
+    nativeCC1101Install();
+    nativeCC1101().version = 0x07;
+
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+}
+
+void test_cc1101_init_tolerates_an_unstable_bus(void)
+{
+    // A bus that answers correctly but inconsistently is worth warning about,
+    // not worth refusing to start on: the radio may still be usable, and a hard
+    // failure here would strand a device that was merely clocked too fast.
+    nativeCC1101Install();
+    nativeCC1101().fault = NativeSpiFault::UnstableStatus;
+
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+    TEST_ASSERT_GREATER_THAN_UINT32(1, nativeCC1101().statusReads);
+}
+
+void test_cc1101_init_probes_both_bit_polarities(void)
+{
+    // The probe must drive every data bit both high and low, otherwise a line
+    // shorted high or low could still follow one of the two patterns. Checking
+    // the scratch registers moved proves both writes reached the device.
+    nativeCC1101Install();
+    nativeCC1101().config[kSync1Register] = 0x00;
+    nativeCC1101().config[kSync0Register] = 0x00;
+
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+
+    // cc1101_configureRF_0() restores the real RADIAN sync word afterwards, so
+    // the scratch values must not have been left behind.
+    TEST_ASSERT_EQUAL_HEX8(0x55, nativeCC1101().config[kSync1Register]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, nativeCC1101().config[kSync0Register]);
+}
+
+void test_cc1101_init_re_runs_the_self_test_on_every_call(void)
+{
+    // Frequency scans call cc1101_init() repeatedly. A bus that dies partway
+    // through a sweep must be caught then, not assumed good from boot.
+    nativeCC1101Install();
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+
+    nativeCC1101().fault = NativeSpiFault::StuckConstant;
+    nativeCC1101().stuckValue = 0x0F;
+    TEST_ASSERT_FALSE(cc1101_init(kTestFrequency));
+
+    nativeCC1101().fault = NativeSpiFault::None;
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+}

--- a/test/test_native_cc1101_link/test_runner.cpp
+++ b/test/test_native_cc1101_link/test_runner.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file test_runner.cpp
+ * @brief Unity entry point for the CC1101 SPI link host suite
+ */
+
+#include <unity.h>
+
+#include "native_cc1101_device.h"
+
+void test_cc1101_init_succeeds_on_a_healthy_bus(void);
+void test_cc1101_init_rejects_miso_stuck_at_0x0f(void);
+void test_cc1101_init_rejects_miso_stuck_at_any_constant(void);
+void test_cc1101_init_rejects_a_stuck_value_that_looks_like_a_real_version(void);
+void test_cc1101_init_rejects_an_absent_radio(void);
+void test_cc1101_init_accepts_an_unknown_silicon_revision(void);
+void test_cc1101_init_tolerates_an_unstable_bus(void);
+void test_cc1101_init_probes_both_bit_polarities(void);
+void test_cc1101_init_re_runs_the_self_test_on_every_call(void);
+
+void setUp(void)
+{
+    nativePinReset();
+    nativeCC1101Install();
+}
+
+void tearDown(void) {}
+
+int main(int, char **)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_cc1101_init_succeeds_on_a_healthy_bus);
+    RUN_TEST(test_cc1101_init_rejects_miso_stuck_at_0x0f);
+    RUN_TEST(test_cc1101_init_rejects_miso_stuck_at_any_constant);
+    RUN_TEST(test_cc1101_init_rejects_a_stuck_value_that_looks_like_a_real_version);
+    RUN_TEST(test_cc1101_init_rejects_an_absent_radio);
+    RUN_TEST(test_cc1101_init_accepts_an_unknown_silicon_revision);
+    RUN_TEST(test_cc1101_init_tolerates_an_unstable_bus);
+    RUN_TEST(test_cc1101_init_probes_both_bit_polarities);
+    RUN_TEST(test_cc1101_init_re_runs_the_self_test_on_every_call);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
The presence check only rejected VERSION 0x00 and 0xFF, so a bus whose MISO line was stuck at any other constant passed and the firmware logged 'Radio found OK'. Every subsequent register read returned that same constant, so RSSI, LQI, MARCSTATE and the whole RX FIFO looked like plausible data and the fault surfaced much later as an unexplained CRC failure that read as a weak RF link (issue #136).

cc1101_init() now runs a write/read-back probe over SYNC1/SYNC0 with two complementary patterns before trusting anything the radio reports. A constant MISO cannot follow both, so this catches a stuck line at any value, a missing device, a wrong MISO pin, a board bus-mux left in the wrong position, and another SPI device holding the line. Failure is fatal, so radio_connected now goes false instead of reporting a healthy radio. Repeated VERSION reads warn about an unreliable bus, and an unknown silicon revision warns rather than refuses now that read-back proves a device is there.

Adds [env:native_cc1101], the first host environment to link the real driver: test/native_shims/SPI.h stands in for the bus and native_cc1101_device.h for the radio, so the self-test is tested against the faults it exists to catch.