### PR TITLE
Stop building and attaching firmware binaries to releases

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -189,13 +189,13 @@ Do not run any of the Phase 6 commands until the user approves. If the user want
    git push origin vX.Y.Z
    ```
 
-3. Pushing the tag triggers `.github/workflows/release.yml`, which builds firmware for huzzah, d1_mini_pro, d1_mini, nodemcuv2 and esp32dev, then creates the GitHub release with the binaries attached.
+3. Pushing the tag triggers `.github/workflows/release.yml`, which creates the GitHub release. No firmware binaries are built or attached: users build from source with their own `private.h`.
 
 4. **Replace the release body.** The workflow generates a generic body from the commit log, not the curated notes. Once the workflow finishes, tell the user to edit the release at
    `https://github.com/genestealer/everblu-meters-esp8266-improved/releases/tag/vX.Y.Z`
    and paste in the contents of `release_notes/RELEASE_NOTES_vX.Y.Z.md`. There is no `gh` CLI available to do this automatically.
 
-5. Confirm the workflow run succeeded and that all five `.bin` files are attached before calling the release done.
+5. Confirm the workflow run succeeded before calling the release done.
 
 ## Common mistakes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,103 +15,7 @@ permissions:
   contents: write
 
 jobs:
-  build-release:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        environment:
-          - name: huzzah
-            board: Adafruit HUZZAH ESP8266
-          - name: d1_mini_pro
-            board: WeMos D1 Mini Pro
-          - name: d1_mini
-            board: WeMos D1 Mini
-          - name: nodemcuv2
-            board: NodeMCU v2
-          - name: esp32dev
-            board: ESP32 Dev Module
-
-    name: Build Release for ${{ matrix.environment.board }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Fetch all history for version info
-
-      - name: Get version from tag
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
-          else
-            TAG=${GITHUB_REF#refs/tags/}
-          fi
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
-          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-          echo "Building version: ${TAG}"
-
-      - name: Cache PlatformIO
-        uses: actions/cache@v4
-        with:
-          path: ~/.platformio
-          key: ${{ runner.os }}-pio-release-${{ hashFiles('**/platformio.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pio-release-
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install PlatformIO
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade platformio
-
-      - name: Create private.h from example if missing
-        run: |
-          if [ ! -f include/private.h ]; then
-            cp include/private.example.h include/private.h
-            echo "Created private.h from private.example.h"
-          fi
-
-      - name: Inject dummy values for CI build
-        run: |
-          sed -i 's/#define METER_CODE "xx-xxxxxxx-xxx"/#define METER_CODE "99-1234567-000"/g' include/private.h
-          echo "Injected dummy METER_CODE=99-1234567-000 for release build"
-
-      - name: Build PlatformIO Project
-        run: pio run -e ${{ matrix.environment.name }}
-
-      - name: Rename firmware with version
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          ENV="${{ matrix.environment.name }}"
-          cd .pio/build/$ENV
-
-          # Rename binary firmware
-          if [ -f firmware.bin ]; then
-            mv firmware.bin everblu-meters-${ENV}-${VERSION}.bin
-          fi
-
-          # Rename ELF file
-          if [ -f firmware.elf ]; then
-            mv firmware.elf everblu-meters-${ENV}-${VERSION}.elf
-          fi
-
-          ls -lh
-
-      - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: firmware-${{ matrix.environment.name }}-${{ steps.version.outputs.version }}
-          path: |
-            .pio/build/${{ matrix.environment.name }}/everblu-meters-*.bin
-            .pio/build/${{ matrix.environment.name }}/everblu-meters-*.elf
-          retention-days: 90
-
   create-release:
-    needs: build-release
     runs-on: ubuntu-latest
     name: Create GitHub Release
 
@@ -130,18 +34,6 @@ jobs:
           fi
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-
-      - name: Download all firmware artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: firmware-artifacts
-
-      - name: Organize release files
-        run: |
-          mkdir -p release-files
-          find firmware-artifacts -name "*.bin" -exec cp {} release-files/ \;
-          find firmware-artifacts -name "*.elf" -exec cp {} release-files/ \;
-          ls -lh release-files/
 
       - name: Generate release notes
         id: release_notes
@@ -173,10 +65,13 @@ jobs:
           echo "" >> release-notes.md
           echo "## Installation" >> release-notes.md
           echo "" >> release-notes.md
-          echo "1. Download the appropriate \`.bin\` file for your board" >> release-notes.md
-          echo "2. Flash using esptool.py or PlatformIO" >> release-notes.md
-          echo "3. Configure your meter settings in \`private.h\`" >> release-notes.md
-          echo "4. Upload and enjoy!" >> release-notes.md
+          echo "No prebuilt binaries are published, because the firmware has to be built with your own meter details." >> release-notes.md
+          echo "" >> release-notes.md
+          echo "1. Check out the repository at this tag" >> release-notes.md
+          echo "2. Copy \`include/private.example.h\` to \`include/private.h\` and fill in your Wi-Fi, MQTT and meter settings" >> release-notes.md
+          echo "3. Build and flash with PlatformIO, for example \`pio run -e huzzah -t upload\`" >> release-notes.md
+          echo "" >> release-notes.md
+          echo "For ESPHome, point your YAML at the external component in \`ESPHOME-release/\`." >> release-notes.md
           echo "" >> release-notes.md
           echo "## Documentation" >> release-notes.md
           echo "" >> release-notes.md
@@ -192,17 +87,11 @@ jobs:
           body_path: release-notes.md
           draft: false
           prerelease: false
-          files: |
-            release-files/*.bin
-            release-files/*.elf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release Summary
         run: |
-          echo "### Release ${{ steps.version.outputs.tag }} Created! 🎉" >> $GITHUB_STEP_SUMMARY
+          echo "### Release ${{ steps.version.outputs.tag }} created" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "View the release at: https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "#### Firmware Files" >> $GITHUB_STEP_SUMMARY
-          ls -lh release-files/ >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Releases are created manually by tagging commits with version tags matching `v*.
 
 ### Fixed
 
+- **`dump_config()` was truncated mid-line on real hardware.** It emitted the whole block as a single `ESP_LOGCONFIG` call, which ran to roughly 480 characters once the RX attenuation, CS pin and SPI self-test lines were added. The logger truncates a message at its transmit buffer (512 bytes including the line header), so the block stopped at `SPI Link Self-Test: PASSED (P` and lost the PARTNUM/VERSION values, i.e. exactly the field that was added so support requests would carry it. It is now split across several calls, the same way the diagnostic report already was.
 - **The unbounded `sprintf()` building the standalone `/json` payload** is now `snprintf()`, matching the rest of `src/main.cpp`.
 
 ### Removed

--- a/ESPHOME-release/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME-release/everblu_meter/everblu_meter.cpp
@@ -470,36 +470,45 @@ void EverbluMeterComponent::dump_config() {
   char gdo0_text[GPIO_SUMMARY_MAX_LEN];
   char gdo2_text[GPIO_SUMMARY_MAX_LEN];
 
+  // Split across several calls for the same reason request_diagnostic_report() is: the
+  // logger truncates a single message at its transmit buffer (512 bytes by default),
+  // including the line header. As one block this ran to ~480 characters and was cut off
+  // mid-token at "SPI Link Self-Test: PASSED (P", losing the very field that was added so
+  // support requests would contain it. Keep each call well under the limit; do not merge
+  // them back into one.
   ESP_LOGCONFIG(TAG,
                 "EverBlu Meter:\n"
                 "  Meter Code: %s (year=%u, serial=%lu)\n"
                 "  Meter Type: %s\n"
                 "  Component Version: %s\n"
                 "  Frequency: %.2f MHz\n"
-                "  Auto Scan: %s\n"
+                "  Auto Scan: %s",
+                this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
+                this->is_gas_ ? "Gas" : "Water", EVERBLU_FW_VERSION, this->frequency_,
+                this->auto_scan_ ? "Enabled" : "Disabled");
+  ESP_LOGCONFIG(TAG,
                 "  Reading Schedule: %s\n"
                 "  Read Time: %02d:%02d\n"
                 "  Timezone Offset: %d\n"
                 "  Auto Align Time: %s\n"
-                "  Auto Align Midpoint: %s\n"
+                "  Auto Align Midpoint: %s",
+                this->reading_schedule_.c_str(), this->read_hour_, this->read_minute_, this->timezone_offset_,
+                this->auto_align_time_ ? "Enabled" : "Disabled", this->auto_align_midpoint_ ? "Enabled" : "Disabled");
+  ESP_LOGCONFIG(TAG,
                 "  Max Retries: %d\n"
                 "  Retry Cooldown: %lu ms\n"
                 "  Initial Read On Boot: %s\n"
-                "  RX Attenuation: %d dB\n"
+                "  RX Attenuation: %d dB",
+                this->max_retries_, this->retry_cooldown_ms_, this->initial_read_on_boot_ ? "Enabled" : "Disabled",
+                this->rx_attenuation_db_);
+  ESP_LOGCONFIG(TAG,
                 "  CS Pin: %s\n"
                 "  GDO0 Pin: %s\n"
-                "  GDO2 Pin: %s\n"
-                "  SPI Link Self-Test: %s",
-                this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
-                this->is_gas_ ? "Gas" : "Water", EVERBLU_FW_VERSION, this->frequency_,
-                this->auto_scan_ ? "Enabled" : "Disabled", this->reading_schedule_.c_str(), this->read_hour_,
-                this->read_minute_, this->timezone_offset_, this->auto_align_time_ ? "Enabled" : "Disabled",
-                this->auto_align_midpoint_ ? "Enabled" : "Disabled", this->max_retries_, this->retry_cooldown_ms_,
-                this->initial_read_on_boot_ ? "Enabled" : "Disabled", this->rx_attenuation_db_,
+                "  GDO2 Pin: %s",
                 pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured (error)"),
                 pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured (error)"),
-                pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled (legacy SPI polling fallback)"),
-                spi_selftest);
+                pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled (legacy SPI polling fallback)"));
+  ESP_LOGCONFIG(TAG, "  SPI Link Self-Test: %s", spi_selftest);
   if (this->gdo2_pin_ != nullptr)
     ESP_LOGCONFIG(TAG, "    GDO2 mode: HW FIFO threshold, TX+RX dynamic");
   if (this->is_gas_)

--- a/ESPHOME/components/everblu_meter/everblu_meter.cpp
+++ b/ESPHOME/components/everblu_meter/everblu_meter.cpp
@@ -470,36 +470,45 @@ void EverbluMeterComponent::dump_config() {
   char gdo0_text[GPIO_SUMMARY_MAX_LEN];
   char gdo2_text[GPIO_SUMMARY_MAX_LEN];
 
+  // Split across several calls for the same reason request_diagnostic_report() is: the
+  // logger truncates a single message at its transmit buffer (512 bytes by default),
+  // including the line header. As one block this ran to ~480 characters and was cut off
+  // mid-token at "SPI Link Self-Test: PASSED (P", losing the very field that was added so
+  // support requests would contain it. Keep each call well under the limit; do not merge
+  // them back into one.
   ESP_LOGCONFIG(TAG,
                 "EverBlu Meter:\n"
                 "  Meter Code: %s (year=%u, serial=%lu)\n"
                 "  Meter Type: %s\n"
                 "  Component Version: %s\n"
                 "  Frequency: %.2f MHz\n"
-                "  Auto Scan: %s\n"
+                "  Auto Scan: %s",
+                this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
+                this->is_gas_ ? "Gas" : "Water", EVERBLU_FW_VERSION, this->frequency_,
+                this->auto_scan_ ? "Enabled" : "Disabled");
+  ESP_LOGCONFIG(TAG,
                 "  Reading Schedule: %s\n"
                 "  Read Time: %02d:%02d\n"
                 "  Timezone Offset: %d\n"
                 "  Auto Align Time: %s\n"
-                "  Auto Align Midpoint: %s\n"
+                "  Auto Align Midpoint: %s",
+                this->reading_schedule_.c_str(), this->read_hour_, this->read_minute_, this->timezone_offset_,
+                this->auto_align_time_ ? "Enabled" : "Disabled", this->auto_align_midpoint_ ? "Enabled" : "Disabled");
+  ESP_LOGCONFIG(TAG,
                 "  Max Retries: %d\n"
                 "  Retry Cooldown: %lu ms\n"
                 "  Initial Read On Boot: %s\n"
-                "  RX Attenuation: %d dB\n"
+                "  RX Attenuation: %d dB",
+                this->max_retries_, this->retry_cooldown_ms_, this->initial_read_on_boot_ ? "Enabled" : "Disabled",
+                this->rx_attenuation_db_);
+  ESP_LOGCONFIG(TAG,
                 "  CS Pin: %s\n"
                 "  GDO0 Pin: %s\n"
-                "  GDO2 Pin: %s\n"
-                "  SPI Link Self-Test: %s",
-                this->meter_code_.c_str(), this->meter_year_, (unsigned long) this->meter_serial_,
-                this->is_gas_ ? "Gas" : "Water", EVERBLU_FW_VERSION, this->frequency_,
-                this->auto_scan_ ? "Enabled" : "Disabled", this->reading_schedule_.c_str(), this->read_hour_,
-                this->read_minute_, this->timezone_offset_, this->auto_align_time_ ? "Enabled" : "Disabled",
-                this->auto_align_midpoint_ ? "Enabled" : "Disabled", this->max_retries_, this->retry_cooldown_ms_,
-                this->initial_read_on_boot_ ? "Enabled" : "Disabled", this->rx_attenuation_db_,
+                "  GDO2 Pin: %s",
                 pin_summary(this->cs_, cs_text, sizeof(cs_text), "NOT configured (error)"),
                 pin_summary(this->gdo0_pin_, gdo0_text, sizeof(gdo0_text), "NOT configured (error)"),
-                pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled (legacy SPI polling fallback)"),
-                spi_selftest);
+                pin_summary(this->gdo2_pin_, gdo2_text, sizeof(gdo2_text), "disabled (legacy SPI polling fallback)"));
+  ESP_LOGCONFIG(TAG, "  SPI Link Self-Test: %s", spi_selftest);
   if (this->gdo2_pin_ != nullptr)
     ESP_LOGCONFIG(TAG, "    GDO2 mode: HW FIFO threshold, TX+RX dynamic");
   if (this->is_gas_)


### PR DESCRIPTION
Removes the firmware build matrix and binary attachments from the release workflow.

- `release.yml` is now a single `create-release` job: no PlatformIO setup, no dummy `private.h` injection, no firmware renaming, no artifact upload/download, and no `files:` on `softprops/action-gh-release`.
- The generated Installation section now tells users to build from source with their own `private.h`, or use the ESPHome external component, instead of downloading a `.bin`.
- The job summary no longer lists firmware files.
- The release skill (`.github/skills/release/SKILL.md`) no longer says binaries are built, and no longer asks the maintainer to verify five `.bin` attachments.

Prebuilt binaries were of little use because the firmware has to be compiled with device-specific settings in `private.h`.