### PR TITLE
Report pin numbers and probe the radio at boot

### DIFF
--- a/.ci/esphome/everblu_meter/.gitignore
+++ b/.ci/esphome/everblu_meter/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/.ci/esphome/everblu_meter/.gitignore
+++ b/.ci/esphome/everblu_meter/.gitignore
@@ -1,5 +1,0 @@
-# Gitignore settings for ESPHome
-# This is an example and may include too much for your use-case.
-# You can modify this file to suit your needs.
-/.esphome/
-/secrets.yaml

--- a/.ci/esphome/everblu_meter/common-full.yaml
+++ b/.ci/esphome/everblu_meter/common-full.yaml
@@ -122,3 +122,7 @@ everblu_meter:
     name: "CI Deep Scan"
   reset_frequency_button:
     name: "CI Reset Freq"
+  stop_reading_button:
+    name: "CI Stop Reading"
+  diagnostic_report_button:
+    name: "CI Diagnostic Report"

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ issue-58-reply.md
 
 # ESPHome build output from scripts/test_build_components
 .esphome/
+.ci/esphome/*/.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ scripts/dev_notes.txt
 /test/rommess
 issue-58-reply.md
 /temp
+
+# ESPHome build output from scripts/test_build_components
+.esphome/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Releases are created manually by tagging commits with version tags matching `v*.
 - **`dump_config()` reports the actual GPIO numbers** for the CS, GDO0 and GDO2 pins instead of just `configured`, and adds the RX attenuation setting and the SPI link self-test result. Support requests usually consist of this block alone, which could not be checked against a board pinout without the numbers.
 - **The SPI write/read-back probe restores the sync word it borrowed.** `SYNC1`/`SYNC0` are the scratch pair, and the last pattern written is `0x55`/`0xAA`. `cc1101_init()` rewrites them immediately afterwards, but `cc1101_collect_diagnostics()` runs against a configured, listening radio, so without the restore the operational sync word silently became `0x55AA`.
 - **`MARCSTATE` is reported by name** in the diagnostic report. As a bare number a state such as `0x11` reads as a fault, when it is usually just a receiver parked with nothing draining the FIFO (`RXFIFO_OVERFLOW`).
+- **The diagnostic report decodes `FREQ2/1/0` into the actual carrier frequency** and prints it alongside the configured base. The two differ by whatever calibration offset is in effect, so reporting only the configured value hid a ~31 kHz discrepancy that could otherwise be spotted only by doing the register arithmetic by hand.
 
 ## [v3.4.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Releases are created manually by tagging commits with version tags matching `v*.
 ### Added
 
 - **`diagnostic_report_button`**: a new optional button that logs a single copy-pasteable block containing the configured CS/GDO0/GDO2 pins, a live SPI link self-test, the key CC1101 registers (PARTNUM, VERSION, MARCSTATE, FREQ2/1/0, MDMCFG4/3/2, PKTCTRL0), RSSI/LQI and the current GDO0/GDO2 line levels. It deliberately does not require the meter reader to be initialised, because the most common reason to press it is that the radio never came up.
-- **GDO0 wiring self-test**: `cc1101_init()` now checks that GDO0 reads LOW while the radio is IDLE, mirroring the existing GDO2 self-test. The pin is configured with a pull-up, so a wrong or unconnected GPIO reads HIGH. Previously a mis-assigned `gdo0_pin` failed silently in a way that resembled success: every sync-word wait returned immediately, producing `GDO0 triggered at 0ms` and "received" frames that were only noise.
+- **GDO0 wiring self-test**: `cc1101_init()` now checks that GDO0 reads LOW while the radio is IDLE, mirroring the existing GDO2 self-test. The pin is configured with a pull-up, so a wrong or unconnected GPIO reads HIGH. Previously a mis-assigned `gdo0_pin` failed silently in a way that resembled success: every sync-word wait returned immediately, producing `GDO0 triggered at 0ms` and "received" frames that were only noise. The verdict is exposed through `cc1101_collect_diagnostics()` and shown in the diagnostic report, so a fault that appears mid-life is visible rather than only at the first boot after a miswire.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Releases are created manually by tagging commits with version tags matching `v*.
 
 - **The SPI link self-test now runs during `setup()`**, not on the first Home Assistant connection. A stuck MISO or a wrong `cs_pin`/`miso_pin` is a hard wiring fault, and users typically capture only the boot log, which previously contained no evidence of it.
 - **`dump_config()` reports the actual GPIO numbers** for the CS, GDO0 and GDO2 pins instead of just `configured`, and adds the RX attenuation setting and the SPI link self-test result. Support requests usually consist of this block alone, which could not be checked against a board pinout without the numbers.
+- **The SPI write/read-back probe restores the sync word it borrowed.** `SYNC1`/`SYNC0` are the scratch pair, and the last pattern written is `0x55`/`0xAA`. `cc1101_init()` rewrites them immediately afterwards, but `cc1101_collect_diagnostics()` runs against a configured, listening radio, so without the restore the operational sync word silently became `0x55AA`.
+- **`MARCSTATE` is reported by name** in the diagnostic report. As a bare number a state such as `0x11` reads as a fault, when it is usually just a receiver parked with nothing draining the FIFO (`RXFIFO_OVERFLOW`).
 
 ## [v3.4.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Releases are created manually by tagging commits with version tags matching `v*.
 - Keep PR coverage explicit per release so branch-only work is auditable against merge history.
 - Add new versions below, not above this section.
 
+## [Unreleased]
+
+### Added
+
+- **`diagnostic_report_button`**: a new optional button that logs a single copy-pasteable block containing the configured CS/GDO0/GDO2 pins, a live SPI link self-test, the key CC1101 registers (PARTNUM, VERSION, MARCSTATE, FREQ2/1/0, MDMCFG4/3/2, PKTCTRL0), RSSI/LQI and the current GDO0/GDO2 line levels. It deliberately does not require the meter reader to be initialised, because the most common reason to press it is that the radio never came up.
+- **GDO0 wiring self-test**: `cc1101_init()` now checks that GDO0 reads LOW while the radio is IDLE, mirroring the existing GDO2 self-test. The pin is configured with a pull-up, so a wrong or unconnected GPIO reads HIGH. Previously a mis-assigned `gdo0_pin` failed silently in a way that resembled success: every sync-word wait returned immediately, producing `GDO0 triggered at 0ms` and "received" frames that were only noise.
+
+### Changed
+
+- **The SPI link self-test now runs during `setup()`**, not on the first Home Assistant connection. A stuck MISO or a wrong `cs_pin`/`miso_pin` is a hard wiring fault, and users typically capture only the boot log, which previously contained no evidence of it.
+- **`dump_config()` reports the actual GPIO numbers** for the CS, GDO0 and GDO2 pins instead of just `configured`, and adds the RX attenuation setting and the SPI link self-test result. Support requests usually consist of this block alone, which could not be checked against a board pinout without the numbers.
+
 ## [v3.4.0] - 2026-07-30
 
 ### AI Metadata

--- a/ESPHOME-release/everblu_meter/__init__.py
+++ b/ESPHOME-release/everblu_meter/__init__.py
@@ -108,6 +108,7 @@ CONF_REQUEST_READING_BUTTON = "request_reading_button"
 CONF_DEEP_SCAN_BUTTON = "deep_scan_button"
 CONF_RESET_FREQUENCY_BUTTON = "reset_frequency_button"
 CONF_STOP_READING_BUTTON = "stop_reading_button"
+CONF_DIAGNOSTIC_REPORT_BUTTON = "diagnostic_report_button"
 CONF_RX_ATTENUATION = "rx_attenuation"
 
 # Meter types
@@ -423,6 +424,11 @@ CONFIG_SCHEMA = (
                 EverbluMeterTriggerButton,
                 icon="mdi:stop-circle-outline",
                 entity_category="config",
+            ),
+            cv.Optional(CONF_DIAGNOSTIC_REPORT_BUTTON): button.button_schema(
+                EverbluMeterTriggerButton,
+                icon="mdi:clipboard-text-search-outline",
+                entity_category="diagnostic",
             ),
         }
     )
@@ -744,3 +750,8 @@ async def to_code(config):
         btn = await button.new_button(config[CONF_STOP_READING_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(btn.set_stop(True))
+
+    if CONF_DIAGNOSTIC_REPORT_BUTTON in config:
+        btn = await button.new_button(config[CONF_DIAGNOSTIC_REPORT_BUTTON])
+        cg.add(btn.set_parent(var))
+        cg.add(btn.set_diagnostic(True))

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -677,9 +677,11 @@ void cc1101_configureRF_0(float freq)
  * second SPI device holding the line. SYNC1/SYNC0 are used as the scratch pair because
  * cc1101_configureRF_0() rewrites both immediately afterwards.
  *
+ * @param partnum_out Optional; receives the PARTNUM register value.
+ * @param version_out Optional; receives the VERSION register value.
  * @return true when the radio is present and the bus is trustworthy.
  */
-static bool cc1101_verify_spi_link(void)
+static bool cc1101_verify_spi_link(uint8_t *partnum_out, uint8_t *version_out)
 {
   // Round 1 then round 2 use complementary patterns, so between them every data bit is
   // driven both high and low in each direction.
@@ -697,6 +699,11 @@ static bool cc1101_verify_spi_link(void)
 
   uint8_t partnum = halRfReadReg(PARTNUM_ADDR);
   uint8_t version = halRfReadReg(VERSION_ADDR);
+
+  if (partnum_out != NULL)
+    *partnum_out = partnum;
+  if (version_out != NULL)
+    *version_out = version;
 
   if (!readback_ok)
   {
@@ -749,6 +756,58 @@ static bool cc1101_verify_spi_link(void)
   return true;
 }
 
+bool cc1101_probe_spi_link(uint8_t *partnum_out, uint8_t *version_out)
+{
+  if (partnum_out != NULL)
+    *partnum_out = 0;
+  if (version_out != NULL)
+    *version_out = 0;
+
+  if ((wiringPiSPISetup(0, 500000)) < 0)
+  {
+    LOG_E("everblu_meter", "Failed to initialize SPI bus - check CC1101 wiring and connections");
+    return false;
+  }
+
+  cc1101_reset();
+  delay(1);
+
+  return cc1101_verify_spi_link(partnum_out, version_out);
+}
+
+void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
+{
+  int8_t cc1100_rssi_convert2dbm(uint8_t Rssi_dec); // defined below
+
+  if (out == NULL)
+    return;
+
+  memset(out, 0, sizeof(*out));
+  out->gdo0_level = -1;
+  out->gdo2_level = -1;
+
+  // Read-back check first: when the bus is untrustworthy every register below returns the
+  // same meaningless byte, and reporting those values as if they were real is what made
+  // this class of fault so hard to spot in the first place.
+  out->link_ok = cc1101_verify_spi_link(&out->partnum, &out->version);
+
+  out->marcstate = halRfReadReg(MARCSTATE_ADDR);
+  out->freq2 = halRfReadReg(FREQ2);
+  out->freq1 = halRfReadReg(FREQ1);
+  out->freq0 = halRfReadReg(FREQ0);
+  out->mdmcfg4 = halRfReadReg(MDMCFG4);
+  out->mdmcfg3 = halRfReadReg(MDMCFG3);
+  out->mdmcfg2 = halRfReadReg(MDMCFG2);
+  out->pktctrl0 = halRfReadReg(PKTCTRL0);
+  out->rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR));
+  out->lqi = halRfReadReg(LQI_ADDR) & 0x7F;
+
+  if (GET_GDO0_PIN() >= 0)
+    out->gdo0_level = (digitalRead(GET_GDO0_PIN()) == LOW) ? 0 : 1;
+  if (GET_GDO2_PIN() >= 0)
+    out->gdo2_level = (digitalRead(GET_GDO2_PIN()) == LOW) ? 0 : 1;
+}
+
 bool cc1101_init(float freq)
 {
 #ifdef USE_ESPHOME
@@ -785,7 +844,7 @@ bool cc1101_init(float freq)
   cc1101_reset();
   delay(1);
 
-  if (!cc1101_verify_spi_link())
+  if (!cc1101_verify_spi_link(NULL, NULL))
   {
     return false;
   }
@@ -799,6 +858,42 @@ bool cc1101_init(float freq)
   delay(5);          // Wait for calibration to complete (typically <1ms, but we add margin)
 
   echo_debug(debug_out, "[CC1101] Frequency synthesizer calibrated for %.6f MHz\n", freq);
+
+  // One-time GDO0 wiring self-test. IOCFG0 is sync-word-detect (set by
+  // cc1101_configureRF_0) and the radio is IDLE here, so a correctly wired GDO0 must read
+  // LOW. The pin is configured INPUT_PULLUP, so an unconnected or wrong GPIO reads HIGH.
+  // Without this check a wrong gdo0_pin fails silently in a way that looks like success:
+  // every "wait for GDO0" loop returns immediately, so the logs show "GDO0 triggered at
+  // 0ms" and a frame is "received" that is really just noise (issue seen on boards where
+  // GDO0 was pointed at an unrelated peripheral pin).
+  {
+    static bool s_gdo0_selftest_done = false;
+    if (!s_gdo0_selftest_done)
+    {
+      s_gdo0_selftest_done = true;
+      CC1101_CMD(SIDLE);
+      delayMicroseconds(100);
+      // Sample a few times: a genuinely idle GDO0 is steady, so a single reading is enough
+      // in principle, but repeating costs nothing and avoids reacting to a transient.
+      bool stuck_high = true;
+      for (uint8_t i = 0; i < 4 && stuck_high; i++)
+      {
+        if (digitalRead(GET_GDO0_PIN()) == LOW)
+          stuck_high = false;
+        delayMicroseconds(100);
+      }
+      if (stuck_high)
+      {
+        LOG_W("everblu_meter",
+              "GDO0 self-test FAILED: pin %d reads HIGH while the radio is IDLE (expected LOW). GDO0 is probably on the wrong GPIO or not connected - the pin has a pull-up, so an unwired pin reads HIGH. Every sync-word wait will then return instantly and 'received' frames will be noise. Check gdo0_pin against your board's CC1101 GDO0 pin.",
+              GET_GDO0_PIN());
+      }
+      else
+      {
+        echo_debug(debug_out, "[CC1101] GDO0 self-test passed (LOW while idle)\n");
+      }
+    }
+  }
 
   // One-time GDO2 wiring self-test. With IOCFG2 in TX-FIFO-threshold mode (0x02, set by
   // cc1101_configureRF_0) GDO2 must read LOW with an empty TX FIFO and HIGH once the FIFO

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -315,6 +315,10 @@ void cc1101_set_rx_attenuation(int db)
 // Monotonic (lifetime) counter; surfaced via cc1101_get_gdo2_timeout_count() for telemetry.
 static uint32_t _gdo2_stuck_timeouts = 0;
 
+// Latest verdict of the GDO0 idle-level self-test (see cc1101_init). Kept as state rather
+// than a log line only, so the fault is visible in the diagnostic report at any time.
+static bool _gdo0_disconnected = false;
+
 uint32_t cc1101_get_gdo2_timeout_count(void)
 {
   return _gdo2_stuck_timeouts;
@@ -801,6 +805,7 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
   out->pktctrl0 = halRfReadReg(PKTCTRL0);
   out->rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR));
   out->lqi = halRfReadReg(LQI_ADDR) & 0x7F;
+  out->gdo0_disconnected = _gdo0_disconnected;
 
   if (GET_GDO0_PIN() >= 0)
     out->gdo0_level = (digitalRead(GET_GDO0_PIN()) == LOW) ? 0 : 1;
@@ -859,39 +864,43 @@ bool cc1101_init(float freq)
 
   echo_debug(debug_out, "[CC1101] Frequency synthesizer calibrated for %.6f MHz\n", freq);
 
-  // One-time GDO0 wiring self-test. IOCFG0 is sync-word-detect (set by
-  // cc1101_configureRF_0) and the radio is IDLE here, so a correctly wired GDO0 must read
-  // LOW. The pin is configured INPUT_PULLUP, so an unconnected or wrong GPIO reads HIGH.
-  // Without this check a wrong gdo0_pin fails silently in a way that looks like success:
-  // every "wait for GDO0" loop returns immediately, so the logs show "GDO0 triggered at
-  // 0ms" and a frame is "received" that is really just noise (issue seen on boards where
-  // GDO0 was pointed at an unrelated peripheral pin).
+  // GDO0 wiring self-test. IOCFG0 is sync-word-detect (set by cc1101_configureRF_0) and
+  // the radio is IDLE here, so a correctly wired GDO0 must read LOW. The pin is configured
+  // INPUT_PULLUP, so an unconnected or wrong GPIO reads HIGH. Without this check a wrong
+  // gdo0_pin fails silently in a way that looks like success: every "wait for GDO0" loop
+  // returns immediately, so the logs show "GDO0 triggered at 0ms" and a frame is
+  // "received" that is really just noise (issue seen on boards where GDO0 was pointed at
+  // an unrelated peripheral pin).
+  //
+  // The check runs on every init - it costs one strobe and a few reads - but the warning
+  // is emitted once, because a frequency scan calls cc1101_init() per step and would
+  // otherwise repeat it dozens of times. The verdict is kept in _gdo0_disconnected so it
+  // stays visible through cc1101_collect_diagnostics().
   {
-    static bool s_gdo0_selftest_done = false;
-    if (!s_gdo0_selftest_done)
+    CC1101_CMD(SIDLE);
+    delayMicroseconds(100);
+    // Sample a few times: a genuinely idle GDO0 is steady, so a single reading is enough
+    // in principle, but repeating costs nothing and avoids reacting to a transient.
+    bool stuck_high = true;
+    for (uint8_t i = 0; i < 4 && stuck_high; i++)
     {
-      s_gdo0_selftest_done = true;
-      CC1101_CMD(SIDLE);
+      if (digitalRead(GET_GDO0_PIN()) == LOW)
+        stuck_high = false;
       delayMicroseconds(100);
-      // Sample a few times: a genuinely idle GDO0 is steady, so a single reading is enough
-      // in principle, but repeating costs nothing and avoids reacting to a transient.
-      bool stuck_high = true;
-      for (uint8_t i = 0; i < 4 && stuck_high; i++)
-      {
-        if (digitalRead(GET_GDO0_PIN()) == LOW)
-          stuck_high = false;
-        delayMicroseconds(100);
-      }
-      if (stuck_high)
-      {
-        LOG_W("everblu_meter",
-              "GDO0 self-test FAILED: pin %d reads HIGH while the radio is IDLE (expected LOW). GDO0 is probably on the wrong GPIO or not connected - the pin has a pull-up, so an unwired pin reads HIGH. Every sync-word wait will then return instantly and 'received' frames will be noise. Check gdo0_pin against your board's CC1101 GDO0 pin.",
-              GET_GDO0_PIN());
-      }
-      else
-      {
-        echo_debug(debug_out, "[CC1101] GDO0 self-test passed (LOW while idle)\n");
-      }
+    }
+    _gdo0_disconnected = stuck_high;
+
+    static bool s_gdo0_warning_logged = false;
+    if (stuck_high && !s_gdo0_warning_logged)
+    {
+      s_gdo0_warning_logged = true;
+      LOG_W("everblu_meter",
+            "GDO0 self-test FAILED: pin %d reads HIGH while the radio is IDLE (expected LOW). GDO0 is probably on the wrong GPIO or not connected - the pin has a pull-up, so an unwired pin reads HIGH. Every sync-word wait will then return instantly and 'received' frames will be noise. Check gdo0_pin against your board's CC1101 GDO0 pin.",
+            GET_GDO0_PIN());
+    }
+    else if (!stuck_high)
+    {
+      echo_debug(debug_out, "[CC1101] GDO0 self-test passed (LOW while idle)\n");
     }
   }
 

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -690,6 +690,12 @@ static bool cc1101_verify_spi_link(uint8_t *partnum_out, uint8_t *version_out)
   // Round 1 then round 2 use complementary patterns, so between them every data bit is
   // driven both high and low in each direction.
   static const uint8_t kProbe[2][2] = {{0xAA, 0x55}, {0x55, 0xAA}};
+  // cc1101_init() rewrites the sync word straight afterwards, but
+  // cc1101_collect_diagnostics() runs against a configured, listening radio and must not
+  // leave the scratch pattern behind: SYNC0 would stay at 0xAA instead of the operational
+  // 0x00, so a parked receiver would be matching on the wrong sync word.
+  const uint8_t saved_sync1 = halRfReadReg(SYNC1);
+  const uint8_t saved_sync0 = halRfReadReg(SYNC0);
   bool readback_ok = true;
   for (uint8_t round = 0; round < 2 && readback_ok; round++)
   {
@@ -700,6 +706,8 @@ static bool cc1101_verify_spi_link(uint8_t *partnum_out, uint8_t *version_out)
       readback_ok = false;
     }
   }
+  halRfWriteReg(SYNC1, saved_sync1);
+  halRfWriteReg(SYNC0, saved_sync0);
 
   uint8_t partnum = halRfReadReg(PARTNUM_ADDR);
   uint8_t version = halRfReadReg(VERSION_ADDR);
@@ -782,7 +790,6 @@ bool cc1101_probe_spi_link(uint8_t *partnum_out, uint8_t *version_out)
 void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
 {
   int8_t cc1100_rssi_convert2dbm(uint8_t Rssi_dec); // defined below
-
   if (out == NULL)
     return;
 
@@ -811,6 +818,39 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
     out->gdo0_level = (digitalRead(GET_GDO0_PIN()) == LOW) ? 0 : 1;
   if (GET_GDO2_PIN() >= 0)
     out->gdo2_level = (digitalRead(GET_GDO2_PIN()) == LOW) ? 0 : 1;
+}
+
+const char *cc1101_marcstate_name(uint8_t marcstate)
+{
+  // Datasheet Table 25. Reported raw, a value such as 0x11 reads as a fault when it is
+  // usually just a receiver that has been parked with nothing draining the FIFO.
+  switch (marcstate & 0x1F)
+  {
+  case 0x00: return "SLEEP";
+  case 0x01: return "IDLE";
+  case 0x02: return "XOFF";
+  case 0x03: return "VCOON_MC";
+  case 0x04: return "REGON_MC";
+  case 0x05: return "MANCAL";
+  case 0x06: return "VCOON";
+  case 0x07: return "REGON";
+  case 0x08: return "STARTCAL";
+  case 0x09: return "BWBOOST";
+  case 0x0A: return "FS_LOCK";
+  case 0x0B: return "IFADCON";
+  case 0x0C: return "ENDCAL";
+  case 0x0D: return "RX";
+  case 0x0E: return "RX_END";
+  case 0x0F: return "RX_RST";
+  case 0x10: return "TXRX_SWITCH";
+  case 0x11: return "RXFIFO_OVERFLOW";
+  case 0x12: return "FSTXON";
+  case 0x13: return "TX";
+  case 0x14: return "TX_END";
+  case 0x15: return "RXTX_SWITCH";
+  case 0x16: return "TXFIFO_UNDERFLOW";
+  default: return "unknown";
+  }
 }
 
 bool cc1101_init(float freq)

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -810,6 +810,7 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
   out->mdmcfg3 = halRfReadReg(MDMCFG3);
   out->mdmcfg2 = halRfReadReg(MDMCFG2);
   out->pktctrl0 = halRfReadReg(PKTCTRL0);
+  out->carrier_mhz = cc1101_freq_registers_to_mhz(out->freq2, out->freq1, out->freq0);
   out->rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR));
   out->lqi = halRfReadReg(LQI_ADDR) & 0x7F;
   out->gdo0_disconnected = _gdo0_disconnected;
@@ -818,6 +819,12 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
     out->gdo0_level = (digitalRead(GET_GDO0_PIN()) == LOW) ? 0 : 1;
   if (GET_GDO2_PIN() >= 0)
     out->gdo2_level = (digitalRead(GET_GDO2_PIN()) == LOW) ? 0 : 1;
+}
+
+float cc1101_freq_registers_to_mhz(uint8_t freq2, uint8_t freq1, uint8_t freq0)
+{
+  const uint32_t freq = ((uint32_t) freq2 << 16) | ((uint32_t) freq1 << 8) | (uint32_t) freq0;
+  return (float) freq * 26.0f / 65536.0f;
 }
 
 const char *cc1101_marcstate_name(uint8_t marcstate)

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -138,6 +138,17 @@ typedef struct
 void cc1101_collect_diagnostics(cc1101_diagnostics_t *out);
 
 /**
+ * @brief Human-readable name for a MARCSTATE value (datasheet Table 25).
+ *
+ * Reported as a bare number, a state such as 0x11 reads as a fault when it is usually
+ * just a receiver parked with nothing draining the FIFO.
+ *
+ * @param marcstate Raw MARCSTATE register value.
+ * @return Static string, never NULL; "unknown" for undefined values.
+ */
+const char *cc1101_marcstate_name(uint8_t marcstate);
+
+/**
  * @enum ReadFailure
  * @brief Why a meter read produced no usable data
  *

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -83,6 +83,55 @@ void cc1101_set_rx_attenuation(int db);
 uint32_t cc1101_get_gdo2_timeout_count(void);
 
 /**
+ * @brief Probe the SPI link to the CC1101 without configuring the radio.
+ *
+ * Performs the same reset + write/read-back self-test as cc1101_init(), but stops there.
+ * Intended to be called early (for example from an ESPHome setup()) so a dead or
+ * mis-wired SPI link is reported in the boot log, rather than only surfacing later when
+ * the first read is attempted. Failures are logged with the same remediation guidance.
+ *
+ * @param partnum_out Optional; receives the PARTNUM register value.
+ * @param version_out Optional; receives the VERSION register value.
+ * @return true when the radio answered and the bus is trustworthy.
+ */
+bool cc1101_probe_spi_link(uint8_t *partnum_out, uint8_t *version_out);
+
+/**
+ * @brief Snapshot of radio identity, key registers and GDO line levels.
+ *
+ * Everything a support request needs in order to tell a wiring fault from an RF problem,
+ * captured in one pass so it can be logged as a single copy-pasteable block.
+ */
+typedef struct
+{
+  bool link_ok;      /**< SPI write/read-back self-test passed */
+  uint8_t partnum;   /**< PARTNUM: 0x00 on a genuine CC1101 */
+  uint8_t version;   /**< VERSION: 0x04 or 0x14 on known revisions */
+  uint8_t marcstate; /**< Main radio control state machine state */
+  uint8_t freq2;     /**< Carrier frequency, MSB */
+  uint8_t freq1;
+  uint8_t freq0;
+  uint8_t mdmcfg4; /**< RX filter bandwidth + data rate exponent */
+  uint8_t mdmcfg3;
+  uint8_t mdmcfg2;
+  uint8_t pktctrl0;
+  int8_t rssi_dbm; /**< Current RSSI, converted to dBm */
+  uint8_t lqi;
+  int gdo0_level; /**< 0 = LOW, 1 = HIGH, -1 = pin not configured */
+  int gdo2_level; /**< 0 = LOW, 1 = HIGH, -1 = pin not configured */
+} cc1101_diagnostics_t;
+
+/**
+ * @brief Fill @p out with a one-shot diagnostic snapshot of the radio.
+ *
+ * Safe to call at any time; does not reset or reconfigure the radio. When the SPI link
+ * is untrustworthy, link_ok is false and the register values are meaningless.
+ *
+ * @param out Destination struct; ignored when NULL.
+ */
+void cc1101_collect_diagnostics(cc1101_diagnostics_t *out);
+
+/**
  * @enum ReadFailure
  * @brief Why a meter read produced no usable data
  *

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -111,6 +111,15 @@ typedef struct
   uint8_t freq2;     /**< Carrier frequency, MSB */
   uint8_t freq1;
   uint8_t freq0;
+  /**
+   * Carrier frequency decoded from FREQ2/1/0, in MHz.
+   *
+   * Read back from the radio, so this is where it is actually tuned. It differs from the
+   * configured base frequency by whatever calibration offset is in effect, which is the
+   * point: a mismatch between the two is otherwise invisible without doing the arithmetic
+   * by hand.
+   */
+  float carrier_mhz;
   uint8_t mdmcfg4; /**< RX filter bandwidth + data rate exponent */
   uint8_t mdmcfg3;
   uint8_t mdmcfg2;
@@ -147,6 +156,15 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out);
  * @return Static string, never NULL; "unknown" for undefined values.
  */
 const char *cc1101_marcstate_name(uint8_t marcstate);
+
+/**
+ * @brief Convert the CC1101 FREQ2/FREQ1/FREQ0 register triple to MHz.
+ *
+ * Inverse of setMHZ(): f_carrier = FREQ * f_xosc / 2^16, with a 26 MHz crystal.
+ *
+ * @return Carrier frequency in MHz.
+ */
+float cc1101_freq_registers_to_mhz(uint8_t freq2, uint8_t freq1, uint8_t freq0);
 
 /**
  * @enum ReadFailure

--- a/ESPHOME-release/everblu_meter/cc1101.h
+++ b/ESPHOME-release/everblu_meter/cc1101.h
@@ -119,6 +119,12 @@ typedef struct
   uint8_t lqi;
   int gdo0_level; /**< 0 = LOW, 1 = HIGH, -1 = pin not configured */
   int gdo2_level; /**< 0 = LOW, 1 = HIGH, -1 = pin not configured */
+  /**
+   * True when the last cc1101_init() found GDO0 HIGH while the radio was IDLE, which means
+   * the pin is almost certainly on the wrong GPIO or not connected. Sync-word waits then
+   * return instantly and "received" frames are noise.
+   */
+  bool gdo0_disconnected;
 } cc1101_diagnostics_t;
 
 /**

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -17,6 +17,18 @@ namespace everblu_meter {
 
 static const char *const TAG = "everblu_meter";
 
+namespace {
+// Render a pin as e.g. "GPIO3" into caller-supplied storage, or return the fallback text
+// when the pin is unset. Uses the buffer-based dump_summary(); the std::string overload is
+// deprecated and is removed in ESPHome 2026.7.0.
+const char *pin_summary(GPIOPin *pin, char *buffer, size_t len, const char *fallback) {
+  if (pin == nullptr)
+    return fallback;
+  pin->dump_summary(buffer, len);
+  return buffer;
+}
+}  // namespace
+
 // ESPHome's documented guidance is that a component's loop() should block for at
 // most ~30 ms (https://developers.esphome.io/architecture/components/); the
 // runtime "took a long time" warning in recent releases fires at ~2550 ms.
@@ -49,6 +61,8 @@ void EverbluMeterTriggerButton::press_action() {
     this->parent_->request_deep_scan();
   } else if (this->is_reset_frequency_) {
     this->parent_->request_reset_frequency();
+  } else if (this->is_diagnostic_) {
+    this->parent_->request_diagnostic_report();
   } else {
     this->parent_->request_manual_read();
   }
@@ -158,6 +172,14 @@ void EverbluMeterComponent::setup() {
 
   // Initialize CC1101 context before creating meter reader
   this->apply_radio_context();
+
+  // Probe the SPI link now rather than waiting for the meter reader to be initialised on
+  // the first Home Assistant connection. A stuck MISO or a wrong cs_pin/miso_pin is a hard
+  // wiring fault, and users routinely capture only the boot log; deferring the check meant
+  // those reports contained no evidence of it at all. The result is reported by
+  // dump_config() and the failure guidance is logged by the driver.
+  this->spi_probe_ran_ = true;
+  this->spi_link_ok_ = cc1101_probe_spi_link(&this->spi_partnum_, &this->spi_version_);
 
   // Create meter reader with all adapters (but don't initialize yet)
   this->meter_reader_ = new MeterReader(this->config_provider_, this->time_provider_, this->data_publisher_);
@@ -367,6 +389,49 @@ void EverbluMeterComponent::request_stop_reading() {
   this->meter_reader_->stopReading();
 }
 
+void EverbluMeterComponent::request_diagnostic_report() {
+  // Deliberately does not require meter_reader_: the most common reason to press this is
+  // that the radio never came up, and a report is most useful precisely then.
+  this->apply_radio_context();
+
+  cc1101_diagnostics_t diag;
+  cc1101_collect_diagnostics(&diag);
+
+  const char *gdo_level[3] = {"LOW", "HIGH", "not configured"};
+  auto level_text = [&](int level) { return gdo_level[level < 0 ? 2 : level]; };
+
+  char cs_text[GPIO_SUMMARY_MAX_LEN];
+  char gdo0_text[GPIO_SUMMARY_MAX_LEN];
+  char gdo2_text[GPIO_SUMMARY_MAX_LEN];
+
+  ESP_LOGI(TAG,
+           "===== EverBlu diagnostic report =====\n"
+           "  Component Version: %s\n"
+           "  Meter Code: %s (year=%u, serial=%lu, %s)\n"
+           "  Configured Frequency: %.6f MHz\n"
+           "  RX Attenuation: %d dB\n"
+           "  CS Pin: %s, GDO0 Pin: %s, GDO2 Pin: %s\n"
+           "  SPI Link Self-Test: %s\n"
+           "  PARTNUM: 0x%02X (expect 0x00), VERSION: 0x%02X (expect 0x04 or 0x14)\n"
+           "  MARCSTATE: 0x%02X, PKTCTRL0: 0x%02X\n"
+           "  FREQ2/1/0: 0x%02X 0x%02X 0x%02X\n"
+           "  MDMCFG4/3/2: 0x%02X 0x%02X 0x%02X\n"
+           "  RSSI: %d dBm, LQI: %u\n"
+           "  GDO0 level: %s (expect LOW while idle), GDO2 level: %s\n"
+           "  GDO2 fault count: %lu\n"
+           "  Meter reader initialised: %s\n"
+           "===== end of report =====",
+           EVERBLU_FW_VERSION, this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
+           this->is_gas_ ? "Gas" : "Water", this->frequency_, this->rx_attenuation_db_,
+           pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured"),
+           pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured"),
+           pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled"),
+           diag.link_ok ? "PASSED" : "FAILED - register values below are meaningless", diag.partnum, diag.version,
+           diag.marcstate, diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0, diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2,
+           diag.rssi_dbm, diag.lqi, level_text(diag.gdo0_level), level_text(diag.gdo2_level),
+           (unsigned long) cc1101_get_gdo2_timeout_count(), this->meter_initialized_ ? "yes" : "no");
+}
+
 void EverbluMeterComponent::apply_radio_context() {
   auto *spi_device = static_cast<spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                                 spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> *>(this);
@@ -401,6 +466,26 @@ void EverbluMeterComponent::update() {
 }
 
 void EverbluMeterComponent::dump_config() {
+  // Report the actual GPIO numbers rather than just "configured". A wrong gdo0_pin or
+  // cs_pin is one of the most common setup faults, and support requests almost always
+  // consist of this block alone - without the numbers it cannot be checked against the
+  // board's pinout.
+  char spi_selftest[128];
+  if (!this->spi_probe_ran_) {
+    snprintf(spi_selftest, sizeof(spi_selftest), "not run");
+  } else if (this->spi_link_ok_) {
+    snprintf(spi_selftest, sizeof(spi_selftest), "PASSED (PARTNUM: 0x%02X, VERSION: 0x%02X)", this->spi_partnum_,
+             this->spi_version_);
+  } else {
+    snprintf(spi_selftest, sizeof(spi_selftest),
+             "FAILED (PARTNUM: 0x%02X, VERSION: 0x%02X) - the radio is not being read; see the errors above",
+             this->spi_partnum_, this->spi_version_);
+  }
+
+  char cs_text[GPIO_SUMMARY_MAX_LEN];
+  char gdo0_text[GPIO_SUMMARY_MAX_LEN];
+  char gdo2_text[GPIO_SUMMARY_MAX_LEN];
+
   ESP_LOGCONFIG(TAG,
                 "EverBlu Meter:\n"
                 "  Meter Code: %s (year=%u, serial=%lu)\n"
@@ -416,17 +501,23 @@ void EverbluMeterComponent::dump_config() {
                 "  Max Retries: %d\n"
                 "  Retry Cooldown: %lu ms\n"
                 "  Initial Read On Boot: %s\n"
+                "  RX Attenuation: %d dB\n"
+                "  CS Pin: %s\n"
                 "  GDO0 Pin: %s\n"
-                "  GDO2 Pin: %s",
+                "  GDO2 Pin: %s\n"
+                "  SPI Link Self-Test: %s",
                 this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
                 this->is_gas_ ? "Gas" : "Water", EVERBLU_FW_VERSION, this->frequency_,
                 this->auto_scan_ ? "Enabled" : "Disabled", this->reading_schedule_.c_str(), this->read_hour_,
                 this->read_minute_, this->timezone_offset_, this->auto_align_time_ ? "Enabled" : "Disabled",
                 this->auto_align_midpoint_ ? "Enabled" : "Disabled", this->max_retries_, this->retry_cooldown_ms_,
-                this->initial_read_on_boot_ ? "Enabled" : "Disabled",
-                this->gdo0_pin_ != nullptr ? "configured" : "NOT configured (error)",
-                this->gdo2_pin_ != nullptr ? "configured (HW FIFO threshold, TX+RX dynamic)"
-                                           : "disabled (legacy SPI polling fallback)");
+                this->initial_read_on_boot_ ? "Enabled" : "Disabled", this->rx_attenuation_db_,
+                pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured (error)"),
+                pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured (error)"),
+                pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled (legacy SPI polling fallback)"),
+                spi_selftest);
+  if (this->gdo2_pin_ != nullptr)
+    ESP_LOGCONFIG(TAG, "    GDO2 mode: HW FIFO threshold, TX+RX dynamic");
   if (this->is_gas_)
     ESP_LOGCONFIG(TAG, "  Gas Volume Divisor: %d", this->gas_volume_divisor_);
 

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -425,11 +425,11 @@ void EverbluMeterComponent::request_diagnostic_report() {
            diag.link_ok ? "PASSED" : "FAILED - the register values below are meaningless", diag.partnum, diag.version);
   ESP_LOGI(TAG,
            "  MARCSTATE: 0x%02X (%s), PKTCTRL0: 0x%02X\n"
-           "  FREQ2/1/0: 0x%02X 0x%02X 0x%02X\n"
+           "  FREQ2/1/0: 0x%02X 0x%02X 0x%02X -> carrier %.6f MHz (configured base %.6f MHz)\n"
            "  MDMCFG4/3/2: 0x%02X 0x%02X 0x%02X\n"
-           "  RSSI: %d dBm, LQI: %u",
+           "  RSSI: %d dBm, LQI: %u (last measurement; only meaningful after a frame arrives)",
            diag.marcstate, cc1101_marcstate_name(diag.marcstate), diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0,
-           diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2, diag.rssi_dbm, diag.lqi);
+           diag.carrier_mhz, this->frequency_, diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2, diag.rssi_dbm, diag.lqi);
   ESP_LOGI(TAG,
            "  GDO0 level: %s (expect LOW while idle), GDO2 level: %s\n"
            "  GDO0 wiring self-test: %s\n"

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -418,6 +418,7 @@ void EverbluMeterComponent::request_diagnostic_report() {
            "  MDMCFG4/3/2: 0x%02X 0x%02X 0x%02X\n"
            "  RSSI: %d dBm, LQI: %u\n"
            "  GDO0 level: %s (expect LOW while idle), GDO2 level: %s\n"
+           "  GDO0 wiring self-test: %s\n"
            "  GDO2 fault count: %lu\n"
            "  Meter reader initialised: %s\n"
            "===== end of report =====",
@@ -429,6 +430,7 @@ void EverbluMeterComponent::request_diagnostic_report() {
            diag.link_ok ? "PASSED" : "FAILED - register values below are meaningless", diag.partnum, diag.version,
            diag.marcstate, diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0, diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2,
            diag.rssi_dbm, diag.lqi, level_text(diag.gdo0_level), level_text(diag.gdo2_level),
+           diag.gdo0_disconnected ? "FAILED - GDO0 looks unconnected or on the wrong GPIO" : "passed",
            (unsigned long) cc1101_get_gdo2_timeout_count(), this->meter_initialized_ ? "yes" : "no");
 }
 

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -404,34 +404,41 @@ void EverbluMeterComponent::request_diagnostic_report() {
   char gdo0_text[GPIO_SUMMARY_MAX_LEN];
   char gdo2_text[GPIO_SUMMARY_MAX_LEN];
 
+  // Emitted as several calls rather than one block: the logger truncates a single message
+  // at its transmit buffer (512 bytes by default), which cut the report off part-way
+  // through the GDO0 line and lost the wiring verdicts that matter most.
+  ESP_LOGI(TAG, "===== EverBlu diagnostic report =====");
   ESP_LOGI(TAG,
-           "===== EverBlu diagnostic report =====\n"
            "  Component Version: %s\n"
            "  Meter Code: %s (year=%u, serial=%lu, %s)\n"
            "  Configured Frequency: %.6f MHz\n"
-           "  RX Attenuation: %d dB\n"
-           "  CS Pin: %s, GDO0 Pin: %s, GDO2 Pin: %s\n"
+           "  RX Attenuation: %d dB",
+           EVERBLU_FW_VERSION, this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
+           this->is_gas_ ? "Gas" : "Water", this->frequency_, this->rx_attenuation_db_);
+  ESP_LOGI(TAG, "  CS Pin: %s, GDO0 Pin: %s, GDO2 Pin: %s",
+           pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured"),
+           pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured"),
+           pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled"));
+  ESP_LOGI(TAG,
            "  SPI Link Self-Test: %s\n"
-           "  PARTNUM: 0x%02X (expect 0x00), VERSION: 0x%02X (expect 0x04 or 0x14)\n"
-           "  MARCSTATE: 0x%02X, PKTCTRL0: 0x%02X\n"
+           "  PARTNUM: 0x%02X (expect 0x00), VERSION: 0x%02X (expect 0x04 or 0x14)",
+           diag.link_ok ? "PASSED" : "FAILED - the register values below are meaningless", diag.partnum, diag.version);
+  ESP_LOGI(TAG,
+           "  MARCSTATE: 0x%02X (%s), PKTCTRL0: 0x%02X\n"
            "  FREQ2/1/0: 0x%02X 0x%02X 0x%02X\n"
            "  MDMCFG4/3/2: 0x%02X 0x%02X 0x%02X\n"
-           "  RSSI: %d dBm, LQI: %u\n"
+           "  RSSI: %d dBm, LQI: %u",
+           diag.marcstate, cc1101_marcstate_name(diag.marcstate), diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0,
+           diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2, diag.rssi_dbm, diag.lqi);
+  ESP_LOGI(TAG,
            "  GDO0 level: %s (expect LOW while idle), GDO2 level: %s\n"
            "  GDO0 wiring self-test: %s\n"
            "  GDO2 fault count: %lu\n"
-           "  Meter reader initialised: %s\n"
-           "===== end of report =====",
-           EVERBLU_FW_VERSION, this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
-           this->is_gas_ ? "Gas" : "Water", this->frequency_, this->rx_attenuation_db_,
-           pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured"),
-           pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured"),
-           pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled"),
-           diag.link_ok ? "PASSED" : "FAILED - register values below are meaningless", diag.partnum, diag.version,
-           diag.marcstate, diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0, diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2,
-           diag.rssi_dbm, diag.lqi, level_text(diag.gdo0_level), level_text(diag.gdo2_level),
+           "  Meter reader initialised: %s",
+           level_text(diag.gdo0_level), level_text(diag.gdo2_level),
            diag.gdo0_disconnected ? "FAILED - GDO0 looks unconnected or on the wrong GPIO" : "passed",
            (unsigned long) cc1101_get_gdo2_timeout_count(), this->meter_initialized_ ? "yes" : "no");
+  ESP_LOGI(TAG, "===== end of report =====");
 }
 
 void EverbluMeterComponent::apply_radio_context() {

--- a/ESPHOME-release/everblu_meter/everblu_meter.h
+++ b/ESPHOME-release/everblu_meter/everblu_meter.h
@@ -48,6 +48,7 @@ class EverbluMeterTriggerButton final : public button::Button {
   void set_deep_scan(bool is_deep_scan) { this->is_deep_scan_ = is_deep_scan; }
   void set_reset_frequency(bool is_reset) { this->is_reset_frequency_ = is_reset; }
   void set_stop(bool is_stop) { this->is_stop_ = is_stop; }
+  void set_diagnostic(bool is_diagnostic) { this->is_diagnostic_ = is_diagnostic; }
 
  protected:
   void press_action() override;
@@ -57,6 +58,7 @@ class EverbluMeterTriggerButton final : public button::Button {
   bool is_deep_scan_{false};
   bool is_reset_frequency_{false};
   bool is_stop_{false};
+  bool is_diagnostic_{false};
 };
 
 class EverbluMeterComponent final : public PollingComponent,
@@ -143,6 +145,7 @@ class EverbluMeterComponent final : public PollingComponent,
   void request_deep_scan();
   void request_reset_frequency();
   void request_stop_reading();
+  void request_diagnostic_report();
 
  protected:
   // Configuration
@@ -170,6 +173,14 @@ class EverbluMeterComponent final : public PollingComponent,
   void republish_initial_states();
   void apply_radio_context();
   bool gdo0_error_logged_{false};  // One-shot flag to prevent log flooding
+
+  // Boot-time SPI link probe result, captured in setup() and reported by dump_config()
+  // so a dead or mis-wired bus is visible in the config block every user copies, without
+  // waiting for a Home Assistant connection or a button press.
+  bool spi_probe_ran_{false};
+  bool spi_link_ok_{false};
+  uint8_t spi_partnum_{0};
+  uint8_t spi_version_{0};
 
   // GDO0 pin (required) and GDO2 pin (optional TX FIFO threshold)
   InternalGPIOPin *gdo0_pin_{nullptr};

--- a/ESPHOME/README.md
+++ b/ESPHOME/README.md
@@ -587,6 +587,7 @@ EverbluMeterComponent (ESPHome)
 - **stop_reading_button** - Cancel the current read/retry sequence. Also requests best-effort cancellation of an in-progress deep frequency scan (it bails at the next step; see [#133](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/133))
 - **deep_scan_button** - Trigger a Deep frequency scan (±150 kHz, fine 2.5 kHz steps, maps the response window then zooms to the carrier centre)
 - **reset_frequency_button** - Reset the frequency offset
+- **diagnostic_report_button** - Print a single copy-pasteable block covering the configured pins, the live SPI link self-test, the key CC1101 registers and the current GDO0/GDO2 levels. Press this first when raising an issue; it captures in one place everything needed to tell a wiring fault from an RF problem, and it works even when the radio never came up
 
 ### Frequency scans in multi-meter setups
 

--- a/ESPHOME/components/everblu_meter/__init__.py
+++ b/ESPHOME/components/everblu_meter/__init__.py
@@ -108,6 +108,7 @@ CONF_REQUEST_READING_BUTTON = "request_reading_button"
 CONF_DEEP_SCAN_BUTTON = "deep_scan_button"
 CONF_RESET_FREQUENCY_BUTTON = "reset_frequency_button"
 CONF_STOP_READING_BUTTON = "stop_reading_button"
+CONF_DIAGNOSTIC_REPORT_BUTTON = "diagnostic_report_button"
 CONF_RX_ATTENUATION = "rx_attenuation"
 
 # Meter types
@@ -423,6 +424,11 @@ CONFIG_SCHEMA = (
                 EverbluMeterTriggerButton,
                 icon="mdi:stop-circle-outline",
                 entity_category="config",
+            ),
+            cv.Optional(CONF_DIAGNOSTIC_REPORT_BUTTON): button.button_schema(
+                EverbluMeterTriggerButton,
+                icon="mdi:clipboard-text-search-outline",
+                entity_category="diagnostic",
             ),
         }
     )
@@ -744,3 +750,8 @@ async def to_code(config):
         btn = await button.new_button(config[CONF_STOP_READING_BUTTON])
         cg.add(btn.set_parent(var))
         cg.add(btn.set_stop(True))
+
+    if CONF_DIAGNOSTIC_REPORT_BUTTON in config:
+        btn = await button.new_button(config[CONF_DIAGNOSTIC_REPORT_BUTTON])
+        cg.add(btn.set_parent(var))
+        cg.add(btn.set_diagnostic(True))

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -17,6 +17,18 @@ namespace everblu_meter {
 
 static const char *const TAG = "everblu_meter";
 
+namespace {
+// Render a pin as e.g. "GPIO3" into caller-supplied storage, or return the fallback text
+// when the pin is unset. Uses the buffer-based dump_summary(); the std::string overload is
+// deprecated and is removed in ESPHome 2026.7.0.
+const char *pin_summary(GPIOPin *pin, char *buffer, size_t len, const char *fallback) {
+  if (pin == nullptr)
+    return fallback;
+  pin->dump_summary(buffer, len);
+  return buffer;
+}
+}  // namespace
+
 // ESPHome's documented guidance is that a component's loop() should block for at
 // most ~30 ms (https://developers.esphome.io/architecture/components/); the
 // runtime "took a long time" warning in recent releases fires at ~2550 ms.
@@ -49,6 +61,8 @@ void EverbluMeterTriggerButton::press_action() {
     this->parent_->request_deep_scan();
   } else if (this->is_reset_frequency_) {
     this->parent_->request_reset_frequency();
+  } else if (this->is_diagnostic_) {
+    this->parent_->request_diagnostic_report();
   } else {
     this->parent_->request_manual_read();
   }
@@ -158,6 +172,14 @@ void EverbluMeterComponent::setup() {
 
   // Initialize CC1101 context before creating meter reader
   this->apply_radio_context();
+
+  // Probe the SPI link now rather than waiting for the meter reader to be initialised on
+  // the first Home Assistant connection. A stuck MISO or a wrong cs_pin/miso_pin is a hard
+  // wiring fault, and users routinely capture only the boot log; deferring the check meant
+  // those reports contained no evidence of it at all. The result is reported by
+  // dump_config() and the failure guidance is logged by the driver.
+  this->spi_probe_ran_ = true;
+  this->spi_link_ok_ = cc1101_probe_spi_link(&this->spi_partnum_, &this->spi_version_);
 
   // Create meter reader with all adapters (but don't initialize yet)
   this->meter_reader_ = new MeterReader(this->config_provider_, this->time_provider_, this->data_publisher_);
@@ -367,6 +389,49 @@ void EverbluMeterComponent::request_stop_reading() {
   this->meter_reader_->stopReading();
 }
 
+void EverbluMeterComponent::request_diagnostic_report() {
+  // Deliberately does not require meter_reader_: the most common reason to press this is
+  // that the radio never came up, and a report is most useful precisely then.
+  this->apply_radio_context();
+
+  cc1101_diagnostics_t diag;
+  cc1101_collect_diagnostics(&diag);
+
+  const char *gdo_level[3] = {"LOW", "HIGH", "not configured"};
+  auto level_text = [&](int level) { return gdo_level[level < 0 ? 2 : level]; };
+
+  char cs_text[GPIO_SUMMARY_MAX_LEN];
+  char gdo0_text[GPIO_SUMMARY_MAX_LEN];
+  char gdo2_text[GPIO_SUMMARY_MAX_LEN];
+
+  ESP_LOGI(TAG,
+           "===== EverBlu diagnostic report =====\n"
+           "  Component Version: %s\n"
+           "  Meter Code: %s (year=%u, serial=%lu, %s)\n"
+           "  Configured Frequency: %.6f MHz\n"
+           "  RX Attenuation: %d dB\n"
+           "  CS Pin: %s, GDO0 Pin: %s, GDO2 Pin: %s\n"
+           "  SPI Link Self-Test: %s\n"
+           "  PARTNUM: 0x%02X (expect 0x00), VERSION: 0x%02X (expect 0x04 or 0x14)\n"
+           "  MARCSTATE: 0x%02X, PKTCTRL0: 0x%02X\n"
+           "  FREQ2/1/0: 0x%02X 0x%02X 0x%02X\n"
+           "  MDMCFG4/3/2: 0x%02X 0x%02X 0x%02X\n"
+           "  RSSI: %d dBm, LQI: %u\n"
+           "  GDO0 level: %s (expect LOW while idle), GDO2 level: %s\n"
+           "  GDO2 fault count: %lu\n"
+           "  Meter reader initialised: %s\n"
+           "===== end of report =====",
+           EVERBLU_FW_VERSION, this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
+           this->is_gas_ ? "Gas" : "Water", this->frequency_, this->rx_attenuation_db_,
+           pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured"),
+           pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured"),
+           pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled"),
+           diag.link_ok ? "PASSED" : "FAILED - register values below are meaningless", diag.partnum, diag.version,
+           diag.marcstate, diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0, diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2,
+           diag.rssi_dbm, diag.lqi, level_text(diag.gdo0_level), level_text(diag.gdo2_level),
+           (unsigned long) cc1101_get_gdo2_timeout_count(), this->meter_initialized_ ? "yes" : "no");
+}
+
 void EverbluMeterComponent::apply_radio_context() {
   auto *spi_device = static_cast<spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                                 spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> *>(this);
@@ -401,6 +466,26 @@ void EverbluMeterComponent::update() {
 }
 
 void EverbluMeterComponent::dump_config() {
+  // Report the actual GPIO numbers rather than just "configured". A wrong gdo0_pin or
+  // cs_pin is one of the most common setup faults, and support requests almost always
+  // consist of this block alone - without the numbers it cannot be checked against the
+  // board's pinout.
+  char spi_selftest[128];
+  if (!this->spi_probe_ran_) {
+    snprintf(spi_selftest, sizeof(spi_selftest), "not run");
+  } else if (this->spi_link_ok_) {
+    snprintf(spi_selftest, sizeof(spi_selftest), "PASSED (PARTNUM: 0x%02X, VERSION: 0x%02X)", this->spi_partnum_,
+             this->spi_version_);
+  } else {
+    snprintf(spi_selftest, sizeof(spi_selftest),
+             "FAILED (PARTNUM: 0x%02X, VERSION: 0x%02X) - the radio is not being read; see the errors above",
+             this->spi_partnum_, this->spi_version_);
+  }
+
+  char cs_text[GPIO_SUMMARY_MAX_LEN];
+  char gdo0_text[GPIO_SUMMARY_MAX_LEN];
+  char gdo2_text[GPIO_SUMMARY_MAX_LEN];
+
   ESP_LOGCONFIG(TAG,
                 "EverBlu Meter:\n"
                 "  Meter Code: %s (year=%u, serial=%lu)\n"
@@ -416,17 +501,23 @@ void EverbluMeterComponent::dump_config() {
                 "  Max Retries: %d\n"
                 "  Retry Cooldown: %lu ms\n"
                 "  Initial Read On Boot: %s\n"
+                "  RX Attenuation: %d dB\n"
+                "  CS Pin: %s\n"
                 "  GDO0 Pin: %s\n"
-                "  GDO2 Pin: %s",
+                "  GDO2 Pin: %s\n"
+                "  SPI Link Self-Test: %s",
                 this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
                 this->is_gas_ ? "Gas" : "Water", EVERBLU_FW_VERSION, this->frequency_,
                 this->auto_scan_ ? "Enabled" : "Disabled", this->reading_schedule_.c_str(), this->read_hour_,
                 this->read_minute_, this->timezone_offset_, this->auto_align_time_ ? "Enabled" : "Disabled",
                 this->auto_align_midpoint_ ? "Enabled" : "Disabled", this->max_retries_, this->retry_cooldown_ms_,
-                this->initial_read_on_boot_ ? "Enabled" : "Disabled",
-                this->gdo0_pin_ != nullptr ? "configured" : "NOT configured (error)",
-                this->gdo2_pin_ != nullptr ? "configured (HW FIFO threshold, TX+RX dynamic)"
-                                           : "disabled (legacy SPI polling fallback)");
+                this->initial_read_on_boot_ ? "Enabled" : "Disabled", this->rx_attenuation_db_,
+                pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured (error)"),
+                pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured (error)"),
+                pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled (legacy SPI polling fallback)"),
+                spi_selftest);
+  if (this->gdo2_pin_ != nullptr)
+    ESP_LOGCONFIG(TAG, "    GDO2 mode: HW FIFO threshold, TX+RX dynamic");
   if (this->is_gas_)
     ESP_LOGCONFIG(TAG, "  Gas Volume Divisor: %d", this->gas_volume_divisor_);
 

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -425,11 +425,11 @@ void EverbluMeterComponent::request_diagnostic_report() {
            diag.link_ok ? "PASSED" : "FAILED - the register values below are meaningless", diag.partnum, diag.version);
   ESP_LOGI(TAG,
            "  MARCSTATE: 0x%02X (%s), PKTCTRL0: 0x%02X\n"
-           "  FREQ2/1/0: 0x%02X 0x%02X 0x%02X\n"
+           "  FREQ2/1/0: 0x%02X 0x%02X 0x%02X -> carrier %.6f MHz (configured base %.6f MHz)\n"
            "  MDMCFG4/3/2: 0x%02X 0x%02X 0x%02X\n"
-           "  RSSI: %d dBm, LQI: %u",
+           "  RSSI: %d dBm, LQI: %u (last measurement; only meaningful after a frame arrives)",
            diag.marcstate, cc1101_marcstate_name(diag.marcstate), diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0,
-           diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2, diag.rssi_dbm, diag.lqi);
+           diag.carrier_mhz, this->frequency_, diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2, diag.rssi_dbm, diag.lqi);
   ESP_LOGI(TAG,
            "  GDO0 level: %s (expect LOW while idle), GDO2 level: %s\n"
            "  GDO0 wiring self-test: %s\n"

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -418,6 +418,7 @@ void EverbluMeterComponent::request_diagnostic_report() {
            "  MDMCFG4/3/2: 0x%02X 0x%02X 0x%02X\n"
            "  RSSI: %d dBm, LQI: %u\n"
            "  GDO0 level: %s (expect LOW while idle), GDO2 level: %s\n"
+           "  GDO0 wiring self-test: %s\n"
            "  GDO2 fault count: %lu\n"
            "  Meter reader initialised: %s\n"
            "===== end of report =====",
@@ -429,6 +430,7 @@ void EverbluMeterComponent::request_diagnostic_report() {
            diag.link_ok ? "PASSED" : "FAILED - register values below are meaningless", diag.partnum, diag.version,
            diag.marcstate, diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0, diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2,
            diag.rssi_dbm, diag.lqi, level_text(diag.gdo0_level), level_text(diag.gdo2_level),
+           diag.gdo0_disconnected ? "FAILED - GDO0 looks unconnected or on the wrong GPIO" : "passed",
            (unsigned long) cc1101_get_gdo2_timeout_count(), this->meter_initialized_ ? "yes" : "no");
 }
 

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -404,34 +404,41 @@ void EverbluMeterComponent::request_diagnostic_report() {
   char gdo0_text[GPIO_SUMMARY_MAX_LEN];
   char gdo2_text[GPIO_SUMMARY_MAX_LEN];
 
+  // Emitted as several calls rather than one block: the logger truncates a single message
+  // at its transmit buffer (512 bytes by default), which cut the report off part-way
+  // through the GDO0 line and lost the wiring verdicts that matter most.
+  ESP_LOGI(TAG, "===== EverBlu diagnostic report =====");
   ESP_LOGI(TAG,
-           "===== EverBlu diagnostic report =====\n"
            "  Component Version: %s\n"
            "  Meter Code: %s (year=%u, serial=%lu, %s)\n"
            "  Configured Frequency: %.6f MHz\n"
-           "  RX Attenuation: %d dB\n"
-           "  CS Pin: %s, GDO0 Pin: %s, GDO2 Pin: %s\n"
+           "  RX Attenuation: %d dB",
+           EVERBLU_FW_VERSION, this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
+           this->is_gas_ ? "Gas" : "Water", this->frequency_, this->rx_attenuation_db_);
+  ESP_LOGI(TAG, "  CS Pin: %s, GDO0 Pin: %s, GDO2 Pin: %s",
+           pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured"),
+           pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured"),
+           pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled"));
+  ESP_LOGI(TAG,
            "  SPI Link Self-Test: %s\n"
-           "  PARTNUM: 0x%02X (expect 0x00), VERSION: 0x%02X (expect 0x04 or 0x14)\n"
-           "  MARCSTATE: 0x%02X, PKTCTRL0: 0x%02X\n"
+           "  PARTNUM: 0x%02X (expect 0x00), VERSION: 0x%02X (expect 0x04 or 0x14)",
+           diag.link_ok ? "PASSED" : "FAILED - the register values below are meaningless", diag.partnum, diag.version);
+  ESP_LOGI(TAG,
+           "  MARCSTATE: 0x%02X (%s), PKTCTRL0: 0x%02X\n"
            "  FREQ2/1/0: 0x%02X 0x%02X 0x%02X\n"
            "  MDMCFG4/3/2: 0x%02X 0x%02X 0x%02X\n"
-           "  RSSI: %d dBm, LQI: %u\n"
+           "  RSSI: %d dBm, LQI: %u",
+           diag.marcstate, cc1101_marcstate_name(diag.marcstate), diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0,
+           diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2, diag.rssi_dbm, diag.lqi);
+  ESP_LOGI(TAG,
            "  GDO0 level: %s (expect LOW while idle), GDO2 level: %s\n"
            "  GDO0 wiring self-test: %s\n"
            "  GDO2 fault count: %lu\n"
-           "  Meter reader initialised: %s\n"
-           "===== end of report =====",
-           EVERBLU_FW_VERSION, this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
-           this->is_gas_ ? "Gas" : "Water", this->frequency_, this->rx_attenuation_db_,
-           pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured"),
-           pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured"),
-           pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled"),
-           diag.link_ok ? "PASSED" : "FAILED - register values below are meaningless", diag.partnum, diag.version,
-           diag.marcstate, diag.pktctrl0, diag.freq2, diag.freq1, diag.freq0, diag.mdmcfg4, diag.mdmcfg3, diag.mdmcfg2,
-           diag.rssi_dbm, diag.lqi, level_text(diag.gdo0_level), level_text(diag.gdo2_level),
+           "  Meter reader initialised: %s",
+           level_text(diag.gdo0_level), level_text(diag.gdo2_level),
            diag.gdo0_disconnected ? "FAILED - GDO0 looks unconnected or on the wrong GPIO" : "passed",
            (unsigned long) cc1101_get_gdo2_timeout_count(), this->meter_initialized_ ? "yes" : "no");
+  ESP_LOGI(TAG, "===== end of report =====");
 }
 
 void EverbluMeterComponent::apply_radio_context() {

--- a/ESPHOME/components/everblu_meter/everblu_meter.h
+++ b/ESPHOME/components/everblu_meter/everblu_meter.h
@@ -48,6 +48,7 @@ class EverbluMeterTriggerButton final : public button::Button {
   void set_deep_scan(bool is_deep_scan) { this->is_deep_scan_ = is_deep_scan; }
   void set_reset_frequency(bool is_reset) { this->is_reset_frequency_ = is_reset; }
   void set_stop(bool is_stop) { this->is_stop_ = is_stop; }
+  void set_diagnostic(bool is_diagnostic) { this->is_diagnostic_ = is_diagnostic; }
 
  protected:
   void press_action() override;
@@ -57,6 +58,7 @@ class EverbluMeterTriggerButton final : public button::Button {
   bool is_deep_scan_{false};
   bool is_reset_frequency_{false};
   bool is_stop_{false};
+  bool is_diagnostic_{false};
 };
 
 class EverbluMeterComponent final : public PollingComponent,
@@ -143,6 +145,7 @@ class EverbluMeterComponent final : public PollingComponent,
   void request_deep_scan();
   void request_reset_frequency();
   void request_stop_reading();
+  void request_diagnostic_report();
 
  protected:
   // Configuration
@@ -170,6 +173,14 @@ class EverbluMeterComponent final : public PollingComponent,
   void republish_initial_states();
   void apply_radio_context();
   bool gdo0_error_logged_{false};  // One-shot flag to prevent log flooding
+
+  // Boot-time SPI link probe result, captured in setup() and reported by dump_config()
+  // so a dead or mis-wired bus is visible in the config block every user copies, without
+  // waiting for a Home Assistant connection or a button press.
+  bool spi_probe_ran_{false};
+  bool spi_link_ok_{false};
+  uint8_t spi_partnum_{0};
+  uint8_t spi_version_{0};
 
   // GDO0 pin (required) and GDO2 pin (optional TX FIFO threshold)
   InternalGPIOPin *gdo0_pin_{nullptr};

--- a/ESPHOME/example-advanced.yaml
+++ b/ESPHOME/example-advanced.yaml
@@ -145,6 +145,8 @@ everblu_meter:
     name: "Reset Frequency Offset"
   stop_reading_button:
     name: "Stop Reading"
+  diagnostic_report_button:
+    name: "Diagnostic Report"
 
   # Core sensors
   volume:

--- a/ESPHOME/example-nano-esp32.yaml
+++ b/ESPHOME/example-nano-esp32.yaml
@@ -115,6 +115,8 @@ everblu_meter:
     name: "Reset Frequency Offset"
   stop_reading_button:
     name: "Stop Reading"
+  diagnostic_report_button:
+    name: "Diagnostic Report"
 
   # Volume sensors
   volume:

--- a/ESPHOME/example-water-meter.yaml
+++ b/ESPHOME/example-water-meter.yaml
@@ -116,6 +116,10 @@ everblu_meter:
     name: "Reset Frequency Offset"
   stop_reading_button:
     name: "Stop Reading"
+  # Prints a full wiring/radio diagnostic block to the log. Press this and attach the
+  # output when reporting a problem.
+  diagnostic_report_button:
+    name: "Diagnostic Report"
 
   # Volume sensors
   volume:

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -677,9 +677,11 @@ void cc1101_configureRF_0(float freq)
  * second SPI device holding the line. SYNC1/SYNC0 are used as the scratch pair because
  * cc1101_configureRF_0() rewrites both immediately afterwards.
  *
+ * @param partnum_out Optional; receives the PARTNUM register value.
+ * @param version_out Optional; receives the VERSION register value.
  * @return true when the radio is present and the bus is trustworthy.
  */
-static bool cc1101_verify_spi_link(void)
+static bool cc1101_verify_spi_link(uint8_t *partnum_out, uint8_t *version_out)
 {
   // Round 1 then round 2 use complementary patterns, so between them every data bit is
   // driven both high and low in each direction.
@@ -697,6 +699,11 @@ static bool cc1101_verify_spi_link(void)
 
   uint8_t partnum = halRfReadReg(PARTNUM_ADDR);
   uint8_t version = halRfReadReg(VERSION_ADDR);
+
+  if (partnum_out != NULL)
+    *partnum_out = partnum;
+  if (version_out != NULL)
+    *version_out = version;
 
   if (!readback_ok)
   {
@@ -749,6 +756,58 @@ static bool cc1101_verify_spi_link(void)
   return true;
 }
 
+bool cc1101_probe_spi_link(uint8_t *partnum_out, uint8_t *version_out)
+{
+  if (partnum_out != NULL)
+    *partnum_out = 0;
+  if (version_out != NULL)
+    *version_out = 0;
+
+  if ((wiringPiSPISetup(0, 500000)) < 0)
+  {
+    LOG_E("everblu_meter", "Failed to initialize SPI bus - check CC1101 wiring and connections");
+    return false;
+  }
+
+  cc1101_reset();
+  delay(1);
+
+  return cc1101_verify_spi_link(partnum_out, version_out);
+}
+
+void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
+{
+  int8_t cc1100_rssi_convert2dbm(uint8_t Rssi_dec); // defined below
+
+  if (out == NULL)
+    return;
+
+  memset(out, 0, sizeof(*out));
+  out->gdo0_level = -1;
+  out->gdo2_level = -1;
+
+  // Read-back check first: when the bus is untrustworthy every register below returns the
+  // same meaningless byte, and reporting those values as if they were real is what made
+  // this class of fault so hard to spot in the first place.
+  out->link_ok = cc1101_verify_spi_link(&out->partnum, &out->version);
+
+  out->marcstate = halRfReadReg(MARCSTATE_ADDR);
+  out->freq2 = halRfReadReg(FREQ2);
+  out->freq1 = halRfReadReg(FREQ1);
+  out->freq0 = halRfReadReg(FREQ0);
+  out->mdmcfg4 = halRfReadReg(MDMCFG4);
+  out->mdmcfg3 = halRfReadReg(MDMCFG3);
+  out->mdmcfg2 = halRfReadReg(MDMCFG2);
+  out->pktctrl0 = halRfReadReg(PKTCTRL0);
+  out->rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR));
+  out->lqi = halRfReadReg(LQI_ADDR) & 0x7F;
+
+  if (GET_GDO0_PIN() >= 0)
+    out->gdo0_level = (digitalRead(GET_GDO0_PIN()) == LOW) ? 0 : 1;
+  if (GET_GDO2_PIN() >= 0)
+    out->gdo2_level = (digitalRead(GET_GDO2_PIN()) == LOW) ? 0 : 1;
+}
+
 bool cc1101_init(float freq)
 {
 #ifdef USE_ESPHOME
@@ -785,7 +844,7 @@ bool cc1101_init(float freq)
   cc1101_reset();
   delay(1);
 
-  if (!cc1101_verify_spi_link())
+  if (!cc1101_verify_spi_link(NULL, NULL))
   {
     return false;
   }
@@ -799,6 +858,42 @@ bool cc1101_init(float freq)
   delay(5);          // Wait for calibration to complete (typically <1ms, but we add margin)
 
   echo_debug(debug_out, "[CC1101] Frequency synthesizer calibrated for %.6f MHz\n", freq);
+
+  // One-time GDO0 wiring self-test. IOCFG0 is sync-word-detect (set by
+  // cc1101_configureRF_0) and the radio is IDLE here, so a correctly wired GDO0 must read
+  // LOW. The pin is configured INPUT_PULLUP, so an unconnected or wrong GPIO reads HIGH.
+  // Without this check a wrong gdo0_pin fails silently in a way that looks like success:
+  // every "wait for GDO0" loop returns immediately, so the logs show "GDO0 triggered at
+  // 0ms" and a frame is "received" that is really just noise (issue seen on boards where
+  // GDO0 was pointed at an unrelated peripheral pin).
+  {
+    static bool s_gdo0_selftest_done = false;
+    if (!s_gdo0_selftest_done)
+    {
+      s_gdo0_selftest_done = true;
+      CC1101_CMD(SIDLE);
+      delayMicroseconds(100);
+      // Sample a few times: a genuinely idle GDO0 is steady, so a single reading is enough
+      // in principle, but repeating costs nothing and avoids reacting to a transient.
+      bool stuck_high = true;
+      for (uint8_t i = 0; i < 4 && stuck_high; i++)
+      {
+        if (digitalRead(GET_GDO0_PIN()) == LOW)
+          stuck_high = false;
+        delayMicroseconds(100);
+      }
+      if (stuck_high)
+      {
+        LOG_W("everblu_meter",
+              "GDO0 self-test FAILED: pin %d reads HIGH while the radio is IDLE (expected LOW). GDO0 is probably on the wrong GPIO or not connected - the pin has a pull-up, so an unwired pin reads HIGH. Every sync-word wait will then return instantly and 'received' frames will be noise. Check gdo0_pin against your board's CC1101 GDO0 pin.",
+              GET_GDO0_PIN());
+      }
+      else
+      {
+        echo_debug(debug_out, "[CC1101] GDO0 self-test passed (LOW while idle)\n");
+      }
+    }
+  }
 
   // One-time GDO2 wiring self-test. With IOCFG2 in TX-FIFO-threshold mode (0x02, set by
   // cc1101_configureRF_0) GDO2 must read LOW with an empty TX FIFO and HIGH once the FIFO

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -315,6 +315,10 @@ void cc1101_set_rx_attenuation(int db)
 // Monotonic (lifetime) counter; surfaced via cc1101_get_gdo2_timeout_count() for telemetry.
 static uint32_t _gdo2_stuck_timeouts = 0;
 
+// Latest verdict of the GDO0 idle-level self-test (see cc1101_init). Kept as state rather
+// than a log line only, so the fault is visible in the diagnostic report at any time.
+static bool _gdo0_disconnected = false;
+
 uint32_t cc1101_get_gdo2_timeout_count(void)
 {
   return _gdo2_stuck_timeouts;
@@ -801,6 +805,7 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
   out->pktctrl0 = halRfReadReg(PKTCTRL0);
   out->rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR));
   out->lqi = halRfReadReg(LQI_ADDR) & 0x7F;
+  out->gdo0_disconnected = _gdo0_disconnected;
 
   if (GET_GDO0_PIN() >= 0)
     out->gdo0_level = (digitalRead(GET_GDO0_PIN()) == LOW) ? 0 : 1;
@@ -859,39 +864,43 @@ bool cc1101_init(float freq)
 
   echo_debug(debug_out, "[CC1101] Frequency synthesizer calibrated for %.6f MHz\n", freq);
 
-  // One-time GDO0 wiring self-test. IOCFG0 is sync-word-detect (set by
-  // cc1101_configureRF_0) and the radio is IDLE here, so a correctly wired GDO0 must read
-  // LOW. The pin is configured INPUT_PULLUP, so an unconnected or wrong GPIO reads HIGH.
-  // Without this check a wrong gdo0_pin fails silently in a way that looks like success:
-  // every "wait for GDO0" loop returns immediately, so the logs show "GDO0 triggered at
-  // 0ms" and a frame is "received" that is really just noise (issue seen on boards where
-  // GDO0 was pointed at an unrelated peripheral pin).
+  // GDO0 wiring self-test. IOCFG0 is sync-word-detect (set by cc1101_configureRF_0) and
+  // the radio is IDLE here, so a correctly wired GDO0 must read LOW. The pin is configured
+  // INPUT_PULLUP, so an unconnected or wrong GPIO reads HIGH. Without this check a wrong
+  // gdo0_pin fails silently in a way that looks like success: every "wait for GDO0" loop
+  // returns immediately, so the logs show "GDO0 triggered at 0ms" and a frame is
+  // "received" that is really just noise (issue seen on boards where GDO0 was pointed at
+  // an unrelated peripheral pin).
+  //
+  // The check runs on every init - it costs one strobe and a few reads - but the warning
+  // is emitted once, because a frequency scan calls cc1101_init() per step and would
+  // otherwise repeat it dozens of times. The verdict is kept in _gdo0_disconnected so it
+  // stays visible through cc1101_collect_diagnostics().
   {
-    static bool s_gdo0_selftest_done = false;
-    if (!s_gdo0_selftest_done)
+    CC1101_CMD(SIDLE);
+    delayMicroseconds(100);
+    // Sample a few times: a genuinely idle GDO0 is steady, so a single reading is enough
+    // in principle, but repeating costs nothing and avoids reacting to a transient.
+    bool stuck_high = true;
+    for (uint8_t i = 0; i < 4 && stuck_high; i++)
     {
-      s_gdo0_selftest_done = true;
-      CC1101_CMD(SIDLE);
+      if (digitalRead(GET_GDO0_PIN()) == LOW)
+        stuck_high = false;
       delayMicroseconds(100);
-      // Sample a few times: a genuinely idle GDO0 is steady, so a single reading is enough
-      // in principle, but repeating costs nothing and avoids reacting to a transient.
-      bool stuck_high = true;
-      for (uint8_t i = 0; i < 4 && stuck_high; i++)
-      {
-        if (digitalRead(GET_GDO0_PIN()) == LOW)
-          stuck_high = false;
-        delayMicroseconds(100);
-      }
-      if (stuck_high)
-      {
-        LOG_W("everblu_meter",
-              "GDO0 self-test FAILED: pin %d reads HIGH while the radio is IDLE (expected LOW). GDO0 is probably on the wrong GPIO or not connected - the pin has a pull-up, so an unwired pin reads HIGH. Every sync-word wait will then return instantly and 'received' frames will be noise. Check gdo0_pin against your board's CC1101 GDO0 pin.",
-              GET_GDO0_PIN());
-      }
-      else
-      {
-        echo_debug(debug_out, "[CC1101] GDO0 self-test passed (LOW while idle)\n");
-      }
+    }
+    _gdo0_disconnected = stuck_high;
+
+    static bool s_gdo0_warning_logged = false;
+    if (stuck_high && !s_gdo0_warning_logged)
+    {
+      s_gdo0_warning_logged = true;
+      LOG_W("everblu_meter",
+            "GDO0 self-test FAILED: pin %d reads HIGH while the radio is IDLE (expected LOW). GDO0 is probably on the wrong GPIO or not connected - the pin has a pull-up, so an unwired pin reads HIGH. Every sync-word wait will then return instantly and 'received' frames will be noise. Check gdo0_pin against your board's CC1101 GDO0 pin.",
+            GET_GDO0_PIN());
+    }
+    else if (!stuck_high)
+    {
+      echo_debug(debug_out, "[CC1101] GDO0 self-test passed (LOW while idle)\n");
     }
   }
 

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -690,6 +690,12 @@ static bool cc1101_verify_spi_link(uint8_t *partnum_out, uint8_t *version_out)
   // Round 1 then round 2 use complementary patterns, so between them every data bit is
   // driven both high and low in each direction.
   static const uint8_t kProbe[2][2] = {{0xAA, 0x55}, {0x55, 0xAA}};
+  // cc1101_init() rewrites the sync word straight afterwards, but
+  // cc1101_collect_diagnostics() runs against a configured, listening radio and must not
+  // leave the scratch pattern behind: SYNC0 would stay at 0xAA instead of the operational
+  // 0x00, so a parked receiver would be matching on the wrong sync word.
+  const uint8_t saved_sync1 = halRfReadReg(SYNC1);
+  const uint8_t saved_sync0 = halRfReadReg(SYNC0);
   bool readback_ok = true;
   for (uint8_t round = 0; round < 2 && readback_ok; round++)
   {
@@ -700,6 +706,8 @@ static bool cc1101_verify_spi_link(uint8_t *partnum_out, uint8_t *version_out)
       readback_ok = false;
     }
   }
+  halRfWriteReg(SYNC1, saved_sync1);
+  halRfWriteReg(SYNC0, saved_sync0);
 
   uint8_t partnum = halRfReadReg(PARTNUM_ADDR);
   uint8_t version = halRfReadReg(VERSION_ADDR);
@@ -782,7 +790,6 @@ bool cc1101_probe_spi_link(uint8_t *partnum_out, uint8_t *version_out)
 void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
 {
   int8_t cc1100_rssi_convert2dbm(uint8_t Rssi_dec); // defined below
-
   if (out == NULL)
     return;
 
@@ -811,6 +818,39 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
     out->gdo0_level = (digitalRead(GET_GDO0_PIN()) == LOW) ? 0 : 1;
   if (GET_GDO2_PIN() >= 0)
     out->gdo2_level = (digitalRead(GET_GDO2_PIN()) == LOW) ? 0 : 1;
+}
+
+const char *cc1101_marcstate_name(uint8_t marcstate)
+{
+  // Datasheet Table 25. Reported raw, a value such as 0x11 reads as a fault when it is
+  // usually just a receiver that has been parked with nothing draining the FIFO.
+  switch (marcstate & 0x1F)
+  {
+  case 0x00: return "SLEEP";
+  case 0x01: return "IDLE";
+  case 0x02: return "XOFF";
+  case 0x03: return "VCOON_MC";
+  case 0x04: return "REGON_MC";
+  case 0x05: return "MANCAL";
+  case 0x06: return "VCOON";
+  case 0x07: return "REGON";
+  case 0x08: return "STARTCAL";
+  case 0x09: return "BWBOOST";
+  case 0x0A: return "FS_LOCK";
+  case 0x0B: return "IFADCON";
+  case 0x0C: return "ENDCAL";
+  case 0x0D: return "RX";
+  case 0x0E: return "RX_END";
+  case 0x0F: return "RX_RST";
+  case 0x10: return "TXRX_SWITCH";
+  case 0x11: return "RXFIFO_OVERFLOW";
+  case 0x12: return "FSTXON";
+  case 0x13: return "TX";
+  case 0x14: return "TX_END";
+  case 0x15: return "RXTX_SWITCH";
+  case 0x16: return "TXFIFO_UNDERFLOW";
+  default: return "unknown";
+  }
 }
 
 bool cc1101_init(float freq)

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -810,6 +810,7 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
   out->mdmcfg3 = halRfReadReg(MDMCFG3);
   out->mdmcfg2 = halRfReadReg(MDMCFG2);
   out->pktctrl0 = halRfReadReg(PKTCTRL0);
+  out->carrier_mhz = cc1101_freq_registers_to_mhz(out->freq2, out->freq1, out->freq0);
   out->rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR));
   out->lqi = halRfReadReg(LQI_ADDR) & 0x7F;
   out->gdo0_disconnected = _gdo0_disconnected;
@@ -818,6 +819,12 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out)
     out->gdo0_level = (digitalRead(GET_GDO0_PIN()) == LOW) ? 0 : 1;
   if (GET_GDO2_PIN() >= 0)
     out->gdo2_level = (digitalRead(GET_GDO2_PIN()) == LOW) ? 0 : 1;
+}
+
+float cc1101_freq_registers_to_mhz(uint8_t freq2, uint8_t freq1, uint8_t freq0)
+{
+  const uint32_t freq = ((uint32_t) freq2 << 16) | ((uint32_t) freq1 << 8) | (uint32_t) freq0;
+  return (float) freq * 26.0f / 65536.0f;
 }
 
 const char *cc1101_marcstate_name(uint8_t marcstate)

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -138,6 +138,17 @@ typedef struct
 void cc1101_collect_diagnostics(cc1101_diagnostics_t *out);
 
 /**
+ * @brief Human-readable name for a MARCSTATE value (datasheet Table 25).
+ *
+ * Reported as a bare number, a state such as 0x11 reads as a fault when it is usually
+ * just a receiver parked with nothing draining the FIFO.
+ *
+ * @param marcstate Raw MARCSTATE register value.
+ * @return Static string, never NULL; "unknown" for undefined values.
+ */
+const char *cc1101_marcstate_name(uint8_t marcstate);
+
+/**
  * @enum ReadFailure
  * @brief Why a meter read produced no usable data
  *

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -83,6 +83,55 @@ void cc1101_set_rx_attenuation(int db);
 uint32_t cc1101_get_gdo2_timeout_count(void);
 
 /**
+ * @brief Probe the SPI link to the CC1101 without configuring the radio.
+ *
+ * Performs the same reset + write/read-back self-test as cc1101_init(), but stops there.
+ * Intended to be called early (for example from an ESPHome setup()) so a dead or
+ * mis-wired SPI link is reported in the boot log, rather than only surfacing later when
+ * the first read is attempted. Failures are logged with the same remediation guidance.
+ *
+ * @param partnum_out Optional; receives the PARTNUM register value.
+ * @param version_out Optional; receives the VERSION register value.
+ * @return true when the radio answered and the bus is trustworthy.
+ */
+bool cc1101_probe_spi_link(uint8_t *partnum_out, uint8_t *version_out);
+
+/**
+ * @brief Snapshot of radio identity, key registers and GDO line levels.
+ *
+ * Everything a support request needs in order to tell a wiring fault from an RF problem,
+ * captured in one pass so it can be logged as a single copy-pasteable block.
+ */
+typedef struct
+{
+  bool link_ok;      /**< SPI write/read-back self-test passed */
+  uint8_t partnum;   /**< PARTNUM: 0x00 on a genuine CC1101 */
+  uint8_t version;   /**< VERSION: 0x04 or 0x14 on known revisions */
+  uint8_t marcstate; /**< Main radio control state machine state */
+  uint8_t freq2;     /**< Carrier frequency, MSB */
+  uint8_t freq1;
+  uint8_t freq0;
+  uint8_t mdmcfg4; /**< RX filter bandwidth + data rate exponent */
+  uint8_t mdmcfg3;
+  uint8_t mdmcfg2;
+  uint8_t pktctrl0;
+  int8_t rssi_dbm; /**< Current RSSI, converted to dBm */
+  uint8_t lqi;
+  int gdo0_level; /**< 0 = LOW, 1 = HIGH, -1 = pin not configured */
+  int gdo2_level; /**< 0 = LOW, 1 = HIGH, -1 = pin not configured */
+} cc1101_diagnostics_t;
+
+/**
+ * @brief Fill @p out with a one-shot diagnostic snapshot of the radio.
+ *
+ * Safe to call at any time; does not reset or reconfigure the radio. When the SPI link
+ * is untrustworthy, link_ok is false and the register values are meaningless.
+ *
+ * @param out Destination struct; ignored when NULL.
+ */
+void cc1101_collect_diagnostics(cc1101_diagnostics_t *out);
+
+/**
  * @enum ReadFailure
  * @brief Why a meter read produced no usable data
  *

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -111,6 +111,15 @@ typedef struct
   uint8_t freq2;     /**< Carrier frequency, MSB */
   uint8_t freq1;
   uint8_t freq0;
+  /**
+   * Carrier frequency decoded from FREQ2/1/0, in MHz.
+   *
+   * Read back from the radio, so this is where it is actually tuned. It differs from the
+   * configured base frequency by whatever calibration offset is in effect, which is the
+   * point: a mismatch between the two is otherwise invisible without doing the arithmetic
+   * by hand.
+   */
+  float carrier_mhz;
   uint8_t mdmcfg4; /**< RX filter bandwidth + data rate exponent */
   uint8_t mdmcfg3;
   uint8_t mdmcfg2;
@@ -147,6 +156,15 @@ void cc1101_collect_diagnostics(cc1101_diagnostics_t *out);
  * @return Static string, never NULL; "unknown" for undefined values.
  */
 const char *cc1101_marcstate_name(uint8_t marcstate);
+
+/**
+ * @brief Convert the CC1101 FREQ2/FREQ1/FREQ0 register triple to MHz.
+ *
+ * Inverse of setMHZ(): f_carrier = FREQ * f_xosc / 2^16, with a 26 MHz crystal.
+ *
+ * @return Carrier frequency in MHz.
+ */
+float cc1101_freq_registers_to_mhz(uint8_t freq2, uint8_t freq1, uint8_t freq0);
 
 /**
  * @enum ReadFailure

--- a/src/core/cc1101.h
+++ b/src/core/cc1101.h
@@ -119,6 +119,12 @@ typedef struct
   uint8_t lqi;
   int gdo0_level; /**< 0 = LOW, 1 = HIGH, -1 = pin not configured */
   int gdo2_level; /**< 0 = LOW, 1 = HIGH, -1 = pin not configured */
+  /**
+   * True when the last cc1101_init() found GDO0 HIGH while the radio was IDLE, which means
+   * the pin is almost certainly on the wrong GPIO or not connected. Sync-word waits then
+   * return instantly and "received" frames are noise.
+   */
+  bool gdo0_disconnected;
 } cc1101_diagnostics_t;
 
 /**

--- a/test/test_native_cc1101_link/native_cc1101_device.h
+++ b/test/test_native_cc1101_link/native_cc1101_device.h
@@ -38,6 +38,14 @@ struct NativeCC1101
     // ---- Fault injection -------------------------------------------------
     NativeSpiFault fault = NativeSpiFault::None;
     uint8_t stuckValue = 0xFF;
+    /**
+     * Whether GDO0 is actually wired to the pin the driver is watching.
+     *
+     * A connected GDO0 is driven LOW by the radio while it is IDLE. When false the fake
+     * leaves the pin alone, so the host pull-up keeps it HIGH - exactly what the firmware
+     * sees when gdo0_pin points at the wrong GPIO or at nothing at all.
+     */
+    bool gdo0Connected = true;
 
     // ---- Observability ---------------------------------------------------
     uint32_t transfers = 0;
@@ -128,6 +136,14 @@ inline void nativeCC1101Transfer(uint8_t *buffer, size_t length)
 {
     NativeCC1101 &device = nativeCC1101();
     device.transfers++;
+
+    // A wired GDO0 is held LOW by the radio outside a packet. The driver sets the pin to
+    // INPUT_PULLUP on every init, which leaves it HIGH, so the fake has to re-assert the
+    // line the same way real silicon would once it is talking on the bus.
+    if (device.gdo0Connected)
+    {
+        digitalWrite(GDO0, LOW);
+    }
 
     if (length == 0)
     {

--- a/test/test_native_cc1101_link/test_cc1101_link.cpp
+++ b/test/test_native_cc1101_link/test_cc1101_link.cpp
@@ -227,6 +227,32 @@ void test_diagnostics_tolerate_a_null_destination(void)
     cc1101_collect_diagnostics(nullptr); // must not crash
 }
 
+void test_diagnostics_leave_the_sync_word_intact(void)
+{
+    // The report button is pressed on a configured, listening radio. The link probe writes
+    // its scratch patterns through SYNC1/SYNC0, and the last one it writes is 0x55/0xAA -
+    // so without a restore the operational sync word would silently become 0x55AA and the
+    // parked receiver would be matching on the wrong pattern.
+    nativeCC1101Install();
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+
+    cc1101_diagnostics_t diag;
+    cc1101_collect_diagnostics(&diag);
+
+    TEST_ASSERT_EQUAL_HEX8(0x55, nativeCC1101().config[kSync1Register]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, nativeCC1101().config[kSync0Register]);
+}
+
+void test_marcstate_names_cover_the_states_that_get_reported(void)
+{
+    // These are the values users actually see in a report and mistake for faults.
+    TEST_ASSERT_EQUAL_STRING("IDLE", cc1101_marcstate_name(0x01));
+    TEST_ASSERT_EQUAL_STRING("RX", cc1101_marcstate_name(0x0D));
+    TEST_ASSERT_EQUAL_STRING("RXFIFO_OVERFLOW", cc1101_marcstate_name(0x11));
+    TEST_ASSERT_EQUAL_STRING("TXFIFO_UNDERFLOW", cc1101_marcstate_name(0x16));
+    TEST_ASSERT_EQUAL_STRING("unknown", cc1101_marcstate_name(0x1F));
+}
+
 // ---------------------------------------------------------------------------
 // GDO0 wiring self-test
 // ---------------------------------------------------------------------------

--- a/test/test_native_cc1101_link/test_cc1101_link.cpp
+++ b/test/test_native_cc1101_link/test_cc1101_link.cpp
@@ -253,6 +253,28 @@ void test_marcstate_names_cover_the_states_that_get_reported(void)
     TEST_ASSERT_EQUAL_STRING("unknown", cc1101_marcstate_name(0x1F));
 }
 
+void test_freq_registers_decode_to_the_tuned_carrier(void)
+{
+    // Taken from a real report: FREQ2/1/0 = 0x10 0xAF 0x65 on a device whose
+    // configured base was 433.782715 MHz. The ~31 kHz difference is the stored
+    // calibration offset, and showing only the base hid it completely.
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 433.8134f, cc1101_freq_registers_to_mhz(0x10, 0xAF, 0x65));
+}
+
+void test_diagnostics_report_where_the_radio_is_actually_tuned(void)
+{
+    // The decoded carrier has to come from the registers the radio is running
+    // on, not from the value the caller asked for, or it could never disagree.
+    nativeCC1101Install();
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+
+    cc1101_diagnostics_t diag;
+    cc1101_collect_diagnostics(&diag);
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, kTestFrequency, diag.carrier_mhz);
+    TEST_ASSERT_EQUAL_FLOAT(cc1101_freq_registers_to_mhz(diag.freq2, diag.freq1, diag.freq0), diag.carrier_mhz);
+}
+
 // ---------------------------------------------------------------------------
 // GDO0 wiring self-test
 // ---------------------------------------------------------------------------

--- a/test/test_native_cc1101_link/test_cc1101_link.cpp
+++ b/test/test_native_cc1101_link/test_cc1101_link.cpp
@@ -139,3 +139,144 @@ void test_cc1101_init_re_runs_the_self_test_on_every_call(void)
     nativeCC1101().fault = NativeSpiFault::None;
     TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
 }
+
+// ---------------------------------------------------------------------------
+// cc1101_probe_spi_link: the same check, callable before the radio is configured
+// ---------------------------------------------------------------------------
+
+void test_probe_reports_the_radio_identity_on_a_healthy_bus(void)
+{
+    // ESPHome calls this during setup() so a wiring fault lands in the boot log
+    // that users actually capture, instead of waiting for the first read.
+    nativeCC1101Install();
+
+    uint8_t partnum = 0xEE;
+    uint8_t version = 0xEE;
+    TEST_ASSERT_TRUE(cc1101_probe_spi_link(&partnum, &version));
+    TEST_ASSERT_EQUAL_HEX8(kCc1101PartNum, partnum);
+    TEST_ASSERT_EQUAL_HEX8(kCc1101Version, version);
+}
+
+void test_probe_rejects_a_stuck_bus_and_reports_what_it_saw(void)
+{
+    // The caller shows these values to the user, so they must be the bytes that
+    // were actually read - seeing PARTNUM and VERSION both equal to the stuck
+    // value is what makes the fault recognisable.
+    nativeCC1101Install();
+    nativeCC1101().fault = NativeSpiFault::StuckConstant;
+    nativeCC1101().stuckValue = 0x0F;
+
+    uint8_t partnum = 0;
+    uint8_t version = 0;
+    TEST_ASSERT_FALSE(cc1101_probe_spi_link(&partnum, &version));
+    TEST_ASSERT_EQUAL_HEX8(0x0F, partnum);
+    TEST_ASSERT_EQUAL_HEX8(0x0F, version);
+}
+
+void test_probe_accepts_null_outputs(void)
+{
+    // The identity is optional: a caller that only wants the verdict should not
+    // have to supply somewhere to put it.
+    nativeCC1101Install();
+
+    TEST_ASSERT_TRUE(cc1101_probe_spi_link(nullptr, nullptr));
+}
+
+// ---------------------------------------------------------------------------
+// cc1101_collect_diagnostics: the one-shot snapshot behind the report button
+// ---------------------------------------------------------------------------
+
+void test_diagnostics_capture_the_configured_radio_state(void)
+{
+    nativeCC1101Install();
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+
+    cc1101_diagnostics_t diag;
+    cc1101_collect_diagnostics(&diag);
+
+    TEST_ASSERT_TRUE(diag.link_ok);
+    TEST_ASSERT_EQUAL_HEX8(kCc1101PartNum, diag.partnum);
+    TEST_ASSERT_EQUAL_HEX8(kCc1101Version, diag.version);
+    // 433.82 MHz lands in the 0x10 page of the frequency word; the exact value
+    // is asserted elsewhere, here it only has to be something the radio was
+    // actually programmed with rather than a default or a stuck byte.
+    TEST_ASSERT_EQUAL_HEX8(0x10, diag.freq2);
+    TEST_ASSERT_EQUAL_HEX8(nativeCC1101().config[0x10], diag.mdmcfg4);
+    TEST_ASSERT_EQUAL_HEX8(nativeCC1101().config[0x08], diag.pktctrl0);
+}
+
+void test_diagnostics_flag_an_untrustworthy_bus(void)
+{
+    // Every register reads back as the stuck value, so the report has to say the
+    // numbers below it are meaningless rather than presenting them as readings.
+    nativeCC1101Install();
+    nativeCC1101().fault = NativeSpiFault::StuckConstant;
+    nativeCC1101().stuckValue = 0x0F;
+
+    cc1101_diagnostics_t diag;
+    cc1101_collect_diagnostics(&diag);
+
+    TEST_ASSERT_FALSE(diag.link_ok);
+    TEST_ASSERT_EQUAL_HEX8(0x0F, diag.partnum);
+    TEST_ASSERT_EQUAL_HEX8(0x0F, diag.version);
+    TEST_ASSERT_EQUAL_HEX8(0x0F, diag.marcstate);
+}
+
+void test_diagnostics_tolerate_a_null_destination(void)
+{
+    cc1101_collect_diagnostics(nullptr); // must not crash
+}
+
+// ---------------------------------------------------------------------------
+// GDO0 wiring self-test
+// ---------------------------------------------------------------------------
+
+void test_gdo0_self_test_passes_when_the_line_is_wired(void)
+{
+    // A wired GDO0 is held LOW by the radio while it is IDLE.
+    nativeCC1101Install();
+    nativeCC1101().gdo0Connected = true;
+
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+
+    cc1101_diagnostics_t diag;
+    cc1101_collect_diagnostics(&diag);
+    TEST_ASSERT_FALSE(diag.gdo0_disconnected);
+    TEST_ASSERT_EQUAL_INT(0, diag.gdo0_level);
+}
+
+void test_gdo0_self_test_detects_a_pin_pointed_at_nothing(void)
+{
+    // The reported failure mode: gdo0_pin set to a GPIO the CC1101 is not on.
+    // The pull-up holds it HIGH, so every sync-word wait returns instantly and
+    // the "frames" that follow are noise. Nothing else in the driver notices.
+    nativeCC1101Install();
+    nativeCC1101().gdo0Connected = false;
+
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency)); // SPI is fine; only GDO0 is wrong
+
+    cc1101_diagnostics_t diag;
+    cc1101_collect_diagnostics(&diag);
+    TEST_ASSERT_TRUE(diag.gdo0_disconnected);
+    TEST_ASSERT_EQUAL_INT(1, diag.gdo0_level);
+}
+
+void test_gdo0_verdict_clears_once_the_line_is_fixed(void)
+{
+    // The verdict is state, not a latch: re-running init on a corrected board
+    // must clear it, otherwise the diagnostic report would keep accusing a
+    // wiring fault that no longer exists.
+    nativeCC1101Install();
+    nativeCC1101().gdo0Connected = false;
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+
+    cc1101_diagnostics_t diag;
+    cc1101_collect_diagnostics(&diag);
+    TEST_ASSERT_TRUE(diag.gdo0_disconnected);
+
+    nativeCC1101().gdo0Connected = true;
+    TEST_ASSERT_TRUE(cc1101_init(kTestFrequency));
+
+    cc1101_collect_diagnostics(&diag);
+    TEST_ASSERT_FALSE(diag.gdo0_disconnected);
+}

--- a/test/test_native_cc1101_link/test_runner.cpp
+++ b/test/test_native_cc1101_link/test_runner.cpp
@@ -22,6 +22,8 @@ void test_probe_accepts_null_outputs(void);
 void test_diagnostics_capture_the_configured_radio_state(void);
 void test_diagnostics_flag_an_untrustworthy_bus(void);
 void test_diagnostics_tolerate_a_null_destination(void);
+void test_diagnostics_leave_the_sync_word_intact(void);
+void test_marcstate_names_cover_the_states_that_get_reported(void);
 void test_gdo0_self_test_passes_when_the_line_is_wired(void);
 void test_gdo0_self_test_detects_a_pin_pointed_at_nothing(void);
 void test_gdo0_verdict_clears_once_the_line_is_fixed(void);
@@ -53,6 +55,8 @@ int main(int, char **)
     RUN_TEST(test_diagnostics_capture_the_configured_radio_state);
     RUN_TEST(test_diagnostics_flag_an_untrustworthy_bus);
     RUN_TEST(test_diagnostics_tolerate_a_null_destination);
+    RUN_TEST(test_diagnostics_leave_the_sync_word_intact);
+    RUN_TEST(test_marcstate_names_cover_the_states_that_get_reported);
     RUN_TEST(test_gdo0_self_test_passes_when_the_line_is_wired);
     RUN_TEST(test_gdo0_self_test_detects_a_pin_pointed_at_nothing);
     RUN_TEST(test_gdo0_verdict_clears_once_the_line_is_fixed);

--- a/test/test_native_cc1101_link/test_runner.cpp
+++ b/test/test_native_cc1101_link/test_runner.cpp
@@ -24,6 +24,8 @@ void test_diagnostics_flag_an_untrustworthy_bus(void);
 void test_diagnostics_tolerate_a_null_destination(void);
 void test_diagnostics_leave_the_sync_word_intact(void);
 void test_marcstate_names_cover_the_states_that_get_reported(void);
+void test_freq_registers_decode_to_the_tuned_carrier(void);
+void test_diagnostics_report_where_the_radio_is_actually_tuned(void);
 void test_gdo0_self_test_passes_when_the_line_is_wired(void);
 void test_gdo0_self_test_detects_a_pin_pointed_at_nothing(void);
 void test_gdo0_verdict_clears_once_the_line_is_fixed(void);
@@ -57,6 +59,8 @@ int main(int, char **)
     RUN_TEST(test_diagnostics_tolerate_a_null_destination);
     RUN_TEST(test_diagnostics_leave_the_sync_word_intact);
     RUN_TEST(test_marcstate_names_cover_the_states_that_get_reported);
+    RUN_TEST(test_freq_registers_decode_to_the_tuned_carrier);
+    RUN_TEST(test_diagnostics_report_where_the_radio_is_actually_tuned);
     RUN_TEST(test_gdo0_self_test_passes_when_the_line_is_wired);
     RUN_TEST(test_gdo0_self_test_detects_a_pin_pointed_at_nothing);
     RUN_TEST(test_gdo0_verdict_clears_once_the_line_is_fixed);

--- a/test/test_native_cc1101_link/test_runner.cpp
+++ b/test/test_native_cc1101_link/test_runner.cpp
@@ -16,6 +16,15 @@ void test_cc1101_init_accepts_an_unknown_silicon_revision(void);
 void test_cc1101_init_tolerates_an_unstable_bus(void);
 void test_cc1101_init_probes_both_bit_polarities(void);
 void test_cc1101_init_re_runs_the_self_test_on_every_call(void);
+void test_probe_reports_the_radio_identity_on_a_healthy_bus(void);
+void test_probe_rejects_a_stuck_bus_and_reports_what_it_saw(void);
+void test_probe_accepts_null_outputs(void);
+void test_diagnostics_capture_the_configured_radio_state(void);
+void test_diagnostics_flag_an_untrustworthy_bus(void);
+void test_diagnostics_tolerate_a_null_destination(void);
+void test_gdo0_self_test_passes_when_the_line_is_wired(void);
+void test_gdo0_self_test_detects_a_pin_pointed_at_nothing(void);
+void test_gdo0_verdict_clears_once_the_line_is_fixed(void);
 
 void setUp(void)
 {
@@ -38,6 +47,15 @@ int main(int, char **)
     RUN_TEST(test_cc1101_init_tolerates_an_unstable_bus);
     RUN_TEST(test_cc1101_init_probes_both_bit_polarities);
     RUN_TEST(test_cc1101_init_re_runs_the_self_test_on_every_call);
+    RUN_TEST(test_probe_reports_the_radio_identity_on_a_healthy_bus);
+    RUN_TEST(test_probe_rejects_a_stuck_bus_and_reports_what_it_saw);
+    RUN_TEST(test_probe_accepts_null_outputs);
+    RUN_TEST(test_diagnostics_capture_the_configured_radio_state);
+    RUN_TEST(test_diagnostics_flag_an_untrustworthy_bus);
+    RUN_TEST(test_diagnostics_tolerate_a_null_destination);
+    RUN_TEST(test_gdo0_self_test_passes_when_the_line_is_wired);
+    RUN_TEST(test_gdo0_self_test_detects_a_pin_pointed_at_nothing);
+    RUN_TEST(test_gdo0_verdict_clears_once_the_line_is_fixed);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Diagnosing a broken setup currently depends on the user pressing the right button and keeping the log open long enough. Two recent reports ([#126](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/126) and a LilyGO T-Embed CC1101 user) had every symptom of a wiring fault, but the logs they shared contained no evidence of it at all: the config block said only `GDO0 Pin: configured`, and the SPI link self-test never ran because it was gated behind the first Home Assistant connection.

This makes the component report enough at boot, unprompted, to tell a wiring fault from an RF problem.

## Changes

**`dump_config()` reports the actual GPIO numbers.** `GDO0 Pin: configured` becomes `GDO0 Pin: GPIO3`, and the CS pin, RX attenuation and SPI link self-test result are added. Support requests are usually just this block, which could not be checked against a board pinout without the numbers.

**The SPI link self-test runs during `setup()`** rather than on the first Home Assistant connection, so a stuck MISO or a wrong `cs_pin`/`miso_pin` lands in the boot log that users actually capture. The result is cached and printed in the config block:

```
SPI Link Self-Test: PASSED (PARTNUM: 0x00, VERSION: 0x14)
SPI Link Self-Test: FAILED (PARTNUM: 0x0F, VERSION: 0x0F) - the radio is not being read
```

**New GDO0 wiring self-test in `cc1101_init()`,** mirroring the existing GDO2 one. `IOCFG0` is sync-word detect and the radio is IDLE at that point, so a correctly wired GDO0 must read LOW; the pin is `INPUT_PULLUP`, so a wrong or unconnected GPIO reads HIGH. Previously a mis-assigned `gdo0_pin` failed silently in a way that resembled success: every sync-word wait returned instantly, producing `GDO0 triggered at 0ms` and "received" frames that were only noise.

**New optional `diagnostic_report_button`** that logs one copy-pasteable block: the configured pins, a live link self-test, the key CC1101 registers (PARTNUM, VERSION, MARCSTATE, FREQ2/1/0, MDMCFG4/3/2, PKTCTRL0), RSSI/LQI, the current GDO0/GDO2 line levels, the GDO2 fault count, and whether the meter reader ever initialised. It deliberately does not require `meter_reader_`, because the usual reason to press it is that the radio never came up.

Incidental fix: the first draft used `GPIOPin::dump_summary()`, which ESPHome deprecated and removes in 2026.7.0, and affected users are already on 2026.7.3. It now uses the buffer-based overload.

## New driver API

- `cc1101_probe_spi_link(partnum_out, version_out)` in [src/core/cc1101.h](https://github.com/genestealer/everblu-meters-esp8266-improved/blob/main/src/core/cc1101.h)
- `cc1101_collect_diagnostics(cc1101_diagnostics_t *)`

## Verification

- 162/162 native tests pass
- `pio run -e huzzah` builds clean
- `esphome compile .ci/esphome/everblu_meter/test.esp8266-full.yaml` succeeds with no warnings
- `esphome config` validates the new schema option
- Examples, `ESPHOME/README.md`, the CI full-config test and the changelog updated; `ESPHOME-release/` regenerated

The ESP32 CI compile could not be run locally (`uv` failed to install into the PlatformIO penv), but the changes are platform-independent and the ESP8266 path exercises them. CI will cover ESP32.
