### PR TITLE
Harden the radio and MQTT paths (salvage of stalled PR #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 
 Releases are created manually by tagging commits with version tags matching `v*.*.*` (e.g., `v2.1.0`). Users should build from source and configure `private.h` with their own meter settings.
 
-
 ## AI Notes For Maintainers And Tools
 
 - Treat release sections as the source of truth for shipped behavior.
@@ -12,6 +11,23 @@ Releases are created manually by tagging commits with version tags matching `v*.
 - If an item was introduced and later superseded in the same release branch, keep only the final behavior in Added/Changed/Fixed/Removed and record superseded work in the AI metadata block.
 - Keep PR coverage explicit per release so branch-only work is auditable against merge history.
 - Add new versions below, not above this section.
+
+## [Unreleased]
+
+### Fixed
+
+- **A frame whose length byte claims more bytes than were decoded is now rejected instead of being accepted unchecked.** `radian_validate_crc()` returned "valid" without verifying anything when the declared length exceeded the decoded payload, which in practice means a truncated or misaligned capture. That bypassed the only integrity gate on the radio path and left the downstream parser sanity checks to catch the damage. Such frames now fail CRC validation and are discarded. The captured `home_001` test fixture is one of these truncated frames and is now marked `crc_valid=0`; parse coverage for the same meter comes from the complete `home_002` frame.
+- **The unbounded `sprintf()` building the standalone `/json` payload** is now `snprintf()`, matching the rest of `src/main.cpp`.
+
+### Changed
+
+- **Standalone MQTT publishes no longer build their topics as Arduino `String`s.** A single read published around 20 topics as `String(mqttBaseTopic) + "/suffix"`, allocating and freeing two heap blocks each time and fragmenting the ~40 KB ESP8266 heap over the life of the device. A `publishSub()` helper formats the topic into a stack buffer instead, consistent with how the rest of the file already builds topics.
+- **`StorageAbstraction::clearAll()` logs a warning on ESPHome** instead of silently returning `false`, so a factory-reset caller can tell the difference between a failure and a no-op. ESPHome's preference API has no bulk-erase primitive; individual keys must be cleared with `clearKey()`.
+
+### Removed
+
+- **Dead diagnostic code in the CC1101 driver:** `cc1101_wait_for_packet()`, `cc1101_check_packet_received()` and `is_look_like_radian_frame()` had no callers and were not part of the `cc1101.h` public API. They also held the only unbounded call into the hex-dump helper. The live receive path is `receive_radian_frame()` and is unchanged.
+- **The unreachable carry branch in `setMHZ()`.** `freq0` is a `byte`, so `if (freq0 > 255)` could never be true; the loop above it already subtracts a whole FREQ1 step before `freq0` can reach 256.
 
 ## [v3.4.0] - 2026-07-30
 
@@ -120,7 +136,6 @@ scope_summary:
 - **RADIAN CRC now validates end-to-end on live frames for the first time.** Two stacked defects meant the CRC was never actually checked: the raw capture truncated the frame so the CRC trailer was never received, and `radian_validate_crc()` computed the checksum over the wrong range (it skipped the length byte). The frame is 124 bytes; the CRC-16/KERMIT is computed over bytes [0..121] (including the length byte) with the trailer at [122-123]. Verified against multiple live captures.
 - **`extract-meter-fixture.py` CRC check used the wrong convention**: it computed the CRC over bytes [1..], skipping the length byte, so captured fixtures were marked `crc_valid=0`. It now matches the firmware and covers bytes [0..].
 
-
 ## [v3.1.1] - 2026-07-08
 
 ### AI Metadata
@@ -138,8 +153,6 @@ scope_summary:
 ### Fixed
 
 - **Wake-up burst truncated to ~60ms on the second and later reads** ([#127](https://github.com/genestealer/everblu-meters-esp8266-improved/issues/127)): `receive_radian_frame()` switches `MDMCFG4` to the 4x-oversampled 9.6 kbps RX rate, but `get_meter_data_for_meter()` never restored the 2.4 kbps TX rate before transmitting. Only the first read after boot worked (fresh from `cc1101_init()`); every later read clocked the wake-up burst out 4x too fast, draining the TX FIFO and hitting `TXFIFO_UNDERFLOW` (MARCSTATE 0x16) after ~60ms instead of the full ~2s burst. The TX phase now rewrites `MDMCFG4`/`MDMCFG3` to 2.4 kbps on every read.
-
-
 
 ## [v3.1.0] - 2026-07-07
 

--- a/ESPHOME-release/everblu_meter/cc1101.cpp
+++ b/ESPHOME-release/everblu_meter/cc1101.cpp
@@ -585,11 +585,10 @@ void setMHZ(float mhz)
       i = 1;
     }
   }
-  if (freq0 > 255)
-  {
-    freq1 += 1;
-    freq0 -= 256;
-  }
+  // No carry handling is needed here. The loop subtracts a whole FREQ1 step
+  // (0.1015625 MHz == 256 FREQ0 LSBs) before freq0 can reach 256, so freq0
+  // always fits in one byte. The former `if (freq0 > 255)` check was dead: freq0
+  // is a byte and can never exceed 255.
 
   /*
   Serial.printf("FREQ2=0x%02X ", freq2);
@@ -934,115 +933,6 @@ void show_cc1101_registers_settings(void)
     echo_debug(debug_out, "%02X ", Patable_verify[i]);
   }
   echo_debug(debug_out, "\n");
-}
-
-uint8_t is_look_like_radian_frame(uint8_t *buffer, size_t len)
-{
-  int ret;
-  ret = FALSE;
-  for (size_t i = 0; i < len; i++)
-  {
-    if (buffer[i] == 0xFF)
-      ret = TRUE;
-  }
-
-  return ret;
-}
-
-//-----------------[check if Packet is received]-------------------------
-uint8_t cc1101_check_packet_received(void)
-{
-  uint8_t rxBuffer[100];
-  uint8_t l_nb_byte;
-  int8_t l_Rssi_dbm;
-  uint8_t l_lqi, l_freq_est, pktLen;
-  pktLen = 0;
-  if (digitalRead(GET_GDO0_PIN()) == TRUE)
-  {
-    // Read RSSI immediately while signal is present (carrier active)
-    // RSSI register needs to be sampled during packet reception for accuracy
-    l_Rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR));
-
-    bool buffer_overflow = false;
-    while (digitalRead(GET_GDO0_PIN()) == TRUE)
-    {
-      delay(2); // Reduced from 5ms to 2ms for faster FIFO reading (prevents overflow)
-
-      // Check for FIFO overflow (bit 7 of RXBYTES register)
-      uint8_t rxbytes_reg = halRfReadReg(RXBYTES_ADDR);
-      if (rxbytes_reg & 0x80)
-      {
-        echo_debug(1, "[ERROR] RX FIFO overflow detected - data corrupted\n");
-        CC1101_CMD(SFRX); // Flush RX FIFO to recover
-        return FALSE;
-      }
-
-      l_nb_byte = rxbytes_reg & RXBYTES_MASK;
-
-      // Bounds check before reading to prevent buffer overflow
-      if ((l_nb_byte) && ((pktLen + l_nb_byte) <= 100))
-      {
-        SPIReadBurstReg(RX_FIFO_ADDR, &rxBuffer[pktLen], l_nb_byte); // Pull data
-        pktLen += l_nb_byte;
-      }
-      else if (l_nb_byte && ((pktLen + l_nb_byte) > 100))
-      {
-        echo_debug(1, "[ERROR] Would overflow rxBuffer (pktLen=%u + l_nb_byte=%u > 100)\n", pktLen, l_nb_byte);
-        buffer_overflow = true;
-        break;
-      }
-    }
-
-    // Read LQI and FREQEST only if packet completed normally (GDO0 went low)
-    // If we exited via buffer overflow, GDO0 may still be high and these registers
-    // are not yet latched, so reading them would give incorrect values.
-    if (buffer_overflow)
-    {
-      echo_debug(1, "[ERROR] Buffer overflow - discarding incomplete packet\n");
-      CC1101_CMD(SFRX); // Flush RX FIFO to recover
-      return FALSE;
-    }
-    // These registers are latched at end-of-packet and contain final quality metrics
-    l_lqi = halRfReadReg(LQI_ADDR);
-    l_freq_est = halRfReadReg(FREQEST_ADDR);
-
-    if (is_look_like_radian_frame(rxBuffer, pktLen))
-    {
-      echo_debug(debug_out, "[CC1101] Packet looks like RADIAN frame");
-      echo_debug(debug_out, "[CC1101] bytes=%u rssi=%d lqi=%u F_est=%d\n", pktLen, l_Rssi_dbm, l_lqi & 0x7F, (int8_t)l_freq_est);
-      show_in_hex_one_line(rxBuffer, pktLen);
-      // show_in_bin(rxBuffer,l_nb_byte);
-    }
-    else
-    {
-      echo_debug(debug_out, ".");
-    }
-    fflush(stdout);
-    return TRUE;
-  }
-  return FALSE;
-}
-
-uint8_t cc1101_wait_for_packet(int milliseconds)
-{
-  int i;
-  for (i = 0; i < milliseconds; i++)
-  {
-    delay(1); // in ms
-    if (i % 100 == 0)
-      FEED_WDT(); // Feed watchdog every 100ms
-    // echo_cc1101_MARCSTATE();
-    if (cc1101_check_packet_received()) // delay till system has data available
-    {
-      return TRUE;
-    }
-    else if (i == milliseconds - 1)
-    {
-      // echo_debug(debug_out,"no packet received!\n");
-      return FALSE;
-    }
-  }
-  return TRUE;
 }
 
 // Diagnostic: the RADIAN frame length is not assumed. Scan every candidate

--- a/ESPHOME-release/everblu_meter/meter_history.cpp
+++ b/ESPHOME-release/everblu_meter/meter_history.cpp
@@ -228,6 +228,9 @@ int MeterHistory::countValidMonths(const uint32_t history[13])
         return 0;
     }
 
+    // A zero entry marks the end of the stored history. Meter volume is a
+    // cumulative counter, so an operational meter never legitimately reports 0,
+    // which makes 0 usable as the "no more data" sentinel.
     for (int i = 0; i < 13; i++)
     {
         if (history[i] == 0)

--- a/ESPHOME-release/everblu_meter/radian_parser.cpp
+++ b/ESPHOME-release/everblu_meter/radian_parser.cpp
@@ -33,8 +33,12 @@ bool radian_validate_crc(const uint8_t *decoded_buffer, size_t size)
 
     if (expected_len > size)
     {
-        // Keep compatibility with frames that advertise a longer length than payload.
-        return true;
+        // The length byte claims more bytes than were decoded, so the CRC
+        // trailer is not in the buffer and the frame cannot be verified at all.
+        // In practice this means a truncated or misaligned capture. Reject it:
+        // accepting it unchecked let corrupt frames through the one integrity
+        // gate the radio path has.
+        return false;
     }
 
     if (expected_len < 4)

--- a/ESPHOME-release/everblu_meter/storage_abstraction.cpp
+++ b/ESPHOME-release/everblu_meter/storage_abstraction.cpp
@@ -391,7 +391,11 @@ bool StorageAbstraction::clearKey(const char *key)
 bool StorageAbstraction::clearAll()
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
-    // Not supported via ESPHome API in bulk; caller can clear individual keys
+    // ESPHome's preference API has no bulk-erase primitive. Say so, otherwise a
+    // caller such as a factory-reset path cannot tell the difference between a
+    // failure and a silent no-op. Individual keys can still be cleared with
+    // clearKey().
+    LOG_W("everblu_meter", "clearAll() is not supported on ESPHome - clear individual keys with clearKey()");
     return false;
 
 #elif defined(ESP8266)

--- a/docs/GDO2_FIFO_MANAGEMENT.md
+++ b/docs/GDO2_FIFO_MANAGEMENT.md
@@ -99,6 +99,11 @@ threshold signal.
 
 ### Current RX loop behaviour
 
+> **Historical note:** the loop below is the diagnostic `cc1101_wait_for_packet()` /
+> `cc1101_check_packet_received()` pair, which was never on the live read path and has since been
+> deleted. It is kept here because it is the loop the analysis in this section was written
+> against. The live RX path is `receive_radian_frame()`, which polls `RXBYTES` in the same shape.
+
 ```
 cc1101_wait_for_packet(ms)            // outer: delay(1) per iteration, polls GDO0
   └─ cc1101_check_packet_received()

--- a/src/core/cc1101.cpp
+++ b/src/core/cc1101.cpp
@@ -585,11 +585,10 @@ void setMHZ(float mhz)
       i = 1;
     }
   }
-  if (freq0 > 255)
-  {
-    freq1 += 1;
-    freq0 -= 256;
-  }
+  // No carry handling is needed here. The loop subtracts a whole FREQ1 step
+  // (0.1015625 MHz == 256 FREQ0 LSBs) before freq0 can reach 256, so freq0
+  // always fits in one byte. The former `if (freq0 > 255)` check was dead: freq0
+  // is a byte and can never exceed 255.
 
   /*
   Serial.printf("FREQ2=0x%02X ", freq2);
@@ -934,115 +933,6 @@ void show_cc1101_registers_settings(void)
     echo_debug(debug_out, "%02X ", Patable_verify[i]);
   }
   echo_debug(debug_out, "\n");
-}
-
-uint8_t is_look_like_radian_frame(uint8_t *buffer, size_t len)
-{
-  int ret;
-  ret = FALSE;
-  for (size_t i = 0; i < len; i++)
-  {
-    if (buffer[i] == 0xFF)
-      ret = TRUE;
-  }
-
-  return ret;
-}
-
-//-----------------[check if Packet is received]-------------------------
-uint8_t cc1101_check_packet_received(void)
-{
-  uint8_t rxBuffer[100];
-  uint8_t l_nb_byte;
-  int8_t l_Rssi_dbm;
-  uint8_t l_lqi, l_freq_est, pktLen;
-  pktLen = 0;
-  if (digitalRead(GET_GDO0_PIN()) == TRUE)
-  {
-    // Read RSSI immediately while signal is present (carrier active)
-    // RSSI register needs to be sampled during packet reception for accuracy
-    l_Rssi_dbm = cc1100_rssi_convert2dbm(halRfReadReg(RSSI_ADDR));
-
-    bool buffer_overflow = false;
-    while (digitalRead(GET_GDO0_PIN()) == TRUE)
-    {
-      delay(2); // Reduced from 5ms to 2ms for faster FIFO reading (prevents overflow)
-
-      // Check for FIFO overflow (bit 7 of RXBYTES register)
-      uint8_t rxbytes_reg = halRfReadReg(RXBYTES_ADDR);
-      if (rxbytes_reg & 0x80)
-      {
-        echo_debug(1, "[ERROR] RX FIFO overflow detected - data corrupted\n");
-        CC1101_CMD(SFRX); // Flush RX FIFO to recover
-        return FALSE;
-      }
-
-      l_nb_byte = rxbytes_reg & RXBYTES_MASK;
-
-      // Bounds check before reading to prevent buffer overflow
-      if ((l_nb_byte) && ((pktLen + l_nb_byte) <= 100))
-      {
-        SPIReadBurstReg(RX_FIFO_ADDR, &rxBuffer[pktLen], l_nb_byte); // Pull data
-        pktLen += l_nb_byte;
-      }
-      else if (l_nb_byte && ((pktLen + l_nb_byte) > 100))
-      {
-        echo_debug(1, "[ERROR] Would overflow rxBuffer (pktLen=%u + l_nb_byte=%u > 100)\n", pktLen, l_nb_byte);
-        buffer_overflow = true;
-        break;
-      }
-    }
-
-    // Read LQI and FREQEST only if packet completed normally (GDO0 went low)
-    // If we exited via buffer overflow, GDO0 may still be high and these registers
-    // are not yet latched, so reading them would give incorrect values.
-    if (buffer_overflow)
-    {
-      echo_debug(1, "[ERROR] Buffer overflow - discarding incomplete packet\n");
-      CC1101_CMD(SFRX); // Flush RX FIFO to recover
-      return FALSE;
-    }
-    // These registers are latched at end-of-packet and contain final quality metrics
-    l_lqi = halRfReadReg(LQI_ADDR);
-    l_freq_est = halRfReadReg(FREQEST_ADDR);
-
-    if (is_look_like_radian_frame(rxBuffer, pktLen))
-    {
-      echo_debug(debug_out, "[CC1101] Packet looks like RADIAN frame");
-      echo_debug(debug_out, "[CC1101] bytes=%u rssi=%d lqi=%u F_est=%d\n", pktLen, l_Rssi_dbm, l_lqi & 0x7F, (int8_t)l_freq_est);
-      show_in_hex_one_line(rxBuffer, pktLen);
-      // show_in_bin(rxBuffer,l_nb_byte);
-    }
-    else
-    {
-      echo_debug(debug_out, ".");
-    }
-    fflush(stdout);
-    return TRUE;
-  }
-  return FALSE;
-}
-
-uint8_t cc1101_wait_for_packet(int milliseconds)
-{
-  int i;
-  for (i = 0; i < milliseconds; i++)
-  {
-    delay(1); // in ms
-    if (i % 100 == 0)
-      FEED_WDT(); // Feed watchdog every 100ms
-    // echo_cc1101_MARCSTATE();
-    if (cc1101_check_packet_received()) // delay till system has data available
-    {
-      return TRUE;
-    }
-    else if (i == milliseconds - 1)
-    {
-      // echo_debug(debug_out,"no packet received!\n");
-      return FALSE;
-    }
-  }
-  return TRUE;
 }
 
 // Diagnostic: the RADIAN frame length is not assumed. Scan every candidate

--- a/src/core/radian_parser.cpp
+++ b/src/core/radian_parser.cpp
@@ -33,8 +33,12 @@ bool radian_validate_crc(const uint8_t *decoded_buffer, size_t size)
 
     if (expected_len > size)
     {
-        // Keep compatibility with frames that advertise a longer length than payload.
-        return true;
+        // The length byte claims more bytes than were decoded, so the CRC
+        // trailer is not in the buffer and the frame cannot be verified at all.
+        // In practice this means a truncated or misaligned capture. Reject it:
+        // accepting it unchecked let corrupt frames through the one integrity
+        // gate the radio path has.
+        return false;
     }
 
     if (expected_len < 4)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -345,6 +345,19 @@ static void parseMeterCode()
 // Buffer size: 128 bytes provides 1.45x safety margin for topic construction
 #define MQTT_TOPIC_BUFFER_SIZE 128
 
+// Publish to "<mqttBaseTopic>/<suffix>" without building the topic as an
+// Arduino String. A single read publishes around 20 topics, and every
+// String(mqttBaseTopic) + "/suffix" allocated and freed two heap blocks, which
+// fragments the ~40 KB ESP8266 heap over the life of the device. The rest of
+// the file already builds topics into a stack buffer; this keeps the hot path
+// consistent with that.
+static bool publishSub(const char *suffix, const char *payload, bool retain = false)
+{
+  char topicBuffer[MQTT_TOPIC_BUFFER_SIZE];
+  snprintf(topicBuffer, sizeof(topicBuffer), "%s/%s", mqttBaseTopic, suffix);
+  return mqtt.publish(topicBuffer, payload, retain);
+}
+
 // ============================================================================
 // Meter Type Configuration
 // ============================================================================
@@ -530,8 +543,8 @@ void onUpdateData()
   digitalWrite(LED_BUILTIN, LOW); // Turn on LED to indicate activity
 
   // Notify MQTT that active reading has started
-  mqtt.publish(String(mqttBaseTopic) + "/active_reading", "true", true);
-  mqtt.publish(String(mqttBaseTopic) + "/cc1101_state", "Reading", true);
+  publishSub("active_reading", "true", true);
+  publishSub("cc1101_state", "Reading", true);
 
   struct tmeter_data meter_data = get_meter_data(); // Fetch meter data
 
@@ -575,7 +588,7 @@ void onUpdateData()
       // for the whole retry sequence so they don't flip to "Not running"/Idle
       // between attempts. They are cleared only on final success or after max
       // retries (see the else branch below).
-      mqtt.publish(String(mqttBaseTopic) + "/last_error", lastErrorMessage, true);
+      publishSub("last_error", lastErrorMessage, true);
       digitalWrite(LED_BUILTIN, HIGH); // Turn off LED
       // Use non-blocking callback instead of recursive call
       mqtt.executeDelayed(5000, onUpdateData);
@@ -589,17 +602,17 @@ void onUpdateData()
       lastErrorMessage = read_failure_message(
           g_retryFailureReason != ReadFailure::None ? g_retryFailureReason : meter_data.failure, false);
       TS_PRINTF("[ERROR] Max retries (%d) reached. Entering 1-hour cooldown period.\n", max_retries);
-      mqtt.publish(String(mqttBaseTopic) + "/active_reading", "false", true);
-      mqtt.publish(String(mqttBaseTopic) + "/cc1101_state", cc1101RadioConnected ? "Idle" : "unavailable", true);
-      mqtt.publish(String(mqttBaseTopic) + "/status_message", "Failed after max retries, cooling down for 1 hour", true);
-      mqtt.publish(String(mqttBaseTopic) + "/last_error", lastErrorMessage, true);
+      publishSub("active_reading", "false", true);
+      publishSub("cc1101_state", cc1101RadioConnected ? "Idle" : "unavailable", true);
+      publishSub("status_message", "Failed after max retries, cooling down for 1 hour", true);
+      publishSub("last_error", lastErrorMessage, true);
 
       char buffer[16];
       snprintf(buffer, sizeof(buffer), "%lu", failedReads);
-      mqtt.publish(String(mqttBaseTopic) + "/failed_reads", buffer, true);
+      publishSub("failed_reads", buffer, true);
 
       snprintf(buffer, sizeof(buffer), "%lu", totalReadAttempts);
-      mqtt.publish(String(mqttBaseTopic) + "/total_attempts", buffer, true);
+      publishSub("total_attempts", buffer, true);
       digitalWrite(LED_BUILTIN, HIGH); // Turn off LED
       _retry = 0;                      // Reset retry counter for next scheduled attempt
       g_retryFailureReason = ReadFailure::None;
@@ -672,7 +685,7 @@ void onUpdateData()
     // Water meters: publish value in liters
     snprintf(valueBuffer, sizeof(valueBuffer), "%d", meter_data.volume);
   }
-  mqtt.publish(String(mqttBaseTopic) + "/liters", valueBuffer, true);
+  publishSub("liters", valueBuffer, true);
   delay(5);
 
   // Publish historical data as JSON attributes for Home Assistant.
@@ -694,7 +707,7 @@ void onUpdateData()
     if (written > 0)
     {
       TS_PRINTF("[MQTT] Publishing JSON attributes (%d bytes): %s\n\n", written, historyJson);
-      mqtt.publish(String(mqttBaseTopic) + "/liters_attributes", historyJson, true);
+      publishSub("liters_attributes", historyJson, true);
       delay(5);
 
       HistoryStats stats = MeterHistory::calculateStats(meter_data.history, currentVolume);
@@ -708,43 +721,43 @@ void onUpdateData()
   }
 
   snprintf(valueBuffer, sizeof(valueBuffer), "%d", meter_data.reads_counter);
-  mqtt.publish(String(mqttBaseTopic) + "/counter", valueBuffer, true);
+  publishSub("counter", valueBuffer, true);
   delay(5);
 
   snprintf(valueBuffer, sizeof(valueBuffer), "%d", meter_data.battery_left);
-  mqtt.publish(String(mqttBaseTopic) + "/battery", valueBuffer, true);
+  publishSub("battery", valueBuffer, true);
   delay(5);
 
   snprintf(valueBuffer, sizeof(valueBuffer), "%d", meter_data.rssi_dbm);
-  mqtt.publish(String(mqttBaseTopic) + "/rssi_dbm", valueBuffer, true);
+  publishSub("rssi_dbm", valueBuffer, true);
   delay(5);
 
   snprintf(valueBuffer, sizeof(valueBuffer), "%d", calculateMeterdBmToPercentage(meter_data.rssi_dbm));
-  mqtt.publish(String(mqttBaseTopic) + "/rssi_percentage", valueBuffer, true);
+  publishSub("rssi_percentage", valueBuffer, true);
   delay(5);
 
   snprintf(valueBuffer, sizeof(valueBuffer), "%d", meter_data.lqi);
-  mqtt.publish(String(mqttBaseTopic) + "/lqi", valueBuffer, true);
+  publishSub("lqi", valueBuffer, true);
   delay(5);
-  mqtt.publish(String(mqttBaseTopic) + "/time_start", timeStartFormatted, true);
+  publishSub("time_start", timeStartFormatted, true);
   delay(5);
-  mqtt.publish(String(mqttBaseTopic) + "/time_end", timeEndFormatted, true);
+  publishSub("time_end", timeEndFormatted, true);
   delay(5);
-  mqtt.publish(String(mqttBaseTopic) + "/timestamp", iso8601, true); // timestamp since epoch in UTC
+  publishSub("timestamp", iso8601, true); // ISO-8601 timestamp in UTC
   delay(5);
-  mqtt.publish(String(mqttBaseTopic) + "/meter_time", meter_data.meter_time, true); // meter's own real-time clock
+  publishSub("meter_time", meter_data.meter_time, true); // meter's own real-time clock
   delay(5);
-  mqtt.publish(String(mqttBaseTopic) + "/meter_type", meter_data.meter_type, true); // meter type/identifier string
+  publishSub("meter_type", meter_data.meter_type, true); // meter type/identifier string
   delay(5);
 
   snprintf(valueBuffer, sizeof(valueBuffer), "%d", calculateLQIToPercentage(meter_data.lqi));
-  mqtt.publish(String(mqttBaseTopic) + "/lqi_percentage", valueBuffer, true);
+  publishSub("lqi_percentage", valueBuffer, true);
   delay(5);
 
   // Publish all data as a JSON message as well this is redundant but may be useful for some
   char json[512];
-  sprintf(json, jsonTemplate, meter_data.volume, meter_data.reads_counter, meter_data.battery_left, meter_data.rssi, iso8601);
-  mqtt.publish(String(mqttBaseTopic) + "/json", json, true);
+  snprintf(json, sizeof(json), jsonTemplate, meter_data.volume, meter_data.reads_counter, meter_data.battery_left, meter_data.rssi, iso8601);
+  publishSub("json", json, true);
   delay(5);
 
 #if AUTO_ALIGN_READING_TIME
@@ -769,7 +782,7 @@ void onUpdateData()
       // Publish updated reading_time HH:MM
       char readingTimeFormatted2[6];
       snprintf(readingTimeFormatted2, sizeof(readingTimeFormatted2), "%02d:%02d", g_readHourUtc, g_readMinuteUtc);
-      mqtt.publish(String(mqttBaseTopic) + "/reading_time", readingTimeFormatted2, true);
+      publishSub("reading_time", readingTimeFormatted2, true);
       delay(5);
 
       TS_PRINTF("[SCHEDULE] Auto-aligned reading time to %02d:%02d local-offset (%02d:%02d UTC) (window %02d-%02d local)\n",
@@ -779,8 +792,8 @@ void onUpdateData()
 #endif
 
   // Notify MQTT that active reading has ended
-  mqtt.publish(String(mqttBaseTopic) + "/active_reading", "false", true);
-  mqtt.publish(String(mqttBaseTopic) + "/cc1101_state", cc1101RadioConnected ? "Idle" : "unavailable", true);
+  publishSub("active_reading", "false", true);
+  publishSub("cc1101_state", cc1101RadioConnected ? "Idle" : "unavailable", true);
   digitalWrite(LED_BUILTIN, HIGH); // Turn off LED to indicate completion
 
   // Reset retry counter and cooldown on successful read
@@ -797,12 +810,12 @@ void onUpdateData()
   char metricBuffer[16];
 
   snprintf(metricBuffer, sizeof(metricBuffer), "%lu", successfulReads);
-  mqtt.publish(String(mqttBaseTopic) + "/successful_reads", metricBuffer, true);
+  publishSub("successful_reads", metricBuffer, true);
 
   snprintf(metricBuffer, sizeof(metricBuffer), "%lu", totalReadAttempts);
-  mqtt.publish(String(mqttBaseTopic) + "/total_attempts", metricBuffer, true);
+  publishSub("total_attempts", metricBuffer, true);
 
-  mqtt.publish(String(mqttBaseTopic) + "/last_error", "None", true);
+  publishSub("last_error", "None", true);
 
   // Perform adaptive frequency tracking based on FREQEST register
   adaptiveFrequencyTracking(meter_data.freqest);

--- a/src/services/meter_history.cpp
+++ b/src/services/meter_history.cpp
@@ -228,6 +228,9 @@ int MeterHistory::countValidMonths(const uint32_t history[13])
         return 0;
     }
 
+    // A zero entry marks the end of the stored history. Meter volume is a
+    // cumulative counter, so an operational meter never legitimately reports 0,
+    // which makes 0 usable as the "no more data" sentinel.
     for (int i = 0; i < 13; i++)
     {
         if (history[i] == 0)

--- a/src/services/storage_abstraction.cpp
+++ b/src/services/storage_abstraction.cpp
@@ -391,7 +391,11 @@ bool StorageAbstraction::clearKey(const char *key)
 bool StorageAbstraction::clearAll()
 {
 #ifdef EVERBLU_USE_ESPHOME_PREFS
-    // Not supported via ESPHome API in bulk; caller can clear individual keys
+    // ESPHome's preference API has no bulk-erase primitive. Say so, otherwise a
+    // caller such as a factory-reset path cannot tell the difference between a
+    // failure and a silent no-op. Individual keys can still be cleared with
+    // clearKey().
+    LOG_W("everblu_meter", "clearAll() is not supported on ESPHome - clear individual keys with clearKey()");
     return false;
 
 #elif defined(ESP8266)

--- a/test/fixtures/meter_frames/fixtures.lst
+++ b/test/fixtures/meter_frames/fixtures.lst
@@ -1,6 +1,13 @@
 # fixture_name|decoded_hex|volume|battery|counter|time_start|time_end|history_available|crc_valid
 # Add captured fixtures with scripts/extract-meter-fixture.py
-home_001|7C 11 00 45 20 0A 50 14 00 45 14 03 EE D6 00 01 08 00 45 BB 0B 00 40 06 1B 04 1A 01 09 3B 31 5F 31 33 33 32 39 30 41 4C 30 32 00 00 06 12 04 01 D7 01 00 00 00 00 00 00 80 80 80 80 80 80 80 80 80 80 80 80 80 84 CB 9D 09 00 36 C4 09 00 F5 F5 09 00 31 2F 0A 00 B6 70 0A 00 F5 B1 0A 00 10 E0 0A 00 8D 02 0B 00 04 1F 0B 00 BD 3E 0B 00 FF 5D 0B 00 9A 79 0B 00 07 97|768837|95|215|6|18|1|1
+#
+# home_001: a truncated capture. The length byte says 124 bytes but only 120 were
+# decoded, so the CRC trailer is missing and radian_validate_crc() rejects it
+# (crc_valid=0). The replay test therefore asserts the CRC failure and stops
+# there: the volume/battery/counter/time columns below are recorded for
+# reference and are NOT asserted for this fixture. Parse coverage of the same
+# meter comes from home_002, which is a complete frame.
+home_001|7C 11 00 45 20 0A 50 14 00 45 14 03 EE D6 00 01 08 00 45 BB 0B 00 40 06 1B 04 1A 01 09 3B 31 5F 31 33 33 32 39 30 41 4C 30 32 00 00 06 12 04 01 D7 01 00 00 00 00 00 00 80 80 80 80 80 80 80 80 80 80 80 80 80 84 CB 9D 09 00 36 C4 09 00 F5 F5 09 00 31 2F 0A 00 B6 70 0A 00 F5 B1 0A 00 10 E0 0A 00 8D 02 0B 00 04 1F 0B 00 BD 3E 0B 00 FF 5D 0B 00 9A 79 0B 00 07 97|768837|95|215|6|18|1|0
 # home_002: full 124-byte CRC-valid frame (meter 257750, clock 09/07/2026 13:03:04); crc_valid=1 is a real check, not the length>size shim.
 home_002|7C 11 00 45 20 0A 50 14 00 45 14 03 EE D6 00 01 08 00 98 33 0C 00 40 06 09 07 1A 04 0D 03 04 5C 31 33 33 32 39 30 41 4C 30 32 00 00 06 12 04 01 A4 01 00 00 00 00 00 00 80 80 80 80 80 80 80 80 80 80 84 80 80 80 31 2F 0A 00 B6 70 0A 00 F5 B1 0A 00 10 E0 0A 00 8D 02 0B 00 04 1F 0B 00 BD 3E 0B 00 FF 5D 0B 00 9A 79 0B 00 07 97 0B 00 75 C0 0B 00 0D E6 0B 00 2C 17 0C 00 7A 60|799640|92|164|6|18|1|1
 # home_259301: meter 259301 (type 047290AL02), volume 585705; full 124-byte CRC-valid frame.

--- a/test/test_native_meter_fixtures/test_native_meter_fixtures.cpp
+++ b/test/test_native_meter_fixtures/test_native_meter_fixtures.cpp
@@ -441,9 +441,10 @@ void test_radian_validate_crc(void)
     uint8_t short_len[8] = {3, 0, 0, 0, 0, 0, 0, 0};
     TEST_ASSERT_FALSE(radian_validate_crc(short_len, sizeof(short_len)));
 
-    // length_field larger than the buffer is accepted (compat shim).
+    // length_field larger than the buffer means the CRC trailer was never
+    // decoded, so the frame is unverifiable and must be rejected.
     uint8_t long_len[8] = {200, 0, 0, 0, 0, 0, 0, 0};
-    TEST_ASSERT_TRUE(radian_validate_crc(long_len, sizeof(long_len)));
+    TEST_ASSERT_FALSE(radian_validate_crc(long_len, sizeof(long_len)));
 
     // length_field == 0 falls back to the actual buffer size.
     uint8_t implicit[8] = {0, 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0, 0};
@@ -1101,9 +1102,8 @@ void test_fixture_frames_reject_every_single_bit_flip(void)
         }
 
         // Byte 0 is the length field. Corrupting it changes where the CRC is
-        // read from, and a length beyond the buffer is deliberately accepted as
-        // a compatibility shim, so it is excluded here and covered separately
-        // in test_radian_validate_crc.
+        // read from rather than corrupting the payload, so it is excluded here
+        // and covered separately in test_radian_validate_crc.
         for (size_t byte = 1; byte < frame_len; byte++)
         {
             for (int bit = 0; bit < 8; bit++)


### PR DESCRIPTION
Salvages the still-relevant parts of the stalled draft PR #103 and drops the rest. Most of that PR has since landed independently or been superseded, so this only carries what is genuinely still open, re-derived against the current tree rather than cherry-picked.

## Fixed

- **`radian_validate_crc()` rejects frames whose length byte exceeds the decoded payload.** It previously returned "valid" without checking anything in that case, which in practice means a truncated or misaligned capture. That bypassed the only integrity gate on the radio path and left the downstream `parse_meter_report` sanity checks to catch the damage.
- **The unbounded `sprintf()`** building the standalone `/json` payload is now `snprintf()`. It was the only `sprintf` in a file that otherwise uses `snprintf` throughout.

## Changed

- **Standalone MQTT publishes no longer build their topics as Arduino `String`s.** A single read published around 20 topics as `String(mqttBaseTopic) + "/suffix"`, allocating and freeing two heap blocks each time and fragmenting the ~40 KB ESP8266 heap over the life of the device. A `publishSub()` helper formats the topic into a stack buffer, consistent with how the rest of `src/main.cpp` already builds topics. All 29 call sites converted.
- **`StorageAbstraction::clearAll()` logs a warning on ESPHome** instead of returning `false` silently, so a factory-reset caller can tell a failure from a no-op.
- `MeterHistory::countValidMonths()` stops at the first zero entry; that invariant (a cumulative meter counter is never legitimately 0) is now written down.

## Removed

- **Dead diagnostic code in the CC1101 driver:** `cc1101_wait_for_packet()`, `cc1101_check_packet_received()` and `is_look_like_radian_frame()` had no callers and were not part of the `cc1101.h` public API. They also held the only unbounded call into `show_in_hex_one_line()`. The live receive path is `receive_radian_frame()` and is unchanged.
- **The unreachable carry branch in `setMHZ()`.** `freq0` is a `byte`, so `if (freq0 > 255)` could never be true; the loop above it already subtracts a whole FREQ1 step before `freq0` can reach 256.

## Test fixture change worth a look

`home_001` is a truncated capture: 120 bytes decoded with a length byte of `0x7C` (124), so it only ever passed CRC validation via the shim this PR removes. It is now marked `crc_valid=0`, which means the replay test asserts the CRC failure and stops there. The volume/battery/counter/time columns stay in the file for reference but are no longer asserted for that fixture, and a comment in `fixtures.lst` says so explicitly. Parse coverage for the same meter comes from `home_002`, a complete 124-byte frame with a genuine CRC. `test_radian_parse_extended_fields_home001` uses an inline copy of the frame and still exercises the parser against it directly.

`test_radian_validate_crc`'s `long_len` case flips from `TEST_ASSERT_TRUE` to `TEST_ASSERT_FALSE` for the same reason.

## Deliberately not included from #103

- The `show_in_hex_formatted()` stack overflow was fixed independently (`flush_hex_line()` + `MAX_CHUNK`), and the current fix is better than the one in #103.
- The NaN sentinel for the frequency offset: `begin()` already uses `NAN`. `loadFrequencyOffset()` still returns `0.0` for "nothing stored" but has no callers left in `src/`.
- Integer-indexed scan loops: the float `for` loops were replaced by the cooperative `ScanState` machine for #133, so the patch no longer applies.
- The `MQTTDataPublisher` stub completeness fix: that file no longer exists.

## Verification

- `native` (162), `native_esphome` (45) and `native_cc1101` (22) host suites all pass.
- `huzzah` builds: RAM 58.7%, flash 40.0%.
- `ESPHOME-release/` regenerated; a fresh run of `prepare-component-release.ps1` produces no diff.

`develop` was merged in to resolve an `[Unreleased]` changelog collision with #151; the two sections are combined in Keep a Changelog order.
